### PR TITLE
Flow layout and buffer type stub

### DIFF
--- a/include/con4m.h
+++ b/include/con4m.h
@@ -43,6 +43,8 @@ typedef void *object_t;
 // Our grid abstraction.
 #include <con4m/grid.h>
 
+#include <con4m/buffer.h>
+
 // IO primitives.
 #include <con4m/term.h>
 #include <con4m/switchboard.h>

--- a/include/con4m.h
+++ b/include/con4m.h
@@ -22,6 +22,9 @@ typedef void *object_t;
 // Single-threaded data structures for internal use.
 #include <con4m/xlist.h>
 
+// Type system.
+#include <con4m/types.h>
+
 // Basic string handling.
 #include <con4m/codepoint.h>
 #include <con4m/colors.h>

--- a/include/con4m/base.h
+++ b/include/con4m/base.h
@@ -18,6 +18,7 @@
 #include <assert.h>
 #include <pthread.h>
 #include <stdarg.h>
+#include <math.h>
 #include <sys/socket.h>
 #include <sys/select.h>
 #include <sys/types.h>

--- a/include/con4m/buffer.h
+++ b/include/con4m/buffer.h
@@ -1,3 +1,9 @@
 #pragma once
 
 #include <con4m.h>
+typedef struct {
+    alignas(8)
+    char   *data;
+    int32_t flags;
+    int32_t byte_len;
+} buffer_t;

--- a/include/con4m/buffer.h
+++ b/include/con4m/buffer.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include <con4m.h>

--- a/include/con4m/c4str.h
+++ b/include/con4m/c4str.h
@@ -36,6 +36,8 @@ extern str_t   *_c4str_strip(const str_t *s, ...);
 extern str_t   *_c4str_truncate(const str_t *s, int64_t, ...);
 extern str_t   *_c4str_join(const xlist_t *l, const str_t *joiner, ...);
 extern str_t   *c4str_from_int(int64_t n);
+extern int64_t  _c4str_find(str_t *, str_t *, ...);
+extern struct flexarray_t *c4str_split(str_t *, str_t *);
 
 extern const uint64_t str_ptr_info[];
 extern const con4m_vtable u8str_vtable;
@@ -46,6 +48,7 @@ extern const con4m_vtable u32str_vtable;
 #define c4str_strip(s, ...) _c4str_strip(s, KFUNC(__VA_ARGS__))
 #define c4str_truncate(s, n, ...) _c4str_truncate(s, n,  KFUNC(__VA_ARGS__))
 #define c4str_join(l, s, ...) _c4str_join(l, s, KFUNC(__VA_ARGS__))
+#define c4str_find(str, sub, ...) _c4str_find(str, sub, KFUNC(__VA_ARGS__))
 
 extern const str_t *empty_string_const;
 extern const str_t *newline_const;

--- a/include/con4m/c4str.h
+++ b/include/con4m/c4str.h
@@ -39,10 +39,6 @@ extern str_t   *c4str_from_int(int64_t n);
 extern int64_t  _c4str_find(str_t *, str_t *, ...);
 extern struct flexarray_t *c4str_split(str_t *, str_t *);
 
-extern const uint64_t str_ptr_info[];
-extern const con4m_vtable u8str_vtable;
-extern const con4m_vtable u32str_vtable;
-
 #define force_utf8(x) c4str_u32_to_u8(x)
 #define force_utf32(x) c4str_u8_to_u32(x)
 #define c4str_strip(s, ...) _c4str_strip(s, KFUNC(__VA_ARGS__))

--- a/include/con4m/c4strbase.h
+++ b/include/con4m/c4strbase.h
@@ -56,6 +56,11 @@ typedef struct {
 
 typedef char str_t;
 
+typedef real_str_t utf8_t;
+typedef real_str_t utf32_t;
+typedef real_str_t buffer_t;
+typedef real_str_t any_str_t;
+
 static inline real_str_t *
 to_internal(const str_t *s)
 {

--- a/include/con4m/c4strbase.h
+++ b/include/con4m/c4strbase.h
@@ -58,7 +58,6 @@ typedef char str_t;
 
 typedef real_str_t utf8_t;
 typedef real_str_t utf32_t;
-typedef real_str_t buffer_t;
 typedef real_str_t any_str_t;
 
 static inline real_str_t *

--- a/include/con4m/dict.h
+++ b/include/con4m/dict.h
@@ -1,4 +1,2 @@
 #include <con4m.h>
 #pragma once
-
-extern const con4m_vtable dict_vtable;

--- a/include/con4m/gc.h
+++ b/include/con4m/gc.h
@@ -155,7 +155,7 @@ extern uint64_t gc_guard;
 typedef struct con4m_arena_t {
     alignas(8)
     con4m_alloc_hdr         *next_alloc;
-    struct hatrack_dict_st  *roots;
+    struct dict_t           *roots;
     struct con4m_arena_t    *previous;
     queue_t                 *late_mutations;
     uint64_t                *heap_end;

--- a/include/con4m/grid.h
+++ b/include/con4m/grid.h
@@ -199,6 +199,7 @@ struct grid_t {
     // we will apply the 'th' tag to anything in these row/columns.
     int8_t              header_rows;
     int8_t              header_cols;
+    int8_t              stripe;
 };
 
 #define GRID_TERMINAL_DIM ((int16_t)-1)
@@ -244,11 +245,6 @@ extern grid_t *_unordered_list(flexarray_t *, ...);
 #define ordered_list(l, ...) _ordered_list(l, KFUNC(__VA_ARGS__))
 #define unordered_list(l, ...) _unordered_list(l, KFUNC(__VA_ARGS__))
 
-
-const con4m_vtable grid_vtable;
-extern const con4m_vtable dimensions_vtable;
-extern const con4m_vtable gridprops_vtable;
-extern const con4m_vtable renderable_vtable;
 
 void
 grid_add_col_span(grid_t *grid, renderable_t *contents, int64_t row,
@@ -368,4 +364,10 @@ static inline void
 grid_add_cell(grid_t *grid, object_t container)
 {
     grid_set_cell_contents(grid, grid->row_cursor, grid->col_cursor, container);
+}
+
+static inline void
+grid_stripe_rows(grid_t *grid)
+{
+    grid->stripe = 1;
 }

--- a/include/con4m/lists.h
+++ b/include/con4m/lists.h
@@ -1,8 +1,2 @@
 #include <con4m.h>
 #pragma once
-
-extern const con4m_vtable list_vtable;
-extern const con4m_vtable queue_vtable;
-extern const con4m_vtable ring_vtable;
-extern const con4m_vtable logring_vtable;
-extern const con4m_vtable stack_vtable;

--- a/include/con4m/object.h
+++ b/include/con4m/object.h
@@ -143,6 +143,8 @@ typedef enum : int64_t {
     CON4M_NUM_BUILTIN_DTS
 } con4m_builtin_t;
 
+#define T_UTF8 T_STR
+
 // in object.c
 extern const con4m_dt_info builtin_type_info[CON4M_NUM_BUILTIN_DTS];
 
@@ -168,3 +170,19 @@ con4m_value_obj_repr(object_t obj)
     repr_fn ptr = (repr_fn)get_vtable(obj)->methods[CON4M_BI_TO_STR];
     return (*ptr)(obj, TO_STR_USE_AS_VALUE);
 }
+
+extern const uint64_t str_ptr_info[];
+extern const con4m_vtable u8str_vtable;
+extern const con4m_vtable u32str_vtable;
+extern const con4m_vtable buffer_vtable;
+extern const con4m_vtable grid_vtable;
+extern const con4m_vtable dimensions_vtable;
+extern const con4m_vtable gridprops_vtable;
+extern const con4m_vtable renderable_vtable;
+extern const con4m_vtable list_vtable;
+extern const con4m_vtable queue_vtable;
+extern const con4m_vtable ring_vtable;
+extern const con4m_vtable logring_vtable;
+extern const con4m_vtable stack_vtable;
+extern const con4m_vtable dict_vtable;
+extern const con4m_vtable xlist_vtable;

--- a/include/con4m/object.h
+++ b/include/con4m/object.h
@@ -186,3 +186,5 @@ extern const con4m_vtable logring_vtable;
 extern const con4m_vtable stack_vtable;
 extern const con4m_vtable dict_vtable;
 extern const con4m_vtable xlist_vtable;
+
+extern uint64_t pmap_first_word[2];

--- a/include/con4m/style.h
+++ b/include/con4m/style.h
@@ -3,21 +3,21 @@
 #include <con4m.h>
 
 // Flags in the style `info` bitfield.
-#define FG_COLOR_ON     0x0002000000000000
-#define BG_COLOR_ON     0x0004000000000000
-#define BOLD_ON         0x0008000000000000
-#define ITALIC_ON       0x0010000000000000
-#define ST_ON           0x0020000000000000
-#define UL_ON           0x0040000000000000
-#define UL_DOUBLE       0x0080000000000000
-#define INV_ON          0x0100000000000000
-#define LOWER_CASE      0x0200000000000000
-#define UPPER_CASE      0x0400000000000000
+#define FG_COLOR_ON     (0x0002000000000000UL)
+#define BG_COLOR_ON     (0x0004000000000000UL)
+#define BOLD_ON         (0x0008000000000000UL)
+#define ITALIC_ON       (0x0010000000000000UL)
+#define ST_ON           (0x0020000000000000UL)
+#define UL_ON           (0x0040000000000000UL)
+#define UL_DOUBLE       (0x0080000000000000UL)
+#define INV_ON          (0x0100000000000000UL)
+#define LOWER_CASE      (0x0200000000000000UL)
+#define UPPER_CASE      (0x0400000000000000UL)
 #define TITLE_CASE      (UPPER_CASE | LOWER_CASE)
-#define STYLE_INVALID   0xffffffffffffffff
-#define FG_COLOR_MASK   0xffffffffff000000
-#define BG_COLOR_MASK   0xffff000000ffffff
-#define FLAG_MASK       0x0000ffffffffffff
+#define STYLE_INVALID   (0xffffffffffffffffUL)
+#define FG_COLOR_MASK   (0xffffffffff000000UL)
+#define BG_COLOR_MASK   (0xffff000000ffffffUL)
+#define FLAG_MASK       (0x0000ffffffffffffUL)
 #define OFFSET_BG_RED   40
 #define OFFSET_BG_GREEN 32
 #define OFFSET_BG_BLUE  24

--- a/include/con4m/style.h
+++ b/include/con4m/style.h
@@ -13,7 +13,7 @@
 #define INV_ON          0x0100000000000000
 #define LOWER_CASE      0x0200000000000000
 #define UPPER_CASE      0x0400000000000000
-#define TITLE_CASE      UPPER_CASE | LOWER_CASE
+#define TITLE_CASE      (UPPER_CASE | LOWER_CASE)
 #define STYLE_INVALID   0xffffffffffffffff
 #define FG_COLOR_MASK   0xffffffffff000000
 #define BG_COLOR_MASK   0xffff000000ffffff
@@ -25,10 +25,6 @@
 #define OFFSET_FG_GREEN 8
 #define OFFSET_FG_BLUE  0
 
-
-#define NEW_UL_ON     1
-#define NEW_UL_DOUBLE 2
-#define NEW_UL_NONE   0
 
 static inline void
 style_debug(char *prefix, const str_t *s) {

--- a/include/con4m/styledb.h
+++ b/include/con4m/styledb.h
@@ -91,6 +91,7 @@ typedef union {
 } str_style_t;
 
 typedef struct {
+    char           *name;
     border_theme_t *border_theme;
     str_style_t     base_style;   // Should be able to slam a style_t onto it.
     color_t         pad_color;
@@ -442,6 +443,5 @@ get_border_theme(render_style_t *style)
 }
 
 extern void layer_styles(const render_style_t *, render_style_t *);
-
 extern const con4m_vtable render_style_vtable;
 extern const uint64_t rs_pmap[2];

--- a/include/con4m/styledb.h
+++ b/include/con4m/styledb.h
@@ -130,7 +130,7 @@ set_fg_color(render_style_t *style, color_t color)
 static inline void
 set_bg_color(render_style_t *style, color_t color)
 {
-    style->base_style |= BG_COLOR_ON | (color << 24);
+    style->base_style |= BG_COLOR_ON | ((uint64_t)color) << 24;
 }
 
 static inline void

--- a/include/con4m/styledb.h
+++ b/include/con4m/styledb.h
@@ -71,29 +71,9 @@ typedef uint8_t border_set_t;
 // Some of the items apply to text, some apply to renderables.
 
 typedef struct {
-    uint64_t     fg_color    : 24;
-    uint64_t     bg_color    : 24;
-    unsigned int invalid     : 1;
-    unsigned int fg_color_on : 1;   // Whether a fg color is set, else inherit.
-    unsigned int bg_color_on : 1;   // Whether a fg color is set, else inherit.
-    unsigned int bold        : 1;   // Use a 'bold' font if possible.
-    unsigned int italic      : 1;
-    unsigned int strikethru  : 1;
-    unsigned int underline   : 2;   // single or double.
-    unsigned int inverse     : 1;
-    unsigned int casing      : 2;   // text casing.
-    // unsigned int reserved    : 5;   // For expansion of string stuff.
-} str_bitfield_t;
-
-typedef union {
-    str_bitfield_t bf;
-    style_t        style;
-} str_style_t;
-
-typedef struct {
     char           *name;
     border_theme_t *border_theme;
-    str_style_t     base_style;   // Should be able to slam a style_t onto it.
+    style_t         base_style;
     color_t         pad_color;
 
     union {
@@ -138,114 +118,119 @@ static inline style_t
 lookup_text_style(char *name)
 {
     render_style_t *rs = lookup_cell_style(name);
-    return rs->base_style.style;
+    return rs->base_style;
 }
 
 static inline void
 set_fg_color(render_style_t *style, color_t color)
 {
-    style->base_style.bf.fg_color    = color;
-    style->base_style.bf.fg_color_on = 1;
+    style->base_style |= FG_COLOR_ON | color;
 }
 
 static inline void
 set_bg_color(render_style_t *style, color_t color)
 {
-    style->base_style.bf.bg_color    = color;
-    style->base_style.bf.bg_color_on = 1;
+    style->base_style |= BG_COLOR_ON | (color << 24);
 }
 
 static inline void
 bold_on(render_style_t *style)
 {
-    style->base_style.bf.bold = 1;
+    style->base_style |= BOLD_ON;
 }
 
 static inline void
 bold_off(render_style_t *style)
 {
-    style->base_style.bf.bold = 0;
+    style->base_style &= ~BOLD_ON;
 }
 
 static inline void
 italic_on(render_style_t *style)
 {
-    style->base_style.bf.italic = 1;
+    style->base_style |= ITALIC_ON;
 }
 
 static inline void
 italic_off(render_style_t *style)
 {
-    style->base_style.bf.italic = 0;
+    style->base_style &= ~ITALIC_ON;
 }
 
 static inline void
 strikethru_on(render_style_t *style)
 {
-    style->base_style.bf.strikethru = 1;
+    style->base_style |= ST_ON;
 }
 
 static inline void
 strikethru_off(render_style_t *style)
 {
-    style->base_style.bf.strikethru = 0;
+    style->base_style &= ~ST_ON;
+}
+
+static inline void
+underline_off(render_style_t *style)
+{
+    style->base_style &= ~(UL_ON|UL_DOUBLE);
 }
 
 static inline void
 underline_on(render_style_t *style)
 {
-    style->base_style.bf.underline = 1;
+    underline_off(style);
+    style->base_style |= UL_ON;
 }
 
 
 static inline void
 double_underline_on(render_style_t *style)
 {
-    style->base_style.bf.underline = 2;
+    underline_off(style);
+    style->base_style |= UL_DOUBLE;
 }
 
-static inline void
-underline_off(render_style_t *style)
-{
-    style->base_style.bf.underline = 0;
-}
 
 static inline void
 inverse_on(render_style_t *style)
 {
-    style->base_style.bf.inverse = 1;
+    style->base_style |= INV_ON;
 }
 
 static inline void
 inverse_off(render_style_t *style)
 {
-    style->base_style.bf.inverse = 0;
+    style->base_style &= ~INV_ON;
+}
+
+static inline void
+casing_off(render_style_t *style)
+{
+    style->base_style &= ~TITLE_CASE;
 }
 
 
 static inline void
 lowercase_on(render_style_t *style)
 {
-    style->base_style.bf.casing = 1;
+    casing_off(style);
+    style->base_style |= LOWER_CASE;
 }
 
 static inline void
 uppercase_on(render_style_t *style)
 {
-    style->base_style.bf.casing = 2;
+    casing_off(style);
+    style->base_style |= UPPER_CASE;
 }
 
 static inline void
 titlecase_on(render_style_t *style)
 {
-    style->base_style.bf.casing = 2;
+    casing_off(style);
+    style->base_style |= TITLE_CASE;
 }
 
-static inline void
-casing_off(render_style_t *style)
-{
-    style->base_style.bf.casing = 0;
-}
 
 const extern border_theme_t *registered_borders;
 
@@ -371,13 +356,13 @@ set_pad_color(render_style_t *style, color_t color)
 static inline void
 clear_fg_color(render_style_t *style)
 {
-    style->base_style.bf.fg_color_on = 0;
+    style->base_style &= ~FG_COLOR_ON;
 }
 
 static inline void
 clear_bg_color(render_style_t *style)
 {
-    style->base_style.bf.bg_color_on = 0;
+    style->base_style &= ~BG_COLOR_ON;
 }
 
 static inline void
@@ -395,25 +380,25 @@ set_borders(render_style_t *style, border_set_t borders)
 static inline bool
 is_bg_color_on(render_style_t *style)
 {
-    return style->base_style.bf.bg_color_on;
+    return style->base_style & BG_COLOR_ON;
 }
 
 static inline bool
 is_fg_color_on(render_style_t *style)
 {
-    return style->base_style.bf.bg_color_on;
+    return style->base_style & FG_COLOR_ON;
 }
 
 static inline color_t
 get_fg_color(render_style_t *style)
 {
-    return (color_t)style->base_style.bf.fg_color;
+    return (color_t)style->base_style & ~FG_COLOR_MASK;
 }
 
 static inline color_t
 get_bg_color(render_style_t *style)
 {
-    return (color_t)style->base_style.bf.bg_color;
+    return (color_t)((style->base_style & ~BG_COLOR_MASK) >> 24);
 }
 
 static inline style_t
@@ -422,13 +407,13 @@ get_pad_style(render_style_t *style)
     if (style->pad_color_set) {
 	return (style->pad_color << 24) | BG_COLOR_ON;
     }
-    return style->base_style.style;
+    return style->base_style;
 }
 
 static inline style_t
 get_string_style(render_style_t *style)
 {
-    return style->base_style.style;
+    return style->base_style;
 }
 
 static inline border_theme_t *

--- a/include/con4m/xlist.h
+++ b/include/con4m/xlist.h
@@ -12,8 +12,6 @@ typedef struct {
     int64_t  **data;
 } xlist_t;
 
-extern const con4m_vtable xlist_vtable;
-
 static inline void *
 xlist_get(const xlist_t *list, int64_t ix, bool *err)
 {

--- a/include/hatrack/dict.h
+++ b/include/hatrack/dict.h
@@ -52,7 +52,7 @@ typedef struct {
 } hatrack_dict_item_t;
 
 
-typedef struct hatrack_dict_st hatrack_dict_t;
+typedef struct dict_t hatrack_dict_t;
 
 typedef void *hatrack_dict_key_t;
 typedef void *hatrack_dict_value_t;
@@ -62,7 +62,7 @@ typedef union {
     hatrack_hash_func_t   custom_hash;
 } hatrack_hash_info_t;
 
-struct hatrack_dict_st {
+struct dict_t {
     crown_t               crown_instance;
     hatrack_hash_info_t   hash_info;
     hatrack_mem_hook_t    free_handler;
@@ -105,3 +105,5 @@ hatrack_dict_item_t  *hatrack_dict_items_sort   (hatrack_dict_t *, uint64_t *);
 hatrack_dict_key_t   *hatrack_dict_keys_nosort  (hatrack_dict_t *, uint64_t *);
 hatrack_dict_value_t *hatrack_dict_values_nosort(hatrack_dict_t *, uint64_t *);
 hatrack_dict_item_t  *hatrack_dict_items_nosort (hatrack_dict_t *, uint64_t *);
+
+typedef hatrack_dict_t dict_t;

--- a/include/hatrack/flexarray.h
+++ b/include/hatrack/flexarray.h
@@ -78,7 +78,7 @@ void         flexarray_grow               (flexarray_t *, uint64_t);
 void         flexarray_shrink             (flexarray_t *, uint64_t);
 uint64_t     flexarray_len                (flexarray_t *);
 flex_view_t *flexarray_view               (flexarray_t *);
-void        *flexarray_view_next          (flex_view_t *, bool *);
+void        *flexarray_view_next          (flex_view_t *, int *);
 void         flexarray_view_delete        (flex_view_t *);
 void        *flexarray_view_get           (flex_view_t *, uint64_t, int *);
 uint64_t     flexarray_view_len           (flex_view_t *);

--- a/meson.build
+++ b/meson.build
@@ -56,6 +56,7 @@ c4m_src  = ['src/con4m/style.c',
             'src/con4m/colors.c',
             'src/con4m/breaks.c', 
             'src/con4m/c4str.c',
+            'src/con4m/buffer.c',
             'src/con4m/ansi.c',
             'src/con4m/hex.c',
             'src/con4m/switchboard.c',
@@ -68,7 +69,7 @@ c4m_src  = ['src/con4m/style.c',
             'src/con4m/lists.c',
             'src/con4m/xlist.c',
             'src/con4m/grid.c',
-            'src/con4m/styledb.c'
+            'src/con4m/styledb.c',
             ]
 
 hat_primary = ['src/hatrack/support/hatrack_common.c',
@@ -128,8 +129,8 @@ ssl      = cc.find_library('ssl')
 
 unibreak = dependency('libunibreak')
 utf8proc = dependency('libutf8proc')
-cmark    = dependency('libcmark-gfm')
-deps     = [unibreak, utf8proc, threads, cmark, ffi, ssl, crypto]
+#cmark    = dependency('libcmark-gfm')
+deps     = [unibreak, utf8proc, threads, ffi, ssl, crypto]
 opts     = [math]
 all_deps = deps + opts
 

--- a/src/con4m/ansi.c
+++ b/src/con4m/ansi.c
@@ -282,6 +282,7 @@ ansi_render_u8(real_str_t *s, FILE *outstream)
 
 	switch (casing) {
 	case UPPER_CASE:
+	    printf("UPPER\n");
 	    ansi_render_one_codepoint_upper(codepoint, outstream);
 	    break;
 	case LOWER_CASE:

--- a/src/con4m/breaks.c
+++ b/src/con4m/breaks.c
@@ -155,6 +155,9 @@ get_all_line_break_ops(const str_t *instr)
 static int32_t
 find_hwrap(const str_t *s, int32_t offset, int32_t width)
 {
+    printf("find_hwrap(offset = %d, width = %d) for ", offset, width);
+    ansi_render(s, stdout);
+    printf("\n");
     real_str_t *str = to_internal(force_utf32(s));
     uint32_t   *u32 = (uint32_t *)str->data;
     int         l   = internal_num_cp(str);
@@ -162,9 +165,11 @@ find_hwrap(const str_t *s, int32_t offset, int32_t width)
     for (int i = offset; i < l; i++) {
 	width -= codepoint_width(u32[i]);
 	if (width < 0) {
+	    printf("result: %d\n", i);
 	    return i;
 	}
     }
+    printf("result: %d\n", l);
     return l;
 }
 
@@ -222,13 +227,13 @@ wrap_text(const str_t *s, int32_t width, int32_t hang)
 		    // No valid break; hard wrap it.
 		    add_break(&res, hard_wrap_ix);
 		    cur_start    = hard_wrap_ix;
-		    hard_wrap_ix = find_hwrap(s, cur_start + hang_width, width);
+		    hard_wrap_ix = find_hwrap(s, cur_start, hang_width);
 		    goto find_next_break;
 		}
 		else {
 		    add_break(&res, last_ok_br);
 		    cur_start    = last_ok_br;
-		    hard_wrap_ix = find_hwrap(s, cur_start + hang_width, width);
+		    hard_wrap_ix = find_hwrap(s, cur_start, hang_width);
 		    goto find_next_break;
 		}
 	    }
@@ -236,13 +241,13 @@ wrap_text(const str_t *s, int32_t width, int32_t hang)
 	    if (next_lb == cur_break) {
 		add_break(&res, next_lb + 1);
 		cur_start = next_lb + 1;
+		hard_wrap_ix = find_hwrap(s, cur_start, hang_width);
 		if (lb_ix == line_breaks->num_breaks) {
 		    next_lb = l;
 		}
 		else {
 		    next_lb = line_breaks->breaks[lb_ix++];
 		}
-		hard_wrap_ix = find_hwrap(s, cur_start + hang_width, width);
 		bo_ix++;
 		goto find_next_break;
 	    }
@@ -264,12 +269,12 @@ wrap_text(const str_t *s, int32_t width, int32_t hang)
 	if (last_ok_br > cur_start) {
 	    add_break(&res, last_ok_br);
 	    cur_start    = last_ok_br;
-	    hard_wrap_ix = find_hwrap(s, cur_start + hang_width, width);
+	    hard_wrap_ix = find_hwrap(s, cur_start, hang_width);
 	}
 	else {
 	    add_break(&res, hard_wrap_ix);
 	    cur_start    = hard_wrap_ix;
-	    hard_wrap_ix = find_hwrap(s, cur_start + hang_width, width);
+	    hard_wrap_ix = find_hwrap(s, cur_start, hang_width);
 	}
     }
 

--- a/src/con4m/breaks.c
+++ b/src/con4m/breaks.c
@@ -155,9 +155,6 @@ get_all_line_break_ops(const str_t *instr)
 static int32_t
 find_hwrap(const str_t *s, int32_t offset, int32_t width)
 {
-    printf("find_hwrap(offset = %d, width = %d) for ", offset, width);
-    ansi_render(s, stdout);
-    printf("\n");
     real_str_t *str = to_internal(force_utf32(s));
     uint32_t   *u32 = (uint32_t *)str->data;
     int         l   = internal_num_cp(str);
@@ -165,11 +162,9 @@ find_hwrap(const str_t *s, int32_t offset, int32_t width)
     for (int i = offset; i < l; i++) {
 	width -= codepoint_width(u32[i]);
 	if (width < 0) {
-	    printf("result: %d\n", i);
 	    return i;
 	}
     }
-    printf("result: %d\n", l);
     return l;
 }
 

--- a/src/con4m/buffer.c
+++ b/src/con4m/buffer.c
@@ -1,0 +1,120 @@
+#include <con4m.h>
+
+static buffer_t *
+buffer_new(va_list args)
+{
+    DECLARE_KARGS(
+	int64_t     len = -1;
+	real_str_t *hex = NULL;
+	);
+    method_kargs(args, len, hex);
+
+    if (len == -1 && hex == NULL) {
+	abort();
+    }
+    if (len != -1 && hex != NULL) {
+	abort();
+    }
+
+    if (len == -1) {
+	len = internal_num_cp(hex) >> 1;
+    }
+
+    con4m_obj_t *obj     = con4m_gc_alloc(get_real_alloc_len(len), NULL);
+    buffer_t     *result = (buffer_t *)obj->data;
+
+
+
+    obj->base_data_type = (con4m_dt_info *)&builtin_type_info[T_BUFFER];
+    obj->concrete_type  = T_BUFFER;
+
+
+    if (hex != NULL) {
+	uint8_t cur         = 0;
+	int     valid_count = 0;
+
+	hex = to_internal(force_utf8(hex->data));
+
+	for (int i = 0; i < hex->byte_len; i++) {
+	    uint8_t byte = hex->data[i];
+	    if (byte >= '0' && byte <= '9') {
+		if ((++valid_count) % 2 == 1) {
+		    cur = (byte - '0') << 4;
+		}
+		else {
+		    cur |= (byte - '0');
+		    result->data[result->byte_len++] = cur;
+		}
+		continue;
+	    }
+	    if (byte >= 'a' && byte <= 'f') {
+		if ((++valid_count) % 2 == 1) {
+		    cur = ((byte - 'a') + 10) << 4;
+		}
+		else {
+		    cur |= (byte - 'a') + 10;
+		    result->data[result->byte_len++] = cur;
+		}
+		continue;
+	    }
+	    if (byte >= 'A' && byte <= 'F') {
+		if ((++valid_count) % 2 == 1) {
+		    cur = ((byte - 'A') + 10) << 4;
+		}
+		else {
+		    cur |= (byte - 'A') + 10;
+		    result->data[result->byte_len++] = cur;
+		}
+		continue;
+	    }
+	}
+    }
+    else {
+	result->byte_len = len;
+    }
+
+    return result;
+}
+
+static char to_hex_map[] = "0123456789abcdef";
+
+utf8_t *
+buffer_repr(buffer_t *buf, to_str_use_t how)
+{
+    utf8_t *result;
+
+    if (how == TO_STR_USE_QUOTED) {
+	result = con4m_new(T_UTF8, "length", buf->byte_len * 4 + 2);
+	char *p = result->data;
+
+	*p++ = '"';
+
+	for (int i = 0; i < buf->byte_len; i++) {
+	    char c = buf->data[i];
+	    *p++ = '\\';
+	    *p++ = 'x';
+	    *p++ = to_hex_map[(c >> 4)];
+	    *p++ = to_hex_map[c & 0x0f];
+	}
+	*p++ = '"';
+    }
+    else {
+	result = con4m_new(T_UTF8, "length", buf->byte_len * 2);
+	char *p = result->data;
+
+	for (int i = 0; i < buf->byte_len; i++) {
+	    char c = buf->data[i];
+	    *p++ = to_hex_map[(c >> 4)];
+	    *p++ = to_hex_map[c & 0x0f];
+	}
+    }
+    return result;
+}
+
+const con4m_vtable buffer_vtable = {
+    .num_entries = 2,
+    .methods     = {
+	(con4m_vtable_entry)buffer_new,
+	(con4m_vtable_entry)buffer_repr,
+    }
+};

--- a/src/con4m/c4str.c
+++ b/src/con4m/c4str.c
@@ -610,7 +610,7 @@ str_t *
 _c4str_truncate(const str_t *s, int64_t len, ...)
 {
     DECLARE_KARGS(
-	bool use_render_width = false;
+	int use_render_width = 0;
 	);
 
     kargs(len, use_render_width);

--- a/src/con4m/c4str.c
+++ b/src/con4m/c4str.c
@@ -740,6 +740,99 @@ c4str_from_file(const char *name, int *err)
     }
 }
 
+int64_t
+_c4str_find(str_t *str, str_t *sub, ...)
+{
+    DECLARE_KARGS(
+	int64_t start = 0;
+	int64_t end   = -1;
+	);
+
+    kargs(sub, start, end);
+
+    str = force_utf32(str);
+    sub = force_utf32(sub);
+
+    uint64_t  i;
+    uint64_t  strcp = c4str_len(str);
+    uint64_t  subcp = c4str_len(sub);
+    uint32_t *strp  = (uint32_t *)str;
+    uint32_t *endp  = strp + end - subcp + 1;
+    uint32_t *subp;
+    uint32_t *p;
+
+    if (start < 0) {
+	start += strcp;
+    }
+    if (start < 0) {
+	return -1;
+    }
+    if (end < 0) {
+	end += strcp + 1;
+    }
+    if (end <= start) {
+	return -1;
+    }
+    if (end > strcp) {
+	end = strcp;
+    }
+    if (subcp == 0) {
+	return start;
+    }
+
+    strp += start;
+    while (strp < endp) {
+	p    = strp;
+	subp = (uint32_t *)sub;
+	for (uint64_t i = 0; i < subcp; i++) {
+	    if (*p++ != *subp++) {
+		goto next_start;
+	    }
+	}
+	return start;
+    next_start:
+	strp++;
+	start++;
+    }
+    return -1;
+}
+
+flexarray_t *
+c4str_split(str_t *str, str_t *sub)
+{
+    str            = force_utf32(str);
+    sub            = force_utf32(sub);
+    uint64_t strcp = c4str_len(str);
+    uint64_t subcp = c4str_len(sub);
+
+    flexarray_t *result = con4m_new(T_LIST, "length", strcp);
+
+    if (!subcp) {
+	for (int i = 0; i < strcp; i++) {
+	    flexarray_set(result, i, c4str_slice(str, i, i + 1));
+	}
+	return result;
+    }
+
+    int64_t start = 0;
+    int64_t ix    = c4str_find(str, sub, "start", start);
+    int     n     = 0;
+
+    while (ix != -1) {
+	flexarray_set(result, n++, c4str_slice(str, start, ix));
+	start = ix + subcp;
+	ix    = c4str_find(str, sub, "start", start);
+    }
+
+    if (start != strcp) {
+	flexarray_set(result, n++, c4str_slice(str, start, strcp));
+    }
+
+    flexarray_shrink(result, n);
+
+    return result;
+}
+
 static str_t *
 c4str_repr(str_t *str, to_str_use_t how)
 {

--- a/src/con4m/c4str.c
+++ b/src/con4m/c4str.c
@@ -753,7 +753,6 @@ _c4str_find(str_t *str, str_t *sub, ...)
     str = force_utf32(str);
     sub = force_utf32(sub);
 
-    uint64_t  i;
     uint64_t  strcp = c4str_len(str);
     uint64_t  subcp = c4str_len(sub);
     uint32_t *strp  = (uint32_t *)str;
@@ -773,7 +772,7 @@ _c4str_find(str_t *str, str_t *sub, ...)
     if (end <= start) {
 	return -1;
     }
-    if (end > strcp) {
+    if ((uint64_t)end > strcp) {
 	end = strcp;
     }
     if (subcp == 0) {
@@ -808,7 +807,7 @@ c4str_split(str_t *str, str_t *sub)
     flexarray_t *result = con4m_new(T_LIST, "length", strcp);
 
     if (!subcp) {
-	for (int i = 0; i < strcp; i++) {
+	for (uint64_t i = 0; i < strcp; i++) {
 	    flexarray_set(result, i, c4str_slice(str, i, i + 1));
 	}
 	return result;
@@ -824,7 +823,7 @@ c4str_split(str_t *str, str_t *sub)
 	ix    = c4str_find(str, sub, "start", start);
     }
 
-    if (start != strcp) {
+    if ((uint64_t)start != strcp) {
 	flexarray_set(result, n++, c4str_slice(str, start, strcp));
     }
 

--- a/src/con4m/grid.c
+++ b/src/con4m/grid.c
@@ -1,10 +1,7 @@
 int debug = 0;
 
-// TODO for partiy:
+// TODO
 // 1. Search.
-// 2. Alternating row color striping option for tables.
-
-// Then:
 // 2. Now we're ready to add a more generic `print()`.
 // 3. I'd like to do the debug console soon-ish.
 
@@ -298,6 +295,7 @@ grid_init(grid_t *grid, va_list args)
 	char         *td_tag        = NULL;
 	int           header_rows   = 0;
 	int           header_cols   = 0;
+	int           stripe        = 0;
 	);
 
     method_kargs(args, start_rows, start_cols, spare_rows, contents,
@@ -320,6 +318,10 @@ grid_init(grid_t *grid, va_list args)
     grid->height        = GRID_UNBOUNDED_DIM;
     grid->td_tag_name   = td_tag;
     grid->th_tag_name   = th_tag;
+
+    if (stripe) {
+	grid->stripe = 1;
+    }
 
     if (contents != NULL) {
 	// NOTE: ignoring num_rows and num_cols; could throw an
@@ -358,6 +360,15 @@ static inline render_style_t *
 get_row_props(grid_t *grid, int row)
 {
     if (!grid->row_props[row]) {
+	if (grid->stripe) {
+	    if (row % 2) {
+		return lookup_cell_style("tr.even");
+	    }
+	    else {
+		return lookup_cell_style("tr.odd");
+	    }
+	}
+
 	return lookup_cell_style("tr");
     }
     else {

--- a/src/con4m/grid.c
+++ b/src/con4m/grid.c
@@ -7,8 +7,7 @@ int debug = 0;
 // Then:
 // 1. Add the ability to add rows or cells easily (and max col width?)
 // 2. Now we're ready to add a more generic `print()`.
-// 3. Deal w/ newlines for fit-to-text (string split).
-// 4. I'd like to do the debug console soon-ish.
+// 3. I'd like to do the debug console soon-ish.
 
 // Not soon, but should eventually get done:
 // 1. Row spans (column spans are there; row spans only stubbed).
@@ -338,7 +337,6 @@ get_column_render_overhead(grid_t *grid)
 static inline int
 column_text_width(grid_t *grid, int col)
 {
-    // For now, this doesn't take newlines into acccount.
     int         max_width = 0;
     real_str_t *s;
 
@@ -353,10 +351,22 @@ column_text_width(grid_t *grid, int col)
 	switch (get_base_type(cell->raw_item)) {
 	case T_STR:
 	case T_UTF32:
-	    s     = (real_str_t *)cell->raw_item;
-	    int n = internal_num_cp(s);
-	    if (n > max_width) {
-		max_width = n;
+	    s = (real_str_t *)cell->raw_item;
+
+	    flexarray_t *f   = c4str_split((str_t *)s->data, c4str_newline());
+	    flex_view_t *v   = flexarray_view(f);
+	    int          len = flexarray_view_len(v);
+
+	    for (i = 0; i < len; i++) {
+		int err;
+		str_t *item = flexarray_view_get(v, i, &err);
+		if (err || item == NULL) {
+		    break;
+		}
+		int cur = c4str_render_len(item);
+		if (cur > max_width) {
+		    max_width = cur;
+		}
 	    }
 	default:
 	    continue;

--- a/src/con4m/grid.c
+++ b/src/con4m/grid.c
@@ -624,7 +624,7 @@ pad_and_style_line(grid_t *grid, renderable_t *cell, int16_t width, str_t *line)
 
 
 
-    style_t     cell_style = merge_style->base_style.style;
+    style_t     cell_style = merge_style->base_style;
     style_t     lpad_style = get_pad_style(merge_style);
     style_t     rpad_style = lpad_style;
     str_t      *copy       = c4str_copy(line);

--- a/src/con4m/grid.c
+++ b/src/con4m/grid.c
@@ -590,7 +590,7 @@ static inline str_t *
 pad_and_style_line(grid_t *grid, renderable_t *cell, int16_t width, str_t *line)
 {
     alignment_t align = cell->current_style->alignment & HORIZONTAL_MASK;
-    int64_t     len   = c4str_len(line);
+    int64_t     len   = c4str_render_len(line);
     uint8_t     lnum  = cell->current_style->left_pad;
     uint8_t     rnum  = cell->current_style->right_pad;
     int64_t     diff  = width - len - lnum - rnum;
@@ -673,7 +673,7 @@ str_render_cell(grid_t *grid, str_t *s, renderable_t *cell, int16_t width,
 	    if (s == NULL) {
 		break;
 	    }
-	    xlist_append(res, c4str_truncate(s, width)); // TODO: change to render width.
+	    xlist_append(res, c4str_truncate(s, width, "use_render_width", 1));
 	}
     }
     else {
@@ -1226,8 +1226,7 @@ align_and_crop_grid_line(grid_t *grid, str_t *line, int32_t width)
     }
     else {
 	// We need to crop. For now, we ONLY crop from the right.
-	return c4str_truncate(line, (int64_t)width);
-	//, "use_render_width", 1);
+	return c4str_truncate(line, (int64_t)width, "use_render_width", 1);
     }
 }
 
@@ -1240,7 +1239,7 @@ align_and_crop_grid(grid_t *grid, xlist_t *lines, int32_t width, int32_t height)
 
     for (int i = 0; i < num_lines; i++) {
 	str_t *s = (str_t *)xlist_get(lines, i, NULL);
-	if (c4str_len(s) == width) {
+	if (c4str_render_len(s) == width) {
 	    continue;
 	}
 

--- a/src/con4m/grid.c
+++ b/src/con4m/grid.c
@@ -1,7 +1,7 @@
 int debug = 0;
 
 // TODO for partiy:
-// 1. Grids are not properly propogating colors to sub-grids?
+// 1. Alignment isn't working??
 // 2. Change sizing to work on renderable width not codepoints.
 // 3. Respect no-wrap.
 // 4. Search.
@@ -12,6 +12,7 @@ int debug = 0;
 // 2. Now we're ready to add a more generic `print()`.
 // 3. Deal w/ newlines for fit-to-text (string split).
 // 4. I'd like to do the debug console soon-ish.
+// 5. Suppress T's and crosses when there are col spans.
 
 // Not soon, but should eventually get done:
 // 1. Row spans (column spans are there; row spans only stubbed).
@@ -587,7 +588,14 @@ static inline str_t *
 pad_and_style_line(grid_t *grid, renderable_t *cell, int16_t width, str_t *line)
 {
 
-    alignment_t align = cell->current_style->alignment & HORIZONTAL_MASK;
+    render_style_t *col_style   = get_col_props(grid, cell->start_col);
+    render_style_t *row_style   = get_row_props(grid, cell->start_row);
+    render_style_t *merge_style = copy_render_style(cell->current_style);
+
+    layer_styles(col_style, merge_style);
+    layer_styles(row_style, merge_style);
+
+    alignment_t align = merge_style->alignment & HORIZONTAL_MASK;
     int64_t     len   = c4str_len(line);
     uint8_t     lnum  = cell->current_style->left_pad;
     uint8_t     rnum  = cell->current_style->right_pad;
@@ -613,15 +621,6 @@ pad_and_style_line(grid_t *grid, renderable_t *cell, int16_t width, str_t *line)
 	    break;
 	}
     }
-
-
-    render_style_t *col_style   = get_col_props(grid, cell->start_col);
-    render_style_t *row_style   = get_row_props(grid, cell->start_row);
-    render_style_t *merge_style = copy_render_style(cell->current_style);
-
-    layer_styles(col_style, merge_style);
-    layer_styles(row_style, merge_style);
-
 
 
     style_t     cell_style = merge_style->base_style;

--- a/src/con4m/grid.c
+++ b/src/con4m/grid.c
@@ -1,9 +1,8 @@
 int debug = 0;
 
 // TODO for partiy:
-// 1. Change sizing to work on renderable width not codepoints.
-// 2. Search.
-// 3. Striping of cell colors.
+// 1. Search.
+// 2. Alternating row color striping option for tables.
 
 // Then:
 // 1. Add the ability to add rows or cells easily (and max col width?)

--- a/src/con4m/grid.c
+++ b/src/con4m/grid.c
@@ -1,17 +1,15 @@
 int debug = 0;
 
 // TODO for partiy:
-// 2. Change sizing to work on renderable width not codepoints.
-// 3. Respect no-wrap.
-// 4. Search.
-// 5. Striping of cell colors.
+// 1. Change sizing to work on renderable width not codepoints.
+// 2. Search.
+// 3. Striping of cell colors.
 
 // Then:
 // 1. Add the ability to add rows or cells easily (and max col width?)
 // 2. Now we're ready to add a more generic `print()`.
 // 3. Deal w/ newlines for fit-to-text (string split).
 // 4. I'd like to do the debug console soon-ish.
-// 5. Suppress T's and crosses when there are col spans.
 
 // Not soon, but should eventually get done:
 // 1. Row spans (column spans are there; row spans only stubbed).

--- a/src/con4m/object.c
+++ b/src/con4m/object.c
@@ -41,7 +41,7 @@ const con4m_dt_info builtin_type_info[CON4M_NUM_BUILTIN_DTS] = {
     { .typeid    = T_BUFFER,
       .alloc_len = CON4M_CUSTOM_ALLOC,
       .ptr_info  = (uint64_t *)pmap_str,
-      .vtable    = &u8str_vtable
+      .vtable    = &buffer_vtable
     },
     { .typeid    = T_UTF32,
       .alloc_len = CON4M_CUSTOM_ALLOC,
@@ -61,7 +61,7 @@ const con4m_dt_info builtin_type_info[CON4M_NUM_BUILTIN_DTS] = {
     { .typeid    = T_TUPLE, },
 
     { .typeid    = T_DICT,
-      .alloc_len = sizeof(hatrack_dict_t),
+      .alloc_len = sizeof(dict_t),
       .ptr_info  = GC_SCAN_ALL,
       .vtable    = &dict_vtable
     },

--- a/src/con4m/object.c
+++ b/src/con4m/object.c
@@ -39,8 +39,8 @@ const con4m_dt_info builtin_type_info[CON4M_NUM_BUILTIN_DTS] = {
       .vtable    = &u8str_vtable
     },
     { .typeid    = T_BUFFER,
-      .alloc_len = CON4M_CUSTOM_ALLOC,
-      .ptr_info  = (uint64_t *)pmap_str,
+      .alloc_len = sizeof(buffer_t),
+      .ptr_info  = (uint64_t *)pmap_first_word,
       .vtable    = &buffer_vtable
     },
     { .typeid    = T_UTF32,

--- a/src/con4m/styledb.c
+++ b/src/con4m/styledb.c
@@ -152,33 +152,31 @@ const border_theme_t *registered_borders = (border_theme_t *)&border_plain;
 
 // Used for border drawing and background (pad color).
 static const render_style_t default_table = {
-    .name                      = "table",
-    .borders                   = BORDER_TOP | BORDER_BOTTOM | BORDER_LEFT |
-                                 BORDER_RIGHT | INTERIOR_HORIZONTAL |
-                                 INTERIOR_VERTICAL,
-    .border_theme              = (border_theme_t *)&border_bold_dash,
-    .dim_kind                  = DIM_AUTO,
-    //.alignment                 = ALIGN_MID_LEFT
+    .name         = "table",
+    .borders      = BORDER_TOP | BORDER_BOTTOM | BORDER_LEFT |  BORDER_RIGHT |
+                    INTERIOR_HORIZONTAL | INTERIOR_VERTICAL,
+    .border_theme = (border_theme_t *)&border_bold_dash,
+    .dim_kind     = DIM_AUTO,
+    .alignment    = ALIGN_MID_LEFT
 };
 
 static const render_style_t default_tr = {
-    .name                      = "tr",
-    .base_style          = 0x00062f4f4ff8f8ff,
-    .dim_kind                  = DIM_AUTO,
-//    .alignment                 = ALIGN_TOP_LEFT,
+    .name       = "tr",
+    .dim_kind   = DIM_AUTO,
+    .alignment  = ALIGN_TOP_LEFT,
+    .base_style = 0x2f3f3ff8f8fful | BG_COLOR_ON | FG_COLOR_ON,
 };
 
 static const render_style_t default_th = {
-    .name                      = "th",
-    .base_style          = UPPER_CASE | 0xb3ff00 | BG_COLOR_ON | FG_COLOR_ON |
-    BOLD_ON,
-    .dim_kind                  = DIM_AUTO,
-    .alignment                 = ALIGN_MID_CENTER,
-
+    .name       = "th",
+    .base_style = UPPER_CASE | 0xb3ff00 | BG_COLOR_ON | FG_COLOR_ON | BOLD_ON,
+    .dim_kind   = DIM_AUTO,
+    .alignment  = ALIGN_MID_CENTER,
 };
 
 static const render_style_t default_td = {
-    .name = "td",
+    .name       = "td",
+    .base_style = 0
 };
 
 static const render_style_t default_tcol = {
@@ -187,50 +185,61 @@ static const render_style_t default_tcol = {
 };
 
 static const render_style_t default_list_grid = {
-    .name                      = "ul/ol",
-    .bottom_pad                = 1,
-    .dim_kind                  = DIM_AUTO,
-//    .alignment                 = ALIGN_MID_LEFT,
+    .name       = "ul",
+    //.base_style = 0x2f3f3ff8f8fful | BG_COLOR_ON | FG_COLOR_ON,
+    .bottom_pad = 1,
+    .dim_kind   = DIM_AUTO,
+    .alignment  = ALIGN_MID_LEFT,
+};
+
+static const render_style_t default_ordered_list_grid = {
+    .name       = "ol",
+    //.base_style = 0x2f3f3ff8f8fful | BG_COLOR_ON | FG_COLOR_ON,
+    .bottom_pad = 1,
+    .dim_kind   = DIM_AUTO,
+    .alignment  = ALIGN_MID_LEFT,
 };
 
 static const render_style_t default_bullet_column = {
     .name       = "bullet",
     .dim_kind   = DIM_ABSOLUTE,
+    //.base_style = 0x2f3f3ff8f8fful | BG_COLOR_ON | FG_COLOR_ON,
     .left_pad   = 1,
-    .dims.units = 1
+    .dims.units = 1,
+    .alignment  = ALIGN_TOP_RIGHT,
 };
 
 static const render_style_t default_list_text_column = {
     .name       = "li",
+    //.base_style = 0x2f3f3ff8f8fful | BG_COLOR_ON | FG_COLOR_ON,
     .dim_kind   = DIM_AUTO,
     .left_pad   = 1,
     .right_pad  = 1,
-//    .alignment  = ALIGN_TOP_LEFT,
+    .alignment  = ALIGN_TOP_LEFT,
 };
 
 static const render_style_t default_h1 = {
-    .name                      = "h1",
+    .name       = "h1",
     .base_style = ITALIC_ON | FG_COLOR_ON | BG_COLOR_ON |  UL_ON |
                   (0xb3ff00UL << 24),
-    .alignment                 = ALIGN_TOP_CENTER,
-    .top_pad                   = 1
+    .alignment  = ALIGN_TOP_CENTER,
+    .top_pad    = 1
 };
 
 static const render_style_t default_h2 = {
-    .name                      = "h2",
+    .name       = "h2",
     .base_style = ITALIC_ON | FG_COLOR_ON | BG_COLOR_ON | UL_ON |
                      (0xff2f8eUL << 24),
-    .alignment                 = ALIGN_TOP_CENTER,
-    .top_pad                   = 1
+    .alignment  = ALIGN_TOP_CENTER,
+    .top_pad    = 1
 };
 
 static const render_style_t default_flow = {
-    .name                      = "flow",
-    .left_pad                  = 1,
-    .right_pad                 = 1,
-    //.alignment                 = ALIGN_TOP_LEFT,
-    .base_style  = BG_COLOR_ON | FG_COLOR_ON | 0xf8f8ff | // Ghost white
-                   (0x2f4f4f << 24)        // Dark slate grey.
+    .name       = "flow",
+    .base_style = 0x2f3f3ff8f8fful | BG_COLOR_ON | FG_COLOR_ON,
+    .left_pad   = 1,
+    .right_pad  = 1,
+    .alignment  = ALIGN_TOP_LEFT,
 };
 
 // Third word of render styles is a pointer.
@@ -259,16 +268,13 @@ lookup_cell_style(char *name)
 {
     init_style_db();
 
-    int ok = false;
+    int ok = 0;
 
-    render_style_t *entry  = hatrack_dict_get(style_dictionary, name,
-					      (bool *)&ok);
+    render_style_t *entry  = hatrack_dict_get(style_dictionary, name, &ok);
 
     if (!entry) {
 	return NULL;
     }
-
-
 
     render_style_t *result = gc_alloc_mapped(render_style_t, &rs_pmap[0]);
     memcpy(result, entry, sizeof(render_style_t));
@@ -281,11 +287,11 @@ con4m_style_init(render_style_t *style, va_list args)
     DECLARE_KARGS(
 	color_t fg_color        = -1;
 	color_t bg_color        = -1;
-	int32_t bold            = -1;
-	int32_t italic          = -1;
-	int32_t strikethru      = -1;
-	int32_t underline       = -1;
-	int32_t inverse         = -1;
+	int64_t bold            = -1;
+	int64_t italic          = -1;
+	int64_t strikethru      = -1;
+	int64_t underline       = -1;
+	int64_t inverse         = -1;
 	double  width_pct       = -1;
 	int64_t flex_units      = -1;
 	int32_t min_size        = -1;
@@ -433,7 +439,7 @@ layer_styles(const render_style_t *base, render_style_t *cur)
 	set_fg_color(cur, base->base_style & ~FG_COLOR_MASK);
     }
     if (!(cur->base_style & BG_COLOR_ON) && base->base_style & BG_COLOR_ON) {
-	set_bg_color(cur, (base->base_style & ~BG_COLOR_MASK) >> 24);
+	set_bg_color(cur, (color_t)((base->base_style & ~BG_COLOR_MASK) >> 24));
     }
     if (base->base_style & BOLD_ON) {
 	cur->base_style |= BOLD_ON;
@@ -518,8 +524,8 @@ install_default_styles()
     set_style("td", (render_style_t *)&default_td);
     set_style("th", (render_style_t *)&default_th);
     set_style("tcol", (render_style_t *)&default_tcol);
-    set_style("ol", (render_style_t *)&default_list_grid);
     set_style("ul", (render_style_t *)&default_list_grid);
+    set_style("ol", (render_style_t *)&default_ordered_list_grid);
     set_style("bullet", (render_style_t *)&default_bullet_column);
     set_style("li", (render_style_t *)&default_list_text_column);
     set_style("h1", (render_style_t *)&default_h1);

--- a/src/con4m/styledb.c
+++ b/src/con4m/styledb.c
@@ -167,6 +167,20 @@ static const render_style_t default_tr = {
     .base_style = 0x2f3f3ff8f8fful | BG_COLOR_ON | FG_COLOR_ON,
 };
 
+static const render_style_t default_tr_even = {
+    .name       = "tr.even",
+    .dim_kind   = DIM_AUTO,
+    .alignment  = ALIGN_TOP_LEFT,
+    .base_style = 0x3f3f3ff8f8fful | BG_COLOR_ON | FG_COLOR_ON,
+};
+
+static const render_style_t default_tr_odd = {
+    .name       = "tr.odd",
+    .dim_kind   = DIM_AUTO,
+    .alignment  = ALIGN_TOP_LEFT,
+    .base_style = 0x5f5f5ff8f8fful | BG_COLOR_ON | FG_COLOR_ON,
+};
+
 static const render_style_t default_th = {
     .name       = "th",
     .base_style = UPPER_CASE | 0xb3ff00 | BG_COLOR_ON | FG_COLOR_ON | BOLD_ON,
@@ -268,9 +282,7 @@ lookup_cell_style(char *name)
 {
     init_style_db();
 
-    int ok = 0;
-
-    render_style_t *entry  = hatrack_dict_get(style_dictionary, name, &ok);
+    render_style_t *entry  = hatrack_dict_get(style_dictionary, name, NULL);
 
     if (!entry) {
 	return NULL;
@@ -521,6 +533,8 @@ install_default_styles()
 
     set_style("table", (render_style_t *)&default_table);
     set_style("tr", (render_style_t *)&default_tr);
+    set_style("tr.even", (render_style_t *)&default_tr_even);
+    set_style("tr.odd", (render_style_t *)&default_tr_odd);
     set_style("td", (render_style_t *)&default_td);
     set_style("th", (render_style_t *)&default_th);
     set_style("tcol", (render_style_t *)&default_tcol);

--- a/src/con4m/styledb.c
+++ b/src/con4m/styledb.c
@@ -163,14 +163,15 @@ static const render_style_t default_table = {
 
 static const render_style_t default_tr = {
     .name                      = "tr",
-    .base_style.style          = 0x00062f4f4ff8f8ff,
+    .base_style          = 0x00062f4f4ff8f8ff,
     .dim_kind                  = DIM_AUTO,
 //    .alignment                 = ALIGN_TOP_LEFT,
 };
 
 static const render_style_t default_th = {
     .name                      = "th",
-    .base_style.style          = 0x175fb3ff00000000,
+    .base_style          = UPPER_CASE | 0xb3ff00 | BG_COLOR_ON | FG_COLOR_ON |
+    BOLD_ON,
     .dim_kind                  = DIM_AUTO,
     .alignment                 = ALIGN_MID_CENTER,
 
@@ -209,24 +210,16 @@ static const render_style_t default_list_text_column = {
 
 static const render_style_t default_h1 = {
     .name                      = "h1",
-    .base_style.bf.italic      = 1,
-    .base_style.bf.fg_color_on = 1,
-    .base_style.bf.bg_color_on = 1,
-    .base_style.bf.fg_color    = 0x000000, // black
-    .base_style.bf.bg_color    = 0xb3ff00, // Atomic lime
-    .base_style.bf.underline   = NEW_UL_ON,
+    .base_style = ITALIC_ON | FG_COLOR_ON | BG_COLOR_ON |  UL_ON |
+                  (0xb3ff00UL << 24),
     .alignment                 = ALIGN_TOP_CENTER,
     .top_pad                   = 1
 };
 
 static const render_style_t default_h2 = {
     .name                      = "h2",
-    .base_style.bf.italic      = 1,
-    .base_style.bf.fg_color_on = 1,
-    .base_style.bf.bg_color_on = 1,
-    .base_style.bf.fg_color    = 0x000000, // black
-    .base_style.bf.bg_color    = 0xff2f8e, // Jazzberry
-    .base_style.bf.underline   = NEW_UL_ON,
+    .base_style = ITALIC_ON | FG_COLOR_ON | BG_COLOR_ON | UL_ON |
+                     (0xff2f8eUL << 24),
     .alignment                 = ALIGN_TOP_CENTER,
     .top_pad                   = 1
 };
@@ -236,10 +229,8 @@ static const render_style_t default_flow = {
     .left_pad                  = 1,
     .right_pad                 = 1,
     //.alignment                 = ALIGN_TOP_LEFT,
-    .base_style.bf.fg_color_on = 1,
-    .base_style.bf.bg_color_on = 1,
-    .base_style.bf.fg_color    = 0xf8f8ff, // Ghost white
-    .base_style.bf.bg_color    = 0x2f4f4f, // Dark slate grey.
+    .base_style  = BG_COLOR_ON | FG_COLOR_ON | 0xf8f8ff | // Ghost white
+                   (0x2f4f4f << 24)        // Dark slate grey.
 };
 
 // Third word of render styles is a pointer.
@@ -355,12 +346,12 @@ con4m_style_init(render_style_t *style, va_list args)
     if (strikethru > 0) {
 	strikethru_on(style);
     }
-    if (underline == NEW_UL_ON) {
-	underline_on(style);
+    if (underline == UL_DOUBLE) {
+	double_underline_on(style);
     }
     else {
-	if (underline == NEW_UL_DOUBLE) {
-	    double_underline_on(style);
+	if (underline != -1) {
+	    underline_on(style);
 	}
     }
     if (inverse > 0) {
@@ -438,29 +429,35 @@ void
 layer_styles(const render_style_t *base, render_style_t *cur)
 {
     // Anything not explicitly set in 'cur' will get set from base.
-    if (!cur->base_style.bf.fg_color_on && base->base_style.bf.fg_color_on) {
-	set_fg_color(cur, base->base_style.bf.fg_color);
+    if (!(cur->base_style & FG_COLOR_ON) && base->base_style & FG_COLOR_ON) {
+	set_fg_color(cur, base->base_style & ~FG_COLOR_MASK);
     }
-    if (!cur->base_style.bf.bg_color_on && base->base_style.bf.bg_color_on) {
-	set_bg_color(cur, base->base_style.bf.bg_color);
+    if (!(cur->base_style & BG_COLOR_ON) && base->base_style & BG_COLOR_ON) {
+	set_bg_color(cur, (base->base_style & ~BG_COLOR_MASK) >> 24);
     }
-    if (base->base_style.bf.bold) {
-	cur->base_style.bf.bold = 1;
+    if (base->base_style & BOLD_ON) {
+	cur->base_style |= BOLD_ON;
     }
-    if (base->base_style.bf.italic) {
-	cur->base_style.bf.italic = 1;
+    if (base->base_style & ITALIC_ON) {
+	cur->base_style |= ITALIC_ON;
     }
-    if (base->base_style.bf.strikethru) {
-	cur->base_style.bf.strikethru = 1;
+    if (base->base_style & ST_ON) {
+	cur->base_style |= ST_ON;
     }
-    if (!cur->base_style.bf.underline) {
-	cur->base_style.bf.underline = base->base_style.bf.underline;
+    if (base->base_style & UL_ON) {
+	cur->base_style |= UL_ON;
     }
-    if (base->base_style.bf.inverse) {
-	cur->base_style.bf.inverse = 1;
+    if (base->base_style & UL_DOUBLE) {
+	cur->base_style |= UL_DOUBLE;
     }
-    if (!cur->base_style.bf.casing) {
-	cur->base_style.bf.casing = base->base_style.bf.casing;
+    if (base->base_style & INV_ON) {
+	cur->base_style |= INV_ON;
+    }
+    if (base->base_style & LOWER_CASE) {
+	cur->base_style |= LOWER_CASE;
+    }
+    if (base->base_style & UPPER_CASE) {
+	cur->base_style |= UPPER_CASE;
     }
 
     if (cur->border_theme == NULL && base->border_theme != NULL) {

--- a/src/con4m/styledb.c
+++ b/src/con4m/styledb.c
@@ -152,67 +152,63 @@ const border_theme_t *registered_borders = (border_theme_t *)&border_plain;
 
 // Used for border drawing and background (pad color).
 static const render_style_t default_table = {
-    .base_style.bf.fg_color_on = 1,
-    .base_style.bf.bg_color_on = 1,
-    .base_style.bf.fg_color    = 0xf8f8ff, // Ghost white
-    .base_style.bf.bg_color    = 0x2f4f4f, // Dark slate grey.
+    .name                      = "table",
     .borders                   = BORDER_TOP | BORDER_BOTTOM | BORDER_LEFT |
                                  BORDER_RIGHT | INTERIOR_HORIZONTAL |
                                  INTERIOR_VERTICAL,
     .border_theme              = (border_theme_t *)&border_bold_dash,
-    .left_pad                  = 1,
-    .right_pad                 = 1,
     .dim_kind                  = DIM_AUTO,
-    .alignment                 = ALIGN_MID_LEFT
+    //.alignment                 = ALIGN_MID_LEFT
 };
 
 static const render_style_t default_tr = {
+    .name                      = "tr",
     .base_style.style          = 0x00062f4f4ff8f8ff,
     .dim_kind                  = DIM_AUTO,
-    .alignment                 = ALIGN_TOP_LEFT
+//    .alignment                 = ALIGN_TOP_LEFT,
 };
 
 static const render_style_t default_th = {
-    .base_style.bf.fg_color_on = 1,
-    .base_style.bf.bg_color_on = 1,
-    .base_style.bf.fg_color    = 0xb3ff00, // Atomic lime
-    .base_style.bf.bg_color    = 0x000000,
-    .left_pad                  = 1,
-    .right_pad                 = 1,
+    .name                      = "th",
+    .base_style.style          = 0x175fb3ff00000000,
     .dim_kind                  = DIM_AUTO,
-    .alignment                 = ALIGN_TOP_LEFT
+    .alignment                 = ALIGN_MID_CENTER,
+
 };
 
 static const render_style_t default_td = {
-    .base_style.style = 0,
+    .name = "td",
 };
 
 static const render_style_t default_tcol = {
+    .name     = "tcol",
     .dim_kind = DIM_AUTO
 };
 
 static const render_style_t default_list_grid = {
-    .left_pad   = 2,
-    .right_pad  = 1,
-    .bottom_pad = 1,
-    .dim_kind   = DIM_AUTO,
-    .alignment  = ALIGN_MID_LEFT
+    .name                      = "ul/ol",
+    .bottom_pad                = 1,
+    .dim_kind                  = DIM_AUTO,
+//    .alignment                 = ALIGN_MID_LEFT,
 };
 
 static const render_style_t default_bullet_column = {
-    .dim_kind   = DIM_FIT_TO_TEXT,
-    .left_pad   = 0,
-    .dims.units = 2
+    .name       = "bullet",
+    .dim_kind   = DIM_ABSOLUTE,
+    .left_pad   = 1,
+    .dims.units = 1
 };
 
 static const render_style_t default_list_text_column = {
+    .name       = "li",
     .dim_kind   = DIM_AUTO,
     .left_pad   = 1,
     .right_pad  = 1,
-    .alignment  = ALIGN_TOP_LEFT
+//    .alignment  = ALIGN_TOP_LEFT,
 };
 
 static const render_style_t default_h1 = {
+    .name                      = "h1",
     .base_style.bf.italic      = 1,
     .base_style.bf.fg_color_on = 1,
     .base_style.bf.bg_color_on = 1,
@@ -224,6 +220,7 @@ static const render_style_t default_h1 = {
 };
 
 static const render_style_t default_h2 = {
+    .name                      = "h2",
     .base_style.bf.italic      = 1,
     .base_style.bf.fg_color_on = 1,
     .base_style.bf.bg_color_on = 1,
@@ -234,8 +231,19 @@ static const render_style_t default_h2 = {
     .top_pad                   = 1
 };
 
+static const render_style_t default_flow = {
+    .name                      = "flow",
+    .left_pad                  = 1,
+    .right_pad                 = 1,
+    //.alignment                 = ALIGN_TOP_LEFT,
+    .base_style.bf.fg_color_on = 1,
+    .base_style.bf.bg_color_on = 1,
+    .base_style.bf.fg_color    = 0xf8f8ff, // Ghost white
+    .base_style.bf.bg_color    = 0x2f4f4f, // Dark slate grey.
+};
+
 // Third word of render styles is a pointer.
-const uint64_t rs_pmap[2] = { 0x1, 0x8000000000000000 };
+const uint64_t rs_pmap[2] = { 0x1, 0xb000000000000000 };
 
 static inline void
 init_style_db()
@@ -262,7 +270,8 @@ lookup_cell_style(char *name)
 
     int ok = false;
 
-    render_style_t *entry  = hatrack_dict_get(style_dictionary, name, &ok);
+    render_style_t *entry  = hatrack_dict_get(style_dictionary, name,
+					      (bool *)&ok);
 
     if (!entry) {
 	return NULL;
@@ -310,6 +319,7 @@ con4m_style_init(render_style_t *style, va_list args)
 		 disable_wrap, pad_color, alignment, border_theme,
 		 enabled_borders, tag);
 
+    style->name = tag;
     // Use basic math to make sure overlaping cell sizing strategies
     // aren't requested in one call.
     int32_t sz_test = width_pct + flex_units + min_size + max_size + fit_text;
@@ -518,6 +528,7 @@ install_default_styles()
     set_style("h1", (render_style_t *)&default_h1);
     set_style("h2", (render_style_t *)&default_h2);
     set_style("table", (render_style_t *)&default_table);
+    set_style("flow", (render_style_t *)&default_flow);
 }
 
 const con4m_vtable render_style_vtable = {

--- a/src/tests/test.c
+++ b/src/tests/test.c
@@ -219,7 +219,7 @@ table_test()
     grid_t     *g     = con4m_new(T_GRID, "start_rows", 4, "start_cols", 3);
     str_t      *hdr   = con4m_new(T_STR, "cstring", "This is a table, brah.");
 
-
+    printf("Render len of test1 = %d; strlen = %d\n", c4str_render_len(test1), c4str_len(test1));
     grid_add_col_span(g, to_str_renderable(hdr, "td"),  0, 0, 3);
     grid_set_cell_contents(g, 1, 0, to_internal(test1));
     grid_set_cell_contents(g, 1, 1, to_internal(test2));

--- a/src/tests/test.c
+++ b/src/tests/test.c
@@ -215,18 +215,21 @@ table_test()
     str_t      *test3 = con4m_new(T_STR, "cstring", "Example 3.");
     str_t      *test4 = con4m_new(T_STR, "cstring", "Defaults.");
     str_t      *test5 = con4m_new(T_STR, "cstring", "Last one.");
-    str_t      *mt    = empty_string();
-    grid_t     *g     = con4m_new(T_GRID, "start_rows", 4, "start_cols", 3);
+    grid_t     *g     = con4m_new(T_GRID, "start_rows", 4, "start_cols", 3,
+				  "header_rows", 1);
     str_t      *hdr   = con4m_new(T_STR, "cstring", "Yes, this is a table.");
 
-    grid_add_col_span(g, to_str_renderable(hdr, "td"),  0, 0, 3);
-    grid_set_cell_contents(g, 1, 0, to_internal(test1));
-    grid_set_cell_contents(g, 1, 1, to_internal(test2));
-    grid_set_cell_contents(g, 1, 2, to_internal(test4));
+
+    grid_add_row(g, to_str_renderable(hdr, "td"));
+    grid_add_cell(g, to_internal(test1));
+    grid_add_cell(g, to_internal(test2));
+    grid_add_cell(g, to_internal(test4));
     grid_set_cell_contents(g, 2, 2, to_internal(test3));
     grid_set_cell_contents(g, 2, 1, to_internal(test5));
     grid_add_col_span(g, to_str_renderable(test1, "td"),  3, 0, 2);
     grid_set_cell_contents(g, 2, 0, to_internal(empty_string()));
+    // If we don't explicitly set this, there can be some render issues
+    // when there's not enough room.
     grid_set_cell_contents(g, 3, 2, to_internal(empty_string()));
     c4str_apply_style(test1, style1);
     c4str_apply_style(test2, style2);
@@ -236,7 +239,6 @@ table_test()
     con4m_new(T_RENDER_STYLE, "flex_units", 2, "tag", "col3");
 //    con4m_new(T_RENDER_STYLE, "width_pct", 10., "tag", "col1");
 //    con4m_new(T_RENDER_STYLE, "width_pct", 30., "tag", "col3");
-    apply_row_style(g, 0, "th");
     apply_column_style(g, 0, "col1");
     apply_column_style(g, 2, "col3");
 
@@ -270,6 +272,7 @@ table_test()
     grid_t *ul   = unordered_list(l);
     grid_t *flow = grid_flow(3, g, ul, ol);
 
+    grid_add_cell(flow, to_internal(test1));
     ansi_render(con4m_value_obj_repr(flow), stdout);
 }
 

--- a/src/tests/test.c
+++ b/src/tests/test.c
@@ -216,17 +216,19 @@ table_test()
     str_t      *test4 = con4m_new(T_STR, "cstring", "Defaults.");
     str_t      *test5 = con4m_new(T_STR, "cstring", "Last one.");
     str_t      *mt    = empty_string();
-    grid_t     *g     = con4m_new(T_GRID, "start_rows", 3, "start_cols", 3);
+    grid_t     *g     = con4m_new(T_GRID, "start_rows", 4, "start_cols", 3);
+    str_t      *hdr   = con4m_new(T_STR, "cstring", "This is a table, brah.");
 
 
-    grid_set_cell_contents(g, 0, 0, to_internal(test1));
-    grid_set_cell_contents(g, 0, 1, to_internal(test2));
-    grid_set_cell_contents(g, 0, 2, to_internal(test4));
-    grid_set_cell_contents(g, 1, 2, to_internal(test3));
-    grid_set_cell_contents(g, 1, 1, to_internal(test5));
-    grid_add_col_span(g, to_str_renderable(test1, "td"),  2, 0, 2);
-    grid_set_cell_contents(g, 1, 0, to_internal(empty_string()));
-    grid_set_cell_contents(g, 2, 2, to_internal(empty_string()));
+    grid_add_col_span(g, to_str_renderable(hdr, "td"),  0, 0, 3);
+    grid_set_cell_contents(g, 1, 0, to_internal(test1));
+    grid_set_cell_contents(g, 1, 1, to_internal(test2));
+    grid_set_cell_contents(g, 1, 2, to_internal(test4));
+    grid_set_cell_contents(g, 2, 2, to_internal(test3));
+    grid_set_cell_contents(g, 2, 1, to_internal(test5));
+    grid_add_col_span(g, to_str_renderable(test1, "td"),  3, 0, 2);
+    grid_set_cell_contents(g, 2, 0, to_internal(empty_string()));
+    grid_set_cell_contents(g, 3, 2, to_internal(empty_string()));
     c4str_apply_style(test1, style1);
     c4str_apply_style(test2, style2);
     c4str_apply_style(test3, style1);
@@ -235,45 +237,43 @@ table_test()
     con4m_new(T_RENDER_STYLE, "flex_units", 2, "tag", "col3");
 //    con4m_new(T_RENDER_STYLE, "width_pct", 10., "tag", "col1");
 //    con4m_new(T_RENDER_STYLE, "width_pct", 30., "tag", "col3");
+    apply_row_style(g, 0, "th");
     apply_column_style(g, 0, "col1");
     apply_column_style(g, 2, "col3");
-    ansi_render(con4m_value_obj_repr(g), stdout);
-}
 
-void
-ordered_list_test()
-{
-    str_t *test1   = con4m_new(T_STR, "cstring",
+    // Ordered / unordered lists.
+    str_t *ol1   = con4m_new(T_STR, "cstring",
 			       "This is a good point, one that you haven't "
 			       "heard before.");
-    str_t *test2   = con4m_new(T_STR, "cstring",
+    str_t *ol2   = con4m_new(T_STR, "cstring",
 			       "This is a point that's just as valid, but you "
 			       "already know it.");
-    str_t *test3   = con4m_new(T_STR, "cstring", "This is a small point.");
-    str_t *test4   = con4m_new(T_STR, "cstring", "Conclusion.");
+    str_t *ol3   = con4m_new(T_STR, "cstring", "This is a small point.");
+    str_t *ol4   = con4m_new(T_STR, "cstring", "Conclusion.");
     flexarray_t *l = con4m_new(T_LIST, "length", 12);
 
-    flexarray_set(l, 0, to_internal(test1));
-    flexarray_set(l, 1, to_internal(test2));
-    flexarray_set(l, 2, to_internal(test3));
-    flexarray_set(l, 3, to_internal(test4));
-    flexarray_set(l, 4, to_internal(test1));
-    flexarray_set(l, 5, to_internal(test2));
-    flexarray_set(l, 6, to_internal(test3));
-    flexarray_set(l, 7, to_internal(test4));
-    flexarray_set(l, 8, to_internal(test1));
-    flexarray_set(l, 9, to_internal(test2));
-    flexarray_set(l, 0xa, to_internal(test3));
-    flexarray_set(l, 0xb, to_internal(test4));
+    flexarray_set(l, 0, to_internal(ol1));
+    flexarray_set(l, 1, to_internal(ol2));
+    flexarray_set(l, 2, to_internal(ol3));
+    flexarray_set(l, 3, to_internal(ol4));
+    flexarray_set(l, 4, to_internal(ol1));
+    flexarray_set(l, 5, to_internal(ol2));
+    flexarray_set(l, 6, to_internal(ol3));
+    flexarray_set(l, 7, to_internal(ol4));
+    flexarray_set(l, 8, to_internal(ol1));
+    flexarray_set(l, 9, to_internal(ol2));
+    flexarray_set(l, 0xa, to_internal(ol3));
+    flexarray_set(l, 0xb, to_internal(ol4));
 
 
-    grid_t      *g = ordered_list(l);
-    apply_column_style(g, 1, "th");
 
-    ansi_render(con4m_value_obj_repr(g), stdout);
-    grid_t      *h = unordered_list(l);
-    ansi_render(con4m_value_obj_repr(h), stdout);
+    grid_t *ol   = ordered_list(l);
+    grid_t *ul   = unordered_list(l);
+    grid_t *flow = grid_flow(3, g, ul, ol);
+
+    ansi_render(con4m_value_obj_repr(flow), stdout);
 }
+
 
 int
 main(int argc, char **argv, char **envp)
@@ -292,7 +292,6 @@ main(int argc, char **argv, char **envp)
     to_slice = NULL;
     test4();
     table_test();
-    ordered_list_test();
     STATIC_ASCII_STR(local_test, "\nGoodbye!\n");
     ansi_render(local_test, stdout);
 

--- a/src/tests/test.c
+++ b/src/tests/test.c
@@ -208,8 +208,8 @@ test4()
 void
 table_test()
 {
-    str_t      *test1 = con4m_new(T_STR, "cstring", "Some example??"
-	" Let's make it a fairly long example, so it will be sure to need"
+    str_t      *test1 = con4m_new(T_STR, "cstring", "Some example 🤯 🤯 🤯"
+	" Let's make it a fairly long 🤯 example, so it will be sure to need"
 	" some reynolds' wrap.");
     str_t      *test2 = con4m_new(T_STR, "cstring", "Some other example.");
     str_t      *test3 = con4m_new(T_STR, "cstring", "Example 3.");
@@ -217,9 +217,8 @@ table_test()
     str_t      *test5 = con4m_new(T_STR, "cstring", "Last one.");
     str_t      *mt    = empty_string();
     grid_t     *g     = con4m_new(T_GRID, "start_rows", 4, "start_cols", 3);
-    str_t      *hdr   = con4m_new(T_STR, "cstring", "This is a table, brah.");
+    str_t      *hdr   = con4m_new(T_STR, "cstring", "Yes, this is a table.");
 
-    printf("Render len of test1 = %d; strlen = %d\n", c4str_render_len(test1), c4str_len(test1));
     grid_add_col_span(g, to_str_renderable(hdr, "td"),  0, 0, 3);
     grid_set_cell_contents(g, 1, 0, to_internal(test1));
     grid_set_cell_contents(g, 1, 1, to_internal(test2));

--- a/src/tests/test.c
+++ b/src/tests/test.c
@@ -266,10 +266,10 @@ table_test()
     flexarray_set(l, 0xa, to_internal(ol3));
     flexarray_set(l, 0xb, to_internal(ol4));
 
-
-
     grid_t *ol   = ordered_list(l);
     grid_t *ul   = unordered_list(l);
+
+    grid_stripe_rows(ol);
     grid_t *flow = grid_flow(3, g, ul, ol);
 
     grid_add_cell(flow, to_internal(test1));


### PR DESCRIPTION
The name might be wrong, but the 'flow' interface gives a grid with one column meant to hold text you plan on outputting in a continuous flow (i.e., to the terminal).

As part of this, I added an API for adding rows and cells to a grid easily, and added auto-expansion of the table when using that API.

The grid is now is feature complete wrt. what I'd done in nimutils.