### PR TITLE
Fixes to compile on Linux w/ gcc and silence warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
 subprojects/*/
 .meson_last
+.vscode
 

--- a/include/con4m/base.h
+++ b/include/con4m/base.h
@@ -35,6 +35,11 @@
 #if defined(__linux__)
 #include <sys/random.h>
 #include <threads.h>
+#include <endian.h>
+#endif
+
+#if defined(__MACH__)
+#include <machine/endian.h>
 #endif
 
 #ifdef HAVE_MUSL
@@ -48,21 +53,29 @@ extern pid_t
 forkpty(int *, char *, struct termios *, struct winsize *);
 #endif
 
-#define min(a, b) ({ __typeof__ (a) _a = (a); __typeof__ (b) _b = (b); \
+#define min(a, b) ({ __typeof__ (a) _a = (a), _b = (b); \
                     _a < _b ? _a : _b; })
-#define max(a, b) ({ __typeof__ (a) _a = (a); __typeof__ (b) _b = (b); \
+#define max(a, b) ({ __typeof__ (a) _a = (a), _b = (b); \
                     _a > _b ? _a : _b; })
 
 #include <vendor.h>
 #include <hatrack.h>
 #include <con4m/datatypes.h>
 
-#if defined(__LITTLE_ENDIAN__)
+#if BYTE_ORDER == LITTLE_ENDIAN
 #define little_64(x)
 #define little_32(x)
 #define little_16(x)
-#else // if defined(__BIG_ENDIAN__)
+#elif BYTE_ORDER == BIG_ENDIAN
+#if defined(linux)
+#define little_64(x) x = htole64(x)
+#define little_32(x) x = htole32(x)
+#define little_16(x) x = htole16(x)
+#else
 #define little_64(x) x = htonll(x)
 #define little_32(x) x = htonl(x)
 #define little_16(x) x = htons(x)
+#endif
+#else
+#error unknown endian
 #endif

--- a/include/con4m/gc.h
+++ b/include/con4m/gc.h
@@ -231,7 +231,7 @@ get_stack_bounds(uint64_t *top, uint64_t *bottom)
     uint64_t       addr;
 
     pthread_getattr_np(self, &attrs);
-    pthread_attr_getstack(&attrs, &addr, &size);
+    pthread_attr_getstack(&attrs, (void **)&addr, &size);
 
     *bottom = (uint64_t)addr;
     *top    = size + (uint64_t)addr;

--- a/include/con4m/style.h
+++ b/include/con4m/style.h
@@ -38,15 +38,15 @@ style_debug(char *prefix, const any_str_t *p)
         return;
 
     if (p->styling == NULL) {
-        printf("debug (%s): len: %lld styles: nil\n", prefix, string_codepoint_len(p));
+        printf("debug (%s): len: %lld styles: nil\n", prefix, (long long)string_codepoint_len(p));
         return;
     }
     else {
-        printf("debug (%s): len: %lld # styles: %lld\n", prefix, string_codepoint_len(p), p->styling->num_entries);
+        printf("debug (%s): len: %lld # styles: %lld\n", prefix, (long long)string_codepoint_len(p), (long long)p->styling->num_entries);
     }
     for (int i = 0; i < p->styling->num_entries; i++) {
         style_entry_t entry = p->styling->styles[i];
-        printf("%d: %llx (%d:%d)\n", i + 1, p->styling->styles[i].info, entry.start, entry.end);
+        printf("%d: %llx (%d:%d)\n", i + 1, (long long)p->styling->styles[i].info, entry.start, entry.end);
     }
 }
 

--- a/include/con4m/styledb.h
+++ b/include/con4m/styledb.h
@@ -134,7 +134,7 @@ titlecase_on(render_style_t *style)
     style->base_style |= TITLE_CASE;
 }
 
-const extern border_theme_t *registered_borders;
+extern const border_theme_t *registered_borders;
 
 static inline _Bool
 set_border_theme(render_style_t *style, char *name)

--- a/include/hatrack.h
+++ b/include/hatrack.h
@@ -36,6 +36,7 @@
 #ifdef __MACH__
 #include <mach/clock.h>
 #include <mach/mach.h>
+#endif
 
 typedef struct hatrack_queue_t queue_t;
 #ifndef NO_CON4M
@@ -108,5 +109,4 @@ free_libc_allocation(void *ptr)
 #include <hatrack/capq.h>
 #include <hatrack/vector.h>
 #include <hatrack/helpmanager.h>
-#endif
 #endif

--- a/src/con4m/crypto/sha.c
+++ b/src/con4m/crypto/sha.c
@@ -67,7 +67,7 @@ sha_cstring_update(sha_ctx *ctx, char *str)
 void
 sha_int_update(sha_ctx *ctx, uint64_t n)
 {
-    little_64(result);
+    little_64(n);
     EVP_DigestUpdate(ctx->openssl_ctx, &n, sizeof(uint64_t));
 }
 

--- a/src/con4m/gc.c
+++ b/src/con4m/gc.c
@@ -176,9 +176,11 @@ con4m_delete_arena(con4m_arena_t *arena)
         }
         rc_free(arena->late_mutations);
 
+#if defined(MADV_ZERO_WIRED_PAGES)
         char *start = ((char *)arena) - page_bytes;
         char *end   = ((char *)arena->heap_end) - page_bytes;
         madvise(start, end - start, MADV_ZERO_WIRED_PAGES);
+#endif
 
         arena = prev_active;
     }

--- a/src/con4m/grid.c
+++ b/src/con4m/grid.c
@@ -714,7 +714,7 @@ calculate_col_widths(grid_t *grid, int16_t width, int16_t *render_width)
             if (units == 0) {
                 continue;
             }
-            /* fallthrough; */
+            /* fallthrough */
         case DIM_UNSET:
         case DIM_AUTO:
             if (--num_flex == 0) {

--- a/src/con4m/lists.c
+++ b/src/con4m/lists.c
@@ -113,11 +113,11 @@ list_can_coerce_to(type_spec_t *my_type, type_spec_t *dst_type)
 {
     base_t base = type_spec_get_base(dst_type);
 
-    if (base == T_BOOL) {
+    if (base == (base_t)T_BOOL) {
         return true;
     }
 
-    if (base == T_LIST || base == T_XLIST) {
+    if (base == (base_t)T_LIST || base == (base_t)T_XLIST) {
         type_spec_t *my_item  = tspec_get_param(my_type, 0);
         type_spec_t *dst_item = tspec_get_param(dst_type, 0);
 
@@ -136,11 +136,11 @@ list_coerce_to(flexarray_t *list, type_spec_t *dst_type)
     type_spec_t *src_item_type = tspec_get_param(get_my_type(list), 0);
     type_spec_t *dst_item_type = tspec_get_param(dst_type, 0);
 
-    if (base == T_BOOL) {
+    if (base == (base_t)T_BOOL) {
         return (object_t)(int64_t)(flexarray_view_len(view) != 0);
     }
 
-    if (base == T_LIST) {
+    if (base == (base_t)T_LIST) {
         flexarray_t *res = con4m_new(dst_type, kw("length", ka(len)));
 
         for (int i = 0; i < len; i++) {

--- a/src/con4m/marshal.c
+++ b/src/con4m/marshal.c
@@ -178,7 +178,7 @@ unmarshal_compact_type(stream_t *s)
         return result;
     case BT_func:
         flags = unmarshal_u8(s);
-        // Fallthrough.
+        // fallthrough
     case BT_list:
     case BT_dict:
     case BT_tuple:
@@ -195,6 +195,8 @@ unmarshal_compact_type(stream_t *s)
         type_hash(result, global_type_env);
         return result;
     }
+    // unreachable
+    abort();
 }
 
 void

--- a/src/con4m/mixed.c
+++ b/src/con4m/mixed.c
@@ -66,6 +66,7 @@ mixed_set_value(mixed_t *m, type_spec_t *type, void **ptr)
         int64_t   n = (int64_t)v;
 
         m->held_value = (void *)n;
+        return;
     }
     case T_INT:
     case T_UINT:

--- a/src/con4m/types.c
+++ b/src/con4m/types.c
@@ -214,7 +214,7 @@ internal_type_hash(type_spec_t *node, type_hash_ctx *ctx)
         // Currently not hashing for future things.
     case BT_func:
         sha_int_update(ctx->sha, (uint64_t)deets->flags);
-
+        break;
     case BT_type_var:
         num_tvars = (uint64_t)hatrack_dict_get(ctx->memos,
                                                (void *)node->typeid,

--- a/src/con4m/xlist.c
+++ b/src/con4m/xlist.c
@@ -209,11 +209,11 @@ xlist_coerce_to(xlist_t *list, type_spec_t *dst_type)
     type_spec_t *dst_item_type = tspec_get_param(dst_type, 0);
     int64_t      len           = xlist_len(list);
 
-    if (base == T_BOOL) {
+    if (base == (base_t)T_BOOL) {
         return (object_t)(int64_t)(xlist_len(list) != 0);
     }
 
-    if (base == T_XLIST) {
+    if (base == (base_t)T_XLIST) {
         xlist_t *res = con4m_new(dst_type, kw("length", ka(len)));
 
         for (int i = 0; i < len; i++) {

--- a/src/tests/hash/performance.c
+++ b/src/tests/hash/performance.c
@@ -103,7 +103,7 @@ enum {
  * ballpark the widest reasonable columns. If a column gets too
  * wide, we don't truncate, we just let things look bad :)
  */
-#define COL_WIDTH    25
+#define COL_WIDTH    26
 #define COL_PAD      1
 #define FMT_READS    "Reads:         %u%%"
 #define FMT_PUTS     "Puts:          %u%%"

--- a/src/tests/test.c
+++ b/src/tests/test.c
@@ -137,7 +137,7 @@ test_rand64()
     uint64_t random = 0;
 
     random = con4m_rand64();
-    printf("Random value: %16llx\n", random);
+    printf("Random value: %16llx\n", (unsigned long long)random);
     assert(random != 0);
 }
 
@@ -505,7 +505,7 @@ main(int argc, char **argv, char **envp)
         test4();
         table_test();
 
-        printf("Sample style: %.16llx\n", style1);
+        printf("Sample style: %.16llx\n", (unsigned long long)style1);
         sha_test();
 
         type_tests();
@@ -550,6 +550,6 @@ main(int argc, char **argv, char **envp)
         stream_putc(sout, '\n');
 
         bottom = top + q;
-        printf("(start) = %p; (end) = %p (%llu bytes)\n", (void *)top, (void *)bottom, q);
+        printf("(start) = %p; (end) = %p (%llu bytes)\n", (void *)top, (void *)bottom, (unsigned long long)q);
     }
 }


### PR DESCRIPTION
A few of the changes here fix compile errors on Linux. Notably there are issues with hatrack.h due to a badly placed #endif and a couple of other Linux-specific things (like not having `htonll`, for example). Most changes are to silence warnings

I don't have a build environment setup for macOS, but I did check the changes to header includes and endian tests made to `base.h` with a small test program to make sure they'll work as expected.

It's not obvious, but for min/max, I changed to always use `__typeof__(a)` to silence sign mismatch in comparison errors. The effect of the comparison is the same, but the compiler doesn't complain this way. Arguably the comparison sites that raise warnings should be fixed to correctly address the warnings, though.

