### PR TITLE
Fix c4m_get_stack_bounds on Linux

### DIFF
--- a/include/con4m/gc.h
+++ b/include/con4m/gc.h
@@ -222,34 +222,5 @@ c4m_gc_malloc(size_t len)
 #define c4m_gc_array_alloc(typename, n) \
     c4m_gc_raw_alloc((sizeof(typename) * n), GC_SCAN_ALL)
 
-#if defined(__linux__)
-static inline void
-c4m_get_stack_bounds(uint64_t *top, uint64_t *bottom)
-{
-    pthread_t      self = pthread_self();
-    pthread_attr_t attrs;
-    size_t         size;
-    uint64_t       addr;
-
-    pthread_getattr_np(self, &attrs);
-    pthread_attr_getstack(&attrs, (void **)&addr, &size);
-
-    *bottom = (uint64_t)addr;
-    *top    = size + (uint64_t)addr;
-}
-#endif
-
-// Apple at least has no way to get the thread's attr struct that
-// I can find. But it does provide an API to get at the same data.
-#if defined(__APPLE__) || defined(BSD)
-static inline void
-c4m_get_stack_bounds(uint64_t *top, uint64_t *bottom)
-{
-    pthread_t self = pthread_self();
-    *bottom        = (uint64_t)pthread_get_stackaddr_np(self);
-    *top           = *bottom - pthread_get_stacksize_np(self);
-}
-#endif
-
 extern void c4m_get_stack_scan_region(uint64_t *top, uint64_t *bottom);
 extern void c4m_initialize_gc();


### PR DESCRIPTION
Fix `c4m_get_stack_bounds` for Linux. The original implementation incorrectly swaps bottom/top.

Move `c4m_get_stack_bounds` from `gc.h` to `gc.c` since there's no reason for it to be public at all, never mind static inline. 
* only called once per collection cycle
* only called internally from `gc.c`
* cost of `pthread_getattr_np` from the main thread is extremely high on Linux for both glibc and, to a lesser extent, musl.
