### PR TITLE
Typechecking pass done

### DIFF
--- a/include/con4m.h
+++ b/include/con4m.h
@@ -84,13 +84,13 @@
 #include "con4m/vm.h"
 
 // The front end.
+#include "frontend/treematch.h"
 #include "frontend/compile.h"
 #include "frontend/errors.h"
 #include "frontend/lex.h"
 #include "frontend/parse.h"
 #include "frontend/scope.h"
 #include "frontend/spec.h"
-#include "frontend/treematch.h"
 #include "frontend/partial.h"
 #include "frontend/cfgs.h"
 

--- a/include/con4m.h
+++ b/include/con4m.h
@@ -1,4 +1,5 @@
 #pragma once
+#define C4M_TYPE_LOG
 
 // Everything includes this; the ordering here is somewhat important
 // due to interdependencies, though they can always be solved via

--- a/include/con4m/datatypes/lists.h
+++ b/include/con4m/datatypes/lists.h
@@ -11,6 +11,6 @@ typedef struct {
     int64_t **data;
 } c4m_xlist_t;
 
-// This needs fw referencing, because this gets read before hatrack.
-// I think it's the build system's fault?
 typedef struct flexarray_t flexarray_t;
+
+typedef struct hatstack_t c4m_stack_t;

--- a/include/con4m/datatypes/memory.h
+++ b/include/con4m/datatypes/memory.h
@@ -1,6 +1,9 @@
 #pragma once
-
 #include "con4m.h"
+
+#ifndef C4M_DISABLE_ALLOC_STATS
+#define C4M_ALLOC_STATS
+#endif
 
 #define C4M_FORCED_ALIGNMENT 16
 
@@ -63,6 +66,9 @@ typedef struct c4m_arena_t {
     queue_t            *late_mutations;
     uint64_t           *heap_end;
     uint64_t            arena_id;
+#ifdef C4M_ALLOC_STATS
+    uint64_t alloc_counter;
+#endif
 
     // This must be 16-byte aligned!
     alignas(C4M_FORCED_ALIGNMENT) uint64_t data[];

--- a/include/con4m/datatypes/objects.h
+++ b/include/con4m/datatypes/objects.h
@@ -70,8 +70,7 @@ typedef struct {
 // dispatch.
 //
 // Note that I expect to steal a bit from the `base_data_type` pointer
-// to distinguish whether the object has been freed; while I currently
-// do not have
+// to distinguish whether the object has been freed.
 
 struct c4m_base_obj_t {
     c4m_dt_info_t     *base_data_type;

--- a/include/con4m/datatypes/types.h
+++ b/include/con4m/datatypes/types.h
@@ -40,3 +40,11 @@ typedef struct {
     c4m_dict_t      *store;
     _Atomic uint64_t next_tid;
 } c4m_type_env_t;
+
+typedef enum {
+    c4m_type_match_exact,
+    c4m_type_match_left_more_specific,
+    c4m_type_match_right_more_specific,
+    c4m_type_match_both_have_more_generic_bits,
+    c4m_type_cant_match,
+} c4m_type_exact_result_t;

--- a/include/con4m/datatypes/types.h
+++ b/include/con4m/datatypes/types.h
@@ -6,6 +6,11 @@ typedef uint64_t c4m_type_hash_t;
 
 typedef struct c4m_type_info_t c4m_type_info_t;
 
+typedef struct {
+    uint64_t   *container_options;
+    c4m_dict_t *props; // Object properties. maps prop name to type node.
+} tv_options_t;
+
 typedef struct c4m_type_t {
     c4m_type_hash_t fw;
     c4m_type_hash_t typeid;
@@ -16,7 +21,7 @@ typedef struct c4m_type_info_t {
     char          *name; // Obj type name or type var name
     c4m_dt_info_t *base_type;
     c4m_xlist_t   *items;
-    c4m_dict_t    *props; // Object properties. maps name to type node.
+    void          *tsi; // Type-specific info.
     uint8_t        flags;
 } c4m_type_info_t;
 
@@ -29,6 +34,16 @@ typedef struct c4m_type_info_t {
 // Basically think of locked types as fully resolved in one universe,
 // but being copied over into others.
 #define C4M_FN_TY_LOCK    2
+// When we're type inferencing, we will keep things as type variables
+// until the last possible minute, whenever we don't have an absolutely
+// concrete type.
+
+// For containers where the exact container type is unknown, this
+// indicates whether or not we're confident in how many type
+// parameters there will be. This is present mainly to aid in tuple
+// merging, and I'm not focused on it right now, so will need to do
+// more testing lqter.
+#define C4M_FN_UNKNOWN_TV_LEN 4
 
 typedef struct {
     c4m_dict_t      *store;
@@ -42,3 +57,7 @@ typedef enum {
     c4m_type_match_both_have_more_generic_bits,
     c4m_type_cant_match,
 } c4m_type_exact_result_t;
+
+#ifdef C4M_USE_INTERNAL_API
+c4m_str_t *internal_type_repr(c4m_type_t *, c4m_dict_t *, int64_t *);
+#endif

--- a/include/con4m/datatypes/types.h
+++ b/include/con4m/datatypes/types.h
@@ -7,12 +7,7 @@ typedef uint64_t c4m_type_hash_t;
 typedef struct c4m_type_info_t c4m_type_info_t;
 
 typedef struct c4m_type_t {
-    // The `typeid field` is EITHER the node's type ID, or a forwarding link
-    // to another node in the graph. The rest of the data is accessed via
-    // indirection, so that we can easily use CAS when this needs to be
-    // multi-threaded (not sure that it would actually ever be necessary.)
-    // But each type spec will always get a unique details node.
-
+    c4m_type_hash_t fw;
     c4m_type_hash_t typeid;
     c4m_type_info_t *details;
 } c4m_type_t;
@@ -22,18 +17,17 @@ typedef struct c4m_type_info_t {
     c4m_dt_info_t *base_type;
     c4m_xlist_t   *items;
     c4m_dict_t    *props; // Object properties. maps name to type node.
-    // 'Locked' means this type node cannot forward, even though it
-    //  might have type variables. That causes the system to
-    //  copy. That is used for function signatures for instance, to
-    //  keep calls from restricting generic types.
-    //
-    // Basically think of locked types as fully resolved in one
-    // universe, but being copied over into others.
-
-    uint8_t flags;
+    uint8_t        flags;
 } c4m_type_info_t;
 
 #define C4M_FN_TY_VARARGS 1
+// 'Locked' means this type node cannot forward, even though it might
+//  have type variables. That causes the system to copy. That is used
+//  for function signatures for instance, to keep calls from
+//  restricting generic types.
+//
+// Basically think of locked types as fully resolved in one universe,
+// but being copied over into others.
 #define C4M_FN_TY_LOCK    2
 
 typedef struct {

--- a/include/con4m/datatypes/types.h
+++ b/include/con4m/datatypes/types.h
@@ -7,8 +7,9 @@ typedef uint64_t c4m_type_hash_t;
 typedef struct c4m_type_info_t c4m_type_info_t;
 
 typedef struct {
-    uint64_t   *container_options;
-    c4m_dict_t *props; // Object properties. maps prop name to type node.
+    uint64_t          *container_options;
+    struct c4m_type_t *value_type;
+    c4m_dict_t        *props; // Object properties. maps prop name to type node.
 } tv_options_t;
 
 typedef struct c4m_type_t {

--- a/include/con4m/exception.h
+++ b/include/con4m/exception.h
@@ -216,3 +216,13 @@ c4m_raise_errno()
 {
     c4m_raise_errcode(errno);
 }
+
+#define unreachable()                                       \
+    {                                                       \
+        c4m_utf8_t *s = c4m_cstr_format(                    \
+            "Reached code that the developer "              \
+            "(wrongly) believed was unreachable, at {}:{}", \
+            c4m_new_utf8(__FILE__),                         \
+            c4m_box_i32(__LINE__));                         \
+        C4M_RAISE(s);                                       \
+    }

--- a/include/con4m/gc.h
+++ b/include/con4m/gc.h
@@ -193,6 +193,10 @@ try_again:
                  arena,
                  arena->heap_end);
 
+#ifdef C4M_ALLOC_STATS
+    arena->alloc_counter++;
+#endif
+
     return (void *)(raw->data);
 }
 
@@ -224,3 +228,10 @@ c4m_gc_malloc(size_t len)
 
 extern void c4m_get_stack_scan_region(uint64_t *top, uint64_t *bottom);
 extern void c4m_initialize_gc();
+extern void c4m_gc_heap_stats(uint64_t *, uint64_t *, uint64_t *);
+
+#ifdef C4M_ALLOC_STATS
+uint64_t get_alloc_counter();
+#else
+#define get_alloc_counter() (0)
+#endif

--- a/include/con4m/string.h
+++ b/include/con4m/string.h
@@ -114,6 +114,6 @@ extern bool         c4m_str_eq(c4m_str_t *, c4m_str_t *);
 
 extern const uint64_t c4m_pmap_str[2];
 
-#ifdef C4M_INTERNAL_API
+#ifdef C4M_USE_INTERNAL_API
 extern void c4m_internal_utf8_set_codepoint_count(c4m_utf8_t *);
 #endif

--- a/include/con4m/type.h
+++ b/include/con4m/type.h
@@ -19,6 +19,7 @@ extern c4m_type_t     *c4m_tspec_set(c4m_type_t *);
 extern c4m_type_t     *c4m_tspec_tuple(int64_t, ...);
 extern c4m_type_t     *c4m_tspec_tuple_from_xlist(c4m_xlist_t *);
 extern c4m_type_t     *c4m_tspec_fn(c4m_type_t *, c4m_xlist_t *, bool);
+extern c4m_type_t     *c4m_tspec_fn_va(c4m_type_t *, int64_t, ...);
 extern c4m_type_t     *c4m_tspec_varargs_fn_va(c4m_type_t *, int64_t, ...);
 extern c4m_type_t     *c4m_tspec_varargs_fn(c4m_type_t *, int64_t, ...);
 extern c4m_type_t     *c4m_global_resolve_type(c4m_type_t *);
@@ -46,12 +47,6 @@ c4m_type_cmp_exact(c4m_type_t *t1, c4m_type_t *t2)
 
 static inline c4m_dt_kind_t
 c4m_tspec_get_base(c4m_type_t *n)
-{
-    return n->details->base_type->dt_kind;
-}
-
-static inline c4m_dt_kind_t
-c4m_tspec_get_type_kind(c4m_type_t *n)
 {
     return n->details->base_type->dt_kind;
 }
@@ -447,6 +442,12 @@ c4m_tspec_is_int_type(c4m_type_t *t)
 }
 
 static inline bool
+c4m_tspec_is_tvar(c4m_type_t *t)
+{
+    return (c4m_tspec_get_base(t) == C4M_T_GENERIC);
+}
+
+static inline bool
 c4m_obj_is_int_type(const c4m_obj_t *obj)
 {
     c4m_base_obj_t *base = (c4m_base_obj_t *)c4m_object_header(obj);
@@ -459,3 +460,22 @@ c4m_type_is_value_type(c4m_type_t *t)
 {
     return c4m_tspec_get_data_type_info(t)->by_value;
 }
+
+#ifdef C4M_USE_INTERNAL_API
+extern c4m_grid_t *c4m_format_global_type_environment();
+extern void        c4m_clean_environment();
+
+static inline bool
+is_partial_type(c4m_type_t *t)
+{
+    return c4m_tspec_get_base_tid(t) == C4M_T_PARTIAL_LIT;
+}
+
+#ifdef C4M_TYPE_LOG
+extern void type_log_on();
+extern void type_log_off();
+#else
+#define type_log_on()
+#define type_log_off()
+#endif
+#endif

--- a/include/con4m/type.h
+++ b/include/con4m/type.h
@@ -31,6 +31,19 @@ extern c4m_type_t     *c4m_get_promotion_type(c4m_type_t *,
 extern void            c4m_initialize_global_types();
 extern c4m_type_hash_t c4m_type_hash(c4m_type_t *node, c4m_type_env_t *env);
 
+extern c4m_type_env_t *c4m_global_type_env;
+
+extern c4m_type_exact_result_t
+c4m_type_cmp_exact_env(c4m_type_t *,
+                       c4m_type_t *,
+                       c4m_type_env_t *);
+
+static inline c4m_type_exact_result_t
+c4m_type_cmp_exact(c4m_type_t *t1, c4m_type_t *t2)
+{
+    return c4m_type_cmp_exact_env(t1, t2, c4m_global_type_env);
+}
+
 static inline c4m_dt_kind_t
 c4m_tspec_get_base(c4m_type_t *n)
 {
@@ -84,8 +97,6 @@ c4m_tenv_next_tid(c4m_type_env_t *env)
 {
     return atomic_fetch_add(&env->next_tid, 1);
 }
-
-extern c4m_type_env_t *c4m_global_type_env;
 
 static inline c4m_type_t *
 c4m_merge_types(c4m_type_t *t1, c4m_type_t *t2)

--- a/include/con4m/type.h
+++ b/include/con4m/type.h
@@ -47,6 +47,10 @@ extern void      c4m_remove_list_options(c4m_type_t *);
 extern void      c4m_remove_dict_options(c4m_type_t *);
 extern void      c4m_remove_set_options(c4m_type_t *);
 extern void      c4m_remove_tuple_options(c4m_type_t *);
+extern bool      c4m_type_has_list_syntax(c4m_type_t *);
+extern bool      c4m_type_has_dict_syntax(c4m_type_t *);
+extern bool      c4m_type_has_set_syntax(c4m_type_t *);
+extern bool      c4m_type_has_tuple_syntax(c4m_type_t *);
 
 extern c4m_type_env_t *c4m_global_type_env;
 

--- a/include/con4m/xlist.h
+++ b/include/con4m/xlist.h
@@ -37,6 +37,7 @@ c4m_xlist_get(const c4m_xlist_t *list, int64_t ix, bool *err)
 }
 
 extern void         c4m_xlist_append(c4m_xlist_t *list, void *item);
+extern void        *c4m_xlist_pop(c4m_xlist_t *list);
 extern void         c4m_xlist_plus_eq(c4m_xlist_t *, c4m_xlist_t *);
 extern c4m_xlist_t *c4m_xlist_plus(c4m_xlist_t *, c4m_xlist_t *);
 extern bool         c4m_xlist_set(c4m_xlist_t *, int64_t, void *);

--- a/include/frontend/cfgs.h
+++ b/include/frontend/cfgs.h
@@ -28,3 +28,4 @@ extern c4m_cfg_node_t *c4m_cfg_add_call(c4m_cfg_node_t *,
 extern c4m_cfg_node_t *c4m_cfg_add_use(c4m_cfg_node_t *,
                                        c4m_tree_node_t *,
                                        c4m_scope_entry_t *);
+extern c4m_grid_t     *c4m_cfg_repr(c4m_cfg_node_t *);

--- a/include/frontend/cfgs.h
+++ b/include/frontend/cfgs.h
@@ -10,7 +10,8 @@ extern c4m_cfg_node_t *c4m_cfg_block_new_branch_node(c4m_cfg_node_t *,
                                                      c4m_utf8_t *,
                                                      c4m_tree_node_t *);
 extern c4m_cfg_node_t *c4m_cfg_add_return(c4m_cfg_node_t *,
-                                          c4m_tree_node_t *);
+                                          c4m_tree_node_t *,
+                                          c4m_cfg_node_t *);
 extern c4m_cfg_node_t *c4m_cfg_add_continue(c4m_cfg_node_t *,
                                             c4m_tree_node_t *,
                                             c4m_utf8_t *);
@@ -29,3 +30,9 @@ extern c4m_cfg_node_t *c4m_cfg_add_use(c4m_cfg_node_t *,
                                        c4m_tree_node_t *,
                                        c4m_scope_entry_t *);
 extern c4m_grid_t     *c4m_cfg_repr(c4m_cfg_node_t *);
+
+static inline c4m_cfg_node_t *
+c4m_cfg_exit_node(c4m_cfg_node_t *block_entry)
+{
+    return block_entry->contents.block_entrance.exit_node;
+}

--- a/include/frontend/compile.h
+++ b/include/frontend/compile.h
@@ -8,14 +8,18 @@ extern c4m_compile_ctx      *c4m_compile_from_entry_point(c4m_str_t *);
 extern void                  c4m_perform_module_loads(c4m_compile_ctx *);
 extern c4m_file_compile_ctx *c4m_init_module_from_loc(c4m_compile_ctx *,
                                                       c4m_str_t *);
-extern c4m_file_compile_ctx *c4m_init_from_use(c4m_compile_ctx *,
-                                               c4m_str_t *,
-                                               c4m_str_t *,
-                                               c4m_str_t *);
+extern c4m_type_t           *c4m_str_to_type(c4m_utf8_t *);
+
 #define c4m_set_package_search_path(x, ...) \
     _c4m_set_package_search_path(x, KFUNC(__VA_ARGS__))
 
 #ifdef C4M_USE_INTERNAL_API
-extern void c4m_file_decl_pass(c4m_compile_ctx *, c4m_file_compile_ctx *);
-extern void c4m_check_pass(c4m_compile_ctx *);
+extern void                  c4m_file_decl_pass(c4m_compile_ctx *,
+                                                c4m_file_compile_ctx *);
+extern void                  c4m_check_pass(c4m_compile_ctx *);
+extern c4m_file_compile_ctx *c4m_init_from_use(c4m_compile_ctx *,
+                                               c4m_str_t *,
+                                               c4m_str_t *,
+                                               c4m_str_t *);
+
 #endif

--- a/include/frontend/compile.h
+++ b/include/frontend/compile.h
@@ -15,6 +15,6 @@ extern c4m_file_compile_ctx *c4m_init_from_use(c4m_compile_ctx *,
 #define c4m_set_package_search_path(x, ...) \
     _c4m_set_package_search_path(x, KFUNC(__VA_ARGS__))
 
-#ifdef C4M_INTERNAL_API
+#ifdef C4M_USE_INTERNAL_API
 extern void c4m_file_decl_pass(c4m_compile_ctx *, c4m_file_compile_ctx *);
 #endif

--- a/include/frontend/compile.h
+++ b/include/frontend/compile.h
@@ -17,4 +17,5 @@ extern c4m_file_compile_ctx *c4m_init_from_use(c4m_compile_ctx *,
 
 #ifdef C4M_USE_INTERNAL_API
 extern void c4m_file_decl_pass(c4m_compile_ctx *, c4m_file_compile_ctx *);
+extern void c4m_check_pass(c4m_compile_ctx *);
 #endif

--- a/include/frontend/datatypes/cfg.h
+++ b/include/frontend/datatypes/cfg.h
@@ -25,6 +25,7 @@ typedef struct {
 } c4m_cfg_block_exit_info_t;
 
 typedef struct {
+    c4m_cfg_node_t *dead_code;
     c4m_cfg_node_t *target;
 } c4m_cfg_jump_info_t;
 

--- a/include/frontend/datatypes/compile.h
+++ b/include/frontend/datatypes/compile.h
@@ -2,12 +2,12 @@
 #include "con4m.h"
 
 typedef struct {
-    c4m_file_compile_ctx *entry_point;
-    c4m_dict_t           *module_cache;
-    c4m_xlist_t          *module_ordering;
     c4m_scope_t          *final_attrs;
     c4m_scope_t          *final_globals;
     c4m_spec_t           *final_spec;
+    c4m_file_compile_ctx *entry_point;
+    c4m_dict_t           *module_cache;
+    c4m_xlist_t          *module_ordering;
     c4m_set_t            *backlog;   // Modules we need to process.
     c4m_set_t            *processed; // Modules we've finished with.
     bool                  fatality;

--- a/include/frontend/datatypes/compile.h
+++ b/include/frontend/datatypes/compile.h
@@ -4,9 +4,11 @@
 typedef struct {
     c4m_file_compile_ctx *entry_point;
     c4m_dict_t           *module_cache;
+    c4m_xlist_t          *module_ordering;
     c4m_scope_t          *final_attrs;
     c4m_scope_t          *final_globals;
     c4m_spec_t           *final_spec;
     c4m_set_t            *backlog;   // Modules we need to process.
     c4m_set_t            *processed; // Modules we've finished with.
+    bool                  fatality;
 } c4m_compile_ctx;

--- a/include/frontend/datatypes/error.h
+++ b/include/frontend/datatypes/error.h
@@ -108,6 +108,15 @@ typedef enum {
     c4m_warn_no_tls,
     c4m_err_search_path,
     c4m_err_no_http,
+    c4m_info_recursive_use,
+    c4m_err_self_recursive_use,
+    c4m_err_redecl_kind,
+    c4m_err_no_redecl,
+    c4m_err_redecl_neq_generics,
+    c4m_err_spec_redef_section,
+    c4m_err_spec_redef_field,
+    c4m_err_spec_locked,
+    c4m_err_dupe_validator,
     c4m_err_last,
 } c4m_compile_error_t;
 

--- a/include/frontend/datatypes/error.h
+++ b/include/frontend/datatypes/error.h
@@ -120,6 +120,7 @@ typedef enum {
     c4m_err_dupe_validator,
     c4m_err_decl_mismatch,
     c4m_err_inconsistent_type,
+    c4m_err_inconsistent_infer_type,
     c4m_err_decl_mask,
     c4m_warn_attr_mask,
     c4m_err_attr_mask,
@@ -135,12 +136,16 @@ typedef enum {
     c4m_err_slice_on_dict,
     c4m_err_bad_slice_ix,
     c4m_err_dupe_label,
-    c4m_err_last,
     c4m_err_iter_name_conflict,
     c4m_err_dict_one_var_for,
     c4m_err_future_dynamic_typecheck,
     c4m_err_iterate_on_non_container,
     c4m_warn_shadowed_var,
+    c4m_err_unary_minus_type,
+    c4m_err_cannot_cmp,
+    c4m_err_range_type,
+    c4m_err_last,
+
 } c4m_compile_error_t;
 
 #define c4m_err_no_error c4m_err_last

--- a/include/frontend/datatypes/error.h
+++ b/include/frontend/datatypes/error.h
@@ -148,6 +148,13 @@ typedef enum {
     c4m_err_concrete_typeof,
     c4m_warn_type_overlap,
     c4m_err_dead_branch,
+    c4m_err_no_ret,
+    c4m_err_use_no_def,
+    c4m_err_declared_incompat,
+    c4m_err_too_general,
+    c4m_warn_unused_param,
+    c4m_warn_def_without_use,
+    c4m_err_call_type_err,
     c4m_err_last,
 
 } c4m_compile_error_t;

--- a/include/frontend/datatypes/error.h
+++ b/include/frontend/datatypes/error.h
@@ -124,7 +124,23 @@ typedef enum {
     c4m_warn_attr_mask,
     c4m_err_attr_mask,
     c4m_err_label_target,
+    c4m_err_fn_not_found,
+    c4m_err_num_params,
+    c4m_err_calling_non_fn,
+    c4m_err_spec_needs_field,
+    c4m_err_field_not_spec,
+    c4m_err_field_not_allowed,
+    c4m_err_undefined_section,
+    c4m_err_section_not_allowed,
+    c4m_err_slice_on_dict,
+    c4m_err_bad_slice_ix,
+    c4m_err_dupe_label,
     c4m_err_last,
+    c4m_err_iter_name_conflict,
+    c4m_err_dict_one_var_for,
+    c4m_err_future_dynamic_typecheck,
+    c4m_err_iterate_on_non_container,
+    c4m_warn_shadowed_var,
 } c4m_compile_error_t;
 
 #define c4m_err_no_error c4m_err_last

--- a/include/frontend/datatypes/error.h
+++ b/include/frontend/datatypes/error.h
@@ -144,6 +144,7 @@ typedef enum {
     c4m_err_unary_minus_type,
     c4m_err_cannot_cmp,
     c4m_err_range_type,
+    c4m_err_switch_case_type,
     c4m_err_last,
 
 } c4m_compile_error_t;

--- a/include/frontend/datatypes/error.h
+++ b/include/frontend/datatypes/error.h
@@ -145,6 +145,9 @@ typedef enum {
     c4m_err_cannot_cmp,
     c4m_err_range_type,
     c4m_err_switch_case_type,
+    c4m_err_concrete_typeof,
+    c4m_warn_type_overlap,
+    c4m_err_dead_branch,
     c4m_err_last,
 
 } c4m_compile_error_t;

--- a/include/frontend/datatypes/error.h
+++ b/include/frontend/datatypes/error.h
@@ -49,6 +49,7 @@ typedef enum {
     c4m_err_parse_1_item_tuple,
     c4m_err_parse_decl_kw_x2,
     c4m_err_parse_decl_2_scopes,
+    c4m_err_parse_decl_const_not_const,
     c4m_err_parse_case_else_or_end,
     c4m_err_parse_case_body_start,
     c4m_err_parse_empty_enum,
@@ -155,6 +156,7 @@ typedef enum {
     c4m_warn_unused_param,
     c4m_warn_def_without_use,
     c4m_err_call_type_err,
+    c4m_err_single_def,
     c4m_err_last,
 
 } c4m_compile_error_t;

--- a/include/frontend/datatypes/error.h
+++ b/include/frontend/datatypes/error.h
@@ -78,6 +78,7 @@ typedef enum {
     c4m_err_parse_lit_underflow,
     c4m_err_parse_lit_odd_hex,
     c4m_err_parse_lit_invalid_neg,
+    c4m_err_parse_for_assign_vars,
     c4m_err_invalid_redeclaration,
     c4m_err_omit_string_enum_value,
     c4m_err_invalid_enum_lit_type,
@@ -117,6 +118,12 @@ typedef enum {
     c4m_err_spec_redef_field,
     c4m_err_spec_locked,
     c4m_err_dupe_validator,
+    c4m_err_decl_mismatch,
+    c4m_err_inconsistent_type,
+    c4m_err_decl_mask,
+    c4m_warn_attr_mask,
+    c4m_err_attr_mask,
+    c4m_err_label_target,
     c4m_err_last,
 } c4m_compile_error_t;
 

--- a/include/frontend/datatypes/error.h
+++ b/include/frontend/datatypes/error.h
@@ -157,6 +157,11 @@ typedef enum {
     c4m_warn_def_without_use,
     c4m_err_call_type_err,
     c4m_err_single_def,
+    c4m_warn_unused_decl,
+    c4m_err_global_remote_def,
+    c4m_err_global_remote_unused,
+    c4m_info_unused_global_decl,
+    c4m_global_def_without_use,
     c4m_err_last,
 
 } c4m_compile_error_t;

--- a/include/frontend/datatypes/file.h
+++ b/include/frontend/datatypes/file.h
@@ -38,7 +38,7 @@ typedef struct c4m_file_compile_ctx {
     c4m_scope_t            *imports;
     c4m_dict_t             *parameters;
     c4m_spec_t             *local_confspecs;
-    c4m_cfg_node_t         *cfg;
+    c4m_cfg_node_t         *cfg; // CFG for the module top-level.
     c4m_utf8_t             *short_doc;
     c4m_utf8_t             *long_doc;
     unsigned int            fatal_errors : 1;

--- a/include/frontend/datatypes/file.h
+++ b/include/frontend/datatypes/file.h
@@ -9,7 +9,7 @@ typedef enum {
     c4m_compile_status_generated_code
 } c4m_file_compile_status;
 
-typedef struct {
+typedef struct c4m_file_compile_ctx {
     // The module_id is calculated by combining the package name and
     // the module name, then hashing it with SHA256. This is not
     // necessarily derived from the URI path.

--- a/include/frontend/datatypes/lex.h
+++ b/include/frontend/datatypes/lex.h
@@ -85,17 +85,18 @@ typedef enum {
 } c4m_token_kind_t;
 
 typedef struct {
-    c4m_codepoint_t *start_ptr;
-    c4m_codepoint_t *end_ptr;
-    c4m_utf32_t     *literal_modifier;
-    void            *literal_value; // Once parsed.
-    c4m_token_kind_t kind;
-    int              token_id;
-    int              line_no;
-    int              line_offset;
+    struct c4m_file_compile_ctx *module;
+    c4m_codepoint_t             *start_ptr;
+    c4m_codepoint_t             *end_ptr;
+    c4m_utf32_t                 *literal_modifier;
+    void                        *literal_value; // Once parsed.
+    c4m_token_kind_t             kind;
+    int                          token_id;
+    int                          line_no;
+    int                          line_offset;
     // Original index relative to all added tokens under a parse node.
     // We do this because we don't keep the comments in the main tree,
     // we stash them with the node payload.
-    uint16_t         child_ix;
-    uint8_t          adjustment; // For keeping track of quoting.
+    uint16_t                     child_ix;
+    uint8_t                      adjustment; // For keeping track of quoting.
 } c4m_token_t;

--- a/include/frontend/datatypes/lex.h
+++ b/include/frontend/datatypes/lex.h
@@ -57,6 +57,8 @@ typedef enum {
     c4m_tt_var,
     c4m_tt_global,
     c4m_tt_const,
+    c4m_tt_once,
+    c4m_tt_let,
     c4m_tt_private,
     c4m_tt_backtick,
     c4m_tt_arrow,

--- a/include/frontend/datatypes/parse.h
+++ b/include/frontend/datatypes/parse.h
@@ -78,6 +78,26 @@ typedef enum {
     c4m_nt_expression,
 } c4m_node_kind_t;
 
+typedef enum : int64_t {
+    c4m_op_plus,
+    c4m_op_minus,
+    c4m_op_mul,
+    c4m_op_mod,
+    c4m_op_div,
+    c4m_op_fdiv,
+    c4m_op_shl,
+    c4m_op_shr,
+    c4m_op_bitand,
+    c4m_op_bitor,
+    c4m_op_bitxor,
+    c4m_op_lt,
+    c4m_op_lte,
+    c4m_op_gt,
+    c4m_op_gte,
+    c4m_op_eq,
+    c4m_op_neq,
+} c4m_operator_t;
+
 typedef struct {
     c4m_token_t *comment_tok;
     int          sibling_id;
@@ -95,8 +115,8 @@ typedef struct {
     c4m_xlist_t        *comments;
     int                 total_kids;
     int                 sibling_id;
-    void               *extra_info;
     c4m_obj_t          *value;
+    void               *extra_info;
     struct c4m_scope_t *static_scope;
     c4m_type_t         *type;
 } c4m_pnode_t;

--- a/include/frontend/datatypes/parse.h
+++ b/include/frontend/datatypes/parse.h
@@ -45,6 +45,8 @@ typedef enum {
     c4m_nt_enum_item,
     c4m_nt_identifier,
     c4m_nt_func_def,
+    c4m_nt_func_mods,
+    c4m_nt_func_mod,
     c4m_nt_formals,
     c4m_nt_varargs_param,
     c4m_nt_member,

--- a/include/frontend/datatypes/partials.h
+++ b/include/frontend/datatypes/partials.h
@@ -22,9 +22,13 @@
 // data structure.
 
 typedef struct {
-    c4m_type_t  *type;
-    unsigned int num_items : 31;
-    unsigned int empty_container;
-    uint64_t    *cached_state;
-    c4m_obj_t   *items;
+    c4m_type_t      *type;
+    unsigned int     num_items         : 30;
+    unsigned int     empty_container   : 1;
+    unsigned int     empty_dict_or_set : 1;
+    // This is a bit field that keeps track of which items are themselves
+    // partially evaluated.
+    uint64_t        *cached_state;
+    c4m_obj_t       *items;
+    c4m_tree_node_t *node;
 } c4m_partial_lit_t;

--- a/include/frontend/datatypes/scope.h
+++ b/include/frontend/datatypes/scope.h
@@ -14,14 +14,15 @@ typedef enum : int8_t {
 } c4m_symbol_kind;
 
 enum {
-    C4M_F_HAS_INITIALIZER  = 1,
-    C4M_F_DECLARED_CONST   = 2,
-    C4M_F_IS_DECLARED      = 4,
-    C4M_F_TYPE_IS_DECLARED = 8,
+    C4M_F_HAS_INITIALIZER  = 0x01,
+    C4M_F_DECLARED_CONST   = 0x02,
+    C4M_F_DECLARED_LET     = 0x04,
+    C4M_F_IS_DECLARED      = 0x08,
+    C4M_F_TYPE_IS_DECLARED = 0x10,
     // 'const' means user immutable not static. This is for iteration
     // variables on loops, etc.
-    C4M_F_USER_IMMUTIBLE   = 0x10,
-    C4M_F_FN_PASS_DONE     = 0x20,
+    C4M_F_USER_IMMUTIBLE   = 0x20,
+    C4M_F_FN_PASS_DONE     = 0x40,
 };
 
 typedef enum c4m_scope_kind {
@@ -104,6 +105,7 @@ typedef struct {
     c4m_sig_info_t        *signature_info;
     struct c4m_cfg_node_t *cfg;
     unsigned int private : 1;
+    unsigned int once    : 1;
 } c4m_fn_decl_t;
 
 typedef struct {

--- a/include/frontend/datatypes/scope.h
+++ b/include/frontend/datatypes/scope.h
@@ -3,7 +3,6 @@
 
 typedef enum : int8_t {
     sk_module,
-    sk_package,
     sk_func,
     sk_extern_func,
     sk_enum_type,
@@ -11,7 +10,6 @@ typedef enum : int8_t {
     sk_attr,
     sk_variable,
     sk_formal,
-    // Will be adding more for sure.
     sk_num_sym_kinds
 } c4m_symbol_kind;
 
@@ -46,24 +44,30 @@ typedef struct {
     unsigned int ffi_allocs : 1;
 } c4m_fn_param_info_t;
 
-typedef struct {
+typedef struct c4m_scope_entry_t {
     // The `value` field gets the proper value for vars and enums, but
     // for other types, it gets a pointer to one of the specific data
     // structures in this file.
 
-    c4m_obj_t           value;
-    c4m_utf8_t         *path;
-    c4m_utf8_t         *name;
-    c4m_tree_node_t    *declaration_node;
-    c4m_xlist_t        *use_locations;
-    c4m_xlist_t        *lhs_locations;
-    uint32_t            offset;
-    uint32_t            size;
-    uint8_t             flags;
-    c4m_symbol_kind     kind;
-    c4m_type_t         *declared_type;
-    c4m_type_t         *inferred_type;
-    struct c4m_scope_t *my_scope;
+    c4m_obj_t                 value;
+    c4m_utf8_t               *path;
+    c4m_utf8_t               *name;
+    c4m_tree_node_t          *declaration_node;
+    c4m_xlist_t              *use_locations;
+    c4m_xlist_t              *lhs_locations;
+    uint32_t                  offset;
+    uint32_t                  size;
+    uint8_t                   flags;
+    c4m_symbol_kind           kind;
+    c4m_type_t               *declared_type;
+    c4m_type_t               *inferred_type;
+    struct c4m_scope_t       *my_scope;
+    // When we merge variable declarations in multiple scopes, we
+    // leave local parse trees point to the local copy of the symbol.
+    // This allows them to find the one we chose as authoritive if
+    // needed.
+    struct c4m_scope_entry_t *authoritative_symbol;
+
 } c4m_scope_entry_t;
 
 typedef struct {

--- a/include/frontend/datatypes/scope.h
+++ b/include/frontend/datatypes/scope.h
@@ -14,14 +14,15 @@ typedef enum : int8_t {
 } c4m_symbol_kind;
 
 enum {
-    C4M_F_HAS_INITIALIZER  = 1,
-    C4M_F_DECLARED_CONST   = 2,
-    C4M_F_IS_DECLARED      = 4,
-    C4M_F_TYPE_IS_DECLARED = 8,
+    C4M_F_HAS_INITIALIZER     = 1,
+    C4M_F_DECLARED_CONST      = 2,
+    C4M_F_IS_DECLARED         = 4,
+    C4M_F_TYPE_IS_DECLARED    = 8,
     // 'const' means user immutable not static. This is for iteration
     // variables on loops, etc.
-    C4M_F_USER_IMMUTIBLE   = 0x10,
-    C4M_F_ALL_SYM_FLAGS    = 0x1f,
+    C4M_F_USER_IMMUTIBLE      = 0x10,
+    C4M_F_ALL_CONTAINER_FLAGS = 0x1f,
+    C4M_F_FN_PASS_DONE        = 0x20,
 };
 
 typedef enum c4m_scope_kind {
@@ -66,6 +67,9 @@ typedef struct c4m_scope_entry_t {
     c4m_type_t         *type;
     struct c4m_scope_t *my_scope;
     c4m_tree_node_t    *type_declaration_node;
+    void               *other_info;
+    c4m_xlist_t        *sym_defs;
+    c4m_xlist_t        *sym_uses;
 } c4m_scope_entry_t;
 
 typedef struct {

--- a/include/frontend/datatypes/scope.h
+++ b/include/frontend/datatypes/scope.h
@@ -14,8 +14,14 @@ typedef enum : int8_t {
 } c4m_symbol_kind;
 
 enum {
-    C4M_F_HAS_DEFAULT_VALUE = 1,
-    C4M_F_IS_CONST          = 2,
+    C4M_F_HAS_INITIALIZER  = 1,
+    C4M_F_DECLARED_CONST   = 2,
+    C4M_F_IS_DECLARED      = 4,
+    C4M_F_TYPE_IS_DECLARED = 8,
+    // 'const' means user immutable not static. This is for iteration
+    // variables on loops, etc.
+    C4M_F_USER_IMMUTIBLE   = 0x10,
+    C4M_F_ALL_SYM_FLAGS    = 0x1f,
 };
 
 typedef enum c4m_scope_kind {
@@ -49,25 +55,17 @@ typedef struct c4m_scope_entry_t {
     // for other types, it gets a pointer to one of the specific data
     // structures in this file.
 
-    c4m_obj_t                 value;
-    c4m_utf8_t               *path;
-    c4m_utf8_t               *name;
-    c4m_tree_node_t          *declaration_node;
-    c4m_xlist_t              *use_locations;
-    c4m_xlist_t              *lhs_locations;
-    uint32_t                  offset;
-    uint32_t                  size;
-    uint8_t                   flags;
-    c4m_symbol_kind           kind;
-    c4m_type_t               *declared_type;
-    c4m_type_t               *inferred_type;
-    struct c4m_scope_t       *my_scope;
-    // When we merge variable declarations in multiple scopes, we
-    // leave local parse trees point to the local copy of the symbol.
-    // This allows them to find the one we chose as authoritive if
-    // needed.
-    struct c4m_scope_entry_t *authoritative_symbol;
-
+    c4m_obj_t           value;
+    c4m_utf8_t         *path;
+    c4m_utf8_t         *name;
+    c4m_tree_node_t    *declaration_node;
+    uint32_t            offset;
+    uint32_t            size;
+    uint8_t             flags;
+    c4m_symbol_kind     kind;
+    c4m_type_t         *type;
+    struct c4m_scope_t *my_scope;
+    c4m_tree_node_t    *type_declaration_node;
 } c4m_scope_entry_t;
 
 typedef struct {

--- a/include/frontend/datatypes/scope.h
+++ b/include/frontend/datatypes/scope.h
@@ -57,20 +57,21 @@ typedef struct c4m_scope_entry_t {
     // for other types, it gets a pointer to one of the specific data
     // structures in this file.
 
-    c4m_obj_t           value;
-    c4m_utf8_t         *path;
-    c4m_utf8_t         *name;
-    c4m_tree_node_t    *declaration_node;
-    uint32_t            offset;
-    uint32_t            size;
-    uint8_t             flags;
-    c4m_symbol_kind     kind;
-    c4m_type_t         *type;
-    struct c4m_scope_t *my_scope;
-    c4m_tree_node_t    *type_declaration_node;
-    void               *other_info;
-    c4m_xlist_t        *sym_defs;
-    c4m_xlist_t        *sym_uses;
+    c4m_obj_t                 value;
+    c4m_utf8_t               *path;
+    c4m_utf8_t               *name;
+    c4m_tree_node_t          *declaration_node;
+    uint32_t                  offset;
+    uint32_t                  size;
+    uint8_t                   flags;
+    c4m_symbol_kind           kind;
+    c4m_type_t               *type;
+    struct c4m_scope_t       *my_scope;
+    c4m_tree_node_t          *type_declaration_node;
+    void                     *other_info;
+    c4m_xlist_t              *sym_defs;
+    c4m_xlist_t              *sym_uses;
+    struct c4m_scope_entry_t *linked_symbol;
 } c4m_scope_entry_t;
 
 typedef struct {

--- a/include/frontend/datatypes/scope.h
+++ b/include/frontend/datatypes/scope.h
@@ -14,15 +14,14 @@ typedef enum : int8_t {
 } c4m_symbol_kind;
 
 enum {
-    C4M_F_HAS_INITIALIZER     = 1,
-    C4M_F_DECLARED_CONST      = 2,
-    C4M_F_IS_DECLARED         = 4,
-    C4M_F_TYPE_IS_DECLARED    = 8,
+    C4M_F_HAS_INITIALIZER  = 1,
+    C4M_F_DECLARED_CONST   = 2,
+    C4M_F_IS_DECLARED      = 4,
+    C4M_F_TYPE_IS_DECLARED = 8,
     // 'const' means user immutable not static. This is for iteration
     // variables on loops, etc.
-    C4M_F_USER_IMMUTIBLE      = 0x10,
-    C4M_F_ALL_CONTAINER_FLAGS = 0x1f,
-    C4M_F_FN_PASS_DONE        = 0x20,
+    C4M_F_USER_IMMUTIBLE   = 0x10,
+    C4M_F_FN_PASS_DONE     = 0x20,
 };
 
 typedef enum c4m_scope_kind {

--- a/include/frontend/datatypes/scope.h
+++ b/include/frontend/datatypes/scope.h
@@ -28,6 +28,7 @@ typedef enum c4m_scope_kind {
     C4M_SCOPE_GLOBAL,
     C4M_SCOPE_MODULE,
     C4M_SCOPE_LOCAL,
+    C4M_SCOPE_FORMALS,
     C4M_SCOPE_ATTRIBUTES,
     C4M_SCOPE_IMPORTS,
 } c4m_scope_kind;
@@ -90,6 +91,7 @@ typedef struct c4m_scope_t {
 typedef struct {
     c4m_type_t          *full_type;
     c4m_scope_t         *fn_scope;
+    c4m_scope_t         *formals;
     c4m_fn_param_info_t *param_info;
     c4m_fn_param_info_t  return_info;
     int                  num_params;

--- a/include/frontend/datatypes/spec.h
+++ b/include/frontend/datatypes/spec.h
@@ -58,7 +58,5 @@ typedef struct {
     c4m_utf8_t         *long_doc;
     c4m_spec_section_t *root_section;
     c4m_dict_t         *section_specs;
-    c4m_xlist_t        *errors; // an xlist of c4m_compile_errors
-    unsigned int        used   : 1;
     unsigned int        locked : 1;
 } c4m_spec_t;

--- a/include/frontend/datatypes/spec.h
+++ b/include/frontend/datatypes/spec.h
@@ -34,7 +34,6 @@ typedef struct {
     unsigned int     validate_range    : 1;
     unsigned int     validate_choice   : 1;
     unsigned int     have_type_pointer : 1;
-
 } c4m_spec_field_t;
 
 typedef struct {
@@ -60,3 +59,30 @@ typedef struct {
     c4m_dict_t         *section_specs;
     unsigned int        locked : 1;
 } c4m_spec_t;
+
+typedef enum {
+    c4m_attr_invalid,
+    c4m_attr_field,
+    c4m_attr_user_def_field,
+    c4m_attr_object_type,
+    c4m_attr_singleton,
+    c4m_attr_instance
+} c4m_attr_status_t;
+
+typedef enum {
+    c4m_attr_no_error,
+    c4m_attr_err_sec_under_field,
+    c4m_attr_err_field_not_allowed,
+    c4m_attr_err_no_such_sec,
+    c4m_attr_err_sec_not_allowed,
+} c4m_attr_error_t;
+
+typedef struct {
+    c4m_attr_status_t kind;
+    union {
+        c4m_spec_section_t *sec_info;
+        c4m_spec_field_t   *field_info;
+    } info;
+    c4m_attr_error_t err;
+    c4m_utf8_t      *err_arg;
+} c4m_attr_info_t;

--- a/include/frontend/lex.h
+++ b/include/frontend/lex.h
@@ -16,5 +16,7 @@ c4m_token_raw_content(c4m_token_t *tok)
                                       "codepoints",
                                       tok->start_ptr + tok->adjustment));
 
-    return c4m_to_utf8(u32);
+    c4m_utf8_t *result = c4m_to_utf8(u32);
+
+    return result;
 }

--- a/include/frontend/parse.h
+++ b/include/frontend/parse.h
@@ -2,6 +2,7 @@
 #include "con4m.h"
 
 extern bool        c4m_parse(c4m_file_compile_ctx *);
+extern bool        c4m_parse_type(c4m_file_compile_ctx *);
 extern c4m_grid_t *c4m_format_parse_tree(c4m_file_compile_ctx *);
 extern void        c4m_print_parse_node(c4m_tree_node_t *);
 extern c4m_utf8_t *c4m_node_type_name(c4m_node_kind_t);
@@ -32,8 +33,8 @@ c4m_node_get_loc_str(c4m_tree_node_t *n)
 
     return c4m_cstr_format("{}:{}:{}",
                            p->token->module->path,
-                           p->token->line_no,
-                           p->token->line_offset + 1);
+                           c4m_box_i64(p->token->line_no),
+                           c4m_box_i64(p->token->line_offset + 1));
 }
 
 static inline c4m_utf8_t *
@@ -148,4 +149,5 @@ cur_node(pass1_ctx *ctx)
 {
     return ctx->cur_tnode;
 }
+
 #endif

--- a/include/frontend/partial.h
+++ b/include/frontend/partial.h
@@ -1,8 +1,17 @@
 #pragma once
 #include "con4m.h"
 
+#ifdef C4M_USE_INTERNAL_API
+
+static inline bool
+c4m_is_partial_type(c4m_type_t *t)
+{
+    return c4m_tspec_get_base_tid(t) == C4M_T_PARTIAL_LIT;
+}
+
 static inline bool
 c4m_is_partial_lit(const c4m_obj_t o)
 {
-    return c4m_obj_type_check(o, c4m_tspec_partial_lit());
+    return c4m_is_partial_type(c4m_get_my_type(o));
 }
+#endif

--- a/include/frontend/scope.h
+++ b/include/frontend/scope.h
@@ -2,6 +2,7 @@
 
 #include "con4m.h"
 
+#ifdef C4M_USE_INTERNAL_API
 extern c4m_scope_t       *c4m_new_scope(c4m_scope_t *, c4m_scope_kind);
 extern c4m_scope_entry_t *c4m_declare_symbol(c4m_file_compile_ctx *,
                                              c4m_scope_t *,
@@ -14,9 +15,38 @@ extern c4m_scope_entry_t *c4m_lookup_symbol(c4m_scope_t *, c4m_utf8_t *);
 extern bool               c4m_merge_symbols(c4m_file_compile_ctx *,
                                             c4m_scope_entry_t *,
                                             c4m_scope_entry_t *);
+extern c4m_grid_t        *c4m_format_scope(c4m_scope_t *);
+extern void               c4m_shadow_check(c4m_file_compile_ctx *,
+                                           c4m_scope_entry_t *,
+                                           c4m_scope_t *);
+extern c4m_scope_entry_t *c4m_symbol_lookup(c4m_scope_t *,
+                                            c4m_scope_t *,
+                                            c4m_scope_t *,
+                                            c4m_scope_t *,
+                                            c4m_utf8_t *);
+extern c4m_scope_entry_t *c4m_add_inferred_symbol(c4m_file_compile_ctx *,
+                                                  c4m_scope_t *,
+                                                  c4m_utf8_t *);
+extern c4m_scope_entry_t *c4m_add_or_replace_symbol(c4m_file_compile_ctx *,
+                                                    c4m_scope_t *,
+                                                    c4m_utf8_t *);
 
 static inline bool
-c4m_sym_is_const(c4m_scope_entry_t *sym)
+c4m_sym_is_declared_const(c4m_scope_entry_t *sym)
 {
-    return (sym->flags & C4M_F_IS_CONST) != 0;
+    return (sym->flags & C4M_F_DECLARED_CONST) != 0;
 }
+
+static inline c4m_type_t *
+c4m_get_sym_type(c4m_scope_entry_t *sym)
+{
+    return sym->type;
+}
+
+static inline bool
+c4m_type_is_declared(c4m_scope_entry_t *sym)
+{
+    return (bool)(sym->flags & C4M_F_TYPE_IS_DECLARED);
+}
+
+#endif

--- a/include/frontend/scope.h
+++ b/include/frontend/scope.h
@@ -30,6 +30,7 @@ extern c4m_scope_entry_t *c4m_add_inferred_symbol(c4m_file_compile_ctx *,
 extern c4m_scope_entry_t *c4m_add_or_replace_symbol(c4m_file_compile_ctx *,
                                                     c4m_scope_t *,
                                                     c4m_utf8_t *);
+extern c4m_utf8_t        *c4m_sym_get_best_ref_loc(c4m_scope_entry_t *);
 
 static inline bool
 c4m_sym_is_declared_const(c4m_scope_entry_t *sym)
@@ -47,6 +48,14 @@ static inline bool
 c4m_type_is_declared(c4m_scope_entry_t *sym)
 {
     return (bool)(sym->flags & C4M_F_TYPE_IS_DECLARED);
+}
+
+extern char *c4m_symbol_kind_names[sk_num_sym_kinds];
+
+static inline c4m_utf8_t *
+c4m_sym_kind_name(c4m_scope_entry_t *sym)
+{
+    return c4m_new_utf8(c4m_symbol_kind_names[sym->kind]);
 }
 
 #endif

--- a/include/frontend/scope.h
+++ b/include/frontend/scope.h
@@ -10,8 +10,10 @@ extern c4m_scope_entry_t *c4m_declare_symbol(c4m_file_compile_ctx *,
                                              c4m_symbol_kind,
                                              bool *,
                                              bool);
-
-c4m_scope_entry_t *c4m_lookup_symbol(c4m_scope_t *, c4m_utf8_t *);
+extern c4m_scope_entry_t *c4m_lookup_symbol(c4m_scope_t *, c4m_utf8_t *);
+extern bool               c4m_merge_symbols(c4m_file_compile_ctx *,
+                                            c4m_scope_entry_t *,
+                                            c4m_scope_entry_t *);
 
 static inline bool
 c4m_sym_is_const(c4m_scope_entry_t *sym)

--- a/include/frontend/spec.h
+++ b/include/frontend/spec.h
@@ -1,4 +1,5 @@
 #pragma once
 #include "con4m.h"
 
-c4m_spec_t *c4m_new_spec();
+extern c4m_spec_t      *c4m_new_spec();
+extern c4m_attr_info_t *c4m_get_attr_info(c4m_spec_t *, c4m_xlist_t *);

--- a/include/frontend/treematch.h
+++ b/include/frontend/treematch.h
@@ -95,9 +95,11 @@ extern c4m_tree_node_t *get_match_on_node(c4m_tree_node_t *, c4m_tpat_node_t *);
 extern c4m_xlist_t *apply_pattern_on_node(c4m_tree_node_t *, c4m_tpat_node_t *);
 
 extern c4m_tpat_node_t *c4m_first_kid_id;
+extern c4m_tpat_node_t *c4m_2nd_kid_id;
 extern c4m_tpat_node_t *c4m_enum_items;
 extern c4m_tpat_node_t *c4m_member_prefix;
 extern c4m_tpat_node_t *c4m_member_last;
+extern c4m_tpat_node_t *c4m_func_mods;
 extern c4m_tpat_node_t *c4m_use_uri;
 extern c4m_tpat_node_t *c4m_extern_params;
 extern c4m_tpat_node_t *c4m_extern_return;

--- a/include/frontend/treematch.h
+++ b/include/frontend/treematch.h
@@ -112,5 +112,6 @@ extern c4m_tpat_node_t *c4m_sym_decls;
 extern c4m_tpat_node_t *c4m_sym_names;
 extern c4m_tpat_node_t *c4m_sym_type;
 extern c4m_tpat_node_t *c4m_sym_init;
+extern c4m_tpat_node_t *c4m_loop_vars;
 
 #endif

--- a/include/frontend/treematch.h
+++ b/include/frontend/treematch.h
@@ -113,5 +113,7 @@ extern c4m_tpat_node_t *c4m_sym_names;
 extern c4m_tpat_node_t *c4m_sym_type;
 extern c4m_tpat_node_t *c4m_sym_init;
 extern c4m_tpat_node_t *c4m_loop_vars;
+extern c4m_tpat_node_t *c4m_case_branches;
+extern c4m_tpat_node_t *c4m_case_else;
 
 #endif

--- a/include/frontend/treematch.h
+++ b/include/frontend/treematch.h
@@ -115,5 +115,7 @@ extern c4m_tpat_node_t *c4m_sym_init;
 extern c4m_tpat_node_t *c4m_loop_vars;
 extern c4m_tpat_node_t *c4m_case_branches;
 extern c4m_tpat_node_t *c4m_case_else;
+extern c4m_tpat_node_t *c4m_elif_branches;
+extern c4m_tpat_node_t *c4m_else_condition;
 
 #endif

--- a/meson.build
+++ b/meson.build
@@ -102,6 +102,7 @@ c4m_src  = ['src/con4m/style.c',
             'src/con4m/frontend/cfg.c',
             'src/con4m/frontend/treematch.c',
             'src/con4m/frontend/decl_pass.c',
+            'src/con4m/frontend/check_pass.c',
             ]
 
 hat_primary = ['src/hatrack/support/hatrack_common.c',

--- a/meson.build
+++ b/meson.build
@@ -119,7 +119,8 @@ hat_primary = ['src/hatrack/support/hatrack_common.c',
                'src/hatrack/queue/hatring.c',
                'src/hatrack/queue/stack.c',
                'src/hatrack/queue/debug.c',
-               'src/hatrack/queue/logring.c']
+               'src/hatrack/queue/logring.c'
+               ]
 
 hat_hashref = ['src/hatrack/hash/ballcap.c',
                'src/hatrack/hash/duncecap.c',

--- a/src/con4m/frontend/check_pass.c
+++ b/src/con4m/frontend/check_pass.c
@@ -147,7 +147,7 @@ type_check_node_against_sym(pass2_ctx         *ctx,
     }
 
     else {
-        if (c4m_tspec_is_error(pnode->type)) {
+        if (pnode->type && c4m_tspec_is_error(pnode->type)) {
             return; // Already errored for this node.
         }
     }
@@ -437,8 +437,6 @@ initial_function_resolution(pass2_ctx       *ctx,
 
         return NULL;
     }
-    // TODO: ADD CFG NODE.
-    // TODO: Fix def/use up for this.
 }
 
 static void base_check_pass_dispatch(pass2_ctx *);
@@ -1563,10 +1561,6 @@ base_check_pass_dispatch(pass2_ctx *ctx)
     default:
         process_children(ctx);
         break;
-    }
-
-    if (pnode->type == NULL) {
-        pnode->type = c4m_tspec_typevar();
     }
 }
 

--- a/src/con4m/frontend/check_pass.c
+++ b/src/con4m/frontend/check_pass.c
@@ -2,12 +2,13 @@
 #include "con4m.h"
 
 typedef struct {
-    c4m_utf8_t      *name;
-    c4m_type_t      *sig;
-    c4m_tree_node_t *loc;
-    // Return type of container for things like index operations,
-    // which will have to be checked later.
-    c4m_type_t      *container_ret;
+    c4m_utf8_t        *name;
+    c4m_type_t        *sig;
+    c4m_tree_node_t   *loc;
+    c4m_scope_entry_t *resolution;
+    c4m_type_t        *deferred_container_type;
+    unsigned int       polymorphic : 1;
+    unsigned int       deferred    : 1;
 } call_resolution_info_t;
 
 typedef struct {
@@ -47,7 +48,7 @@ typedef struct {
     // Current fn decl object when in a fn. It's NULL in a module context.
     c4m_fn_decl_t        *fn_decl;
     c4m_xlist_t          *current_rhs_uses;
-    c4m_xlist_t          *current_section_prefix;
+    c4m_utf8_t           *current_section_prefix;
     c4m_xlist_t          *loop_stack;
     c4m_xlist_t          *deferred_calls;
 } pass2_ctx;
@@ -65,12 +66,32 @@ get_pnode_type(c4m_tree_node_t *node)
     return pnode->type;
 }
 
+static inline void
+set_node_type(c4m_tree_node_t *node, c4m_type_t *type)
+{
+    c4m_pnode_t *pnode = get_pnode(node);
+    if (pnode->type == NULL) {
+        pnode->type = type;
+    }
+    else {
+        c4m_merge_types(pnode->type, type);
+    }
+}
+
 static void
-add_def(pass2_ctx *ctx, c4m_scope_entry_t *sym)
+add_def(pass2_ctx *ctx, c4m_scope_entry_t *sym, bool finish_flow)
 {
     ctx->cfg = c4m_cfg_add_def(ctx->cfg, ctx->node, sym, ctx->current_rhs_uses);
 
-    ctx->current_rhs_uses == NULL;
+    if (finish_flow) {
+        ctx->current_rhs_uses = NULL;
+    }
+
+    if (sym->sym_defs == NULL) {
+        sym->sym_defs = c4m_new(c4m_tspec_xlist(c4m_tspec_ref()));
+    }
+
+    c4m_xlist_append(sym->sym_defs, ctx->node);
 }
 
 static void
@@ -80,6 +101,18 @@ add_use(pass2_ctx *ctx, c4m_scope_entry_t *sym)
     if (ctx->current_rhs_uses) {
         c4m_xlist_append(ctx->current_rhs_uses, sym);
     }
+
+    if (sym->sym_uses == NULL) {
+        sym->sym_uses = c4m_new(c4m_tspec_xlist(c4m_tspec_ref()));
+    }
+
+    c4m_xlist_append(sym->sym_uses, ctx->node);
+}
+
+static inline void
+start_data_flow(pass2_ctx *ctx)
+{
+    ctx->current_rhs_uses = c4m_new(c4m_tspec_xlist(c4m_tspec_ref()));
 }
 
 static inline c4m_xlist_t *
@@ -139,6 +172,159 @@ type_check_nodes(c4m_tree_node_t *n1, c4m_tree_node_t *n2)
     c4m_pnode_t *pnode2 = get_pnode(n2);
 
     return c4m_merge_types(pnode1->type, pnode2->type);
+}
+
+// This maps names to how many arguments the function takes.  If
+// there's no return type, it'll be a negative number.  For now, the
+// type constraints will be handled by the caller, and the # of args
+// should already be checked.
+
+static c4m_dict_t *polymorphic_fns = NULL;
+
+static void
+setup_polymorphic_fns()
+{
+    polymorphic_fns = c4m_new(c4m_tspec_dict(c4m_tspec_utf8(),
+                                             c4m_tspec_ref()));
+
+    hatrack_dict_put(polymorphic_fns, c4m_new_utf8("__slice__"), (void *)~3);
+    hatrack_dict_put(polymorphic_fns, c4m_new_utf8("__index__"), (void *)~2);
+    hatrack_dict_put(polymorphic_fns, c4m_new_utf8("__plus__"), (void *)2);
+    hatrack_dict_put(polymorphic_fns, c4m_new_utf8("__minus__"), (void *)2);
+    hatrack_dict_put(polymorphic_fns, c4m_new_utf8("__mul__"), (void *)2);
+    hatrack_dict_put(polymorphic_fns, c4m_new_utf8("__mod__"), (void *)2);
+    hatrack_dict_put(polymorphic_fns, c4m_new_utf8("__div__"), (void *)2);
+    hatrack_dict_put(polymorphic_fns, c4m_new_utf8("__fdiv__"), (void *)2);
+    hatrack_dict_put(polymorphic_fns, c4m_new_utf8("__shl__"), (void *)2);
+    hatrack_dict_put(polymorphic_fns, c4m_new_utf8("__shr__"), (void *)2);
+    hatrack_dict_put(polymorphic_fns, c4m_new_utf8("__bitand__"), (void *)2);
+    hatrack_dict_put(polymorphic_fns, c4m_new_utf8("__bitor__"), (void *)2);
+    hatrack_dict_put(polymorphic_fns, c4m_new_utf8("__bitxor__"), (void *)2);
+    hatrack_dict_put(polymorphic_fns, c4m_new_utf8("__cmp__"), (void *)2);
+    hatrack_dict_put(polymorphic_fns,
+                     c4m_new_utf8("__set_slice__"),
+                     (void *)~4);
+    hatrack_dict_put(polymorphic_fns,
+                     c4m_new_utf8("__set_index__"),
+                     (void *)~3);
+}
+
+static call_resolution_info_t *
+initial_function_resolution(pass2_ctx       *ctx,
+                            c4m_utf8_t      *call_name,
+                            c4m_type_t      *called_type,
+                            c4m_tree_node_t *call_loc)
+{
+    // For now, (maybe will changed when we add in objects), the only
+    // overloading we allow for function names is for builtin names.
+    // For such things `overload` will be true. And for these, we do
+    // NOT make any serious attempt to do resolution when the first
+    // argument is not "concrete enough", meaning the only type
+    // variables we would allow would be in *parameters* to function
+    // calls.
+    //
+    // We'll try to statically bind at the end of processing though.
+    // And if there's an ambiguity, we'll generate a run-time
+    // dispatch.
+    //
+    // For any other function, we unify immediately, and if there is
+    // no symbol at this point, we know it's a miss, since all
+    // declarations have been processed by this point.
+    //
+    // However, if the function we've looked up hasn't been fully
+    // inferenced yet, we won't have enough information yet to bind
+    // the types yet (the functions params are often all going to just
+    // be type variables).
+    //
+    // If a function hasn't been processed, comparing vs. its type sig
+    // is worthless, because we don't want concrete types at call
+    // sites to influence the actual type. So in those cases, we defer
+    // until the end of the pass, just like w/ overloads.
+
+    if (polymorphic_fns == NULL) {
+        setup_polymorphic_fns();
+    }
+
+    call_resolution_info_t *info = c4m_gc_alloc(call_resolution_info_t);
+
+    info->name = call_name;
+    info->loc  = call_loc;
+    info->sig  = called_type;
+
+    // Result will be non-zero in all cases we allow polymorphism,
+    // thus the null check, even though we were putting in ints.
+    if (hatrack_dict_get(polymorphic_fns, call_name, NULL) != NULL) {
+        info->polymorphic = 1;
+        info->deferred    = 1;
+
+        c4m_xlist_append(ctx->deferred_calls, info);
+
+        return info;
+    }
+
+    // Otherwise, at this point we must be able to statically bind
+    // from our static scope, and currently the function can only live
+    // in the module or global scope.
+    c4m_scope_entry_t *sym = c4m_symbol_lookup(NULL,
+                                               ctx->file_ctx->module_scope,
+                                               ctx->global_scope,
+                                               NULL,
+                                               call_name);
+
+    if (sym == NULL) {
+        c4m_add_error(ctx->file_ctx,
+                      c4m_err_fn_not_found,
+                      call_loc,
+                      call_name);
+        return NULL;
+    }
+
+    switch (sym->kind) {
+    case sk_func:
+    case sk_extern_func:
+        info->resolution = sym;
+
+        ctx->cfg = c4m_cfg_add_call(ctx->cfg,
+                                    call_loc,
+                                    sym,
+                                    ctx->current_rhs_uses);
+
+        int sig_params = c4m_tspec_get_num_params(info->sig);
+        int sym_params = c4m_tspec_get_num_params(sym->type);
+
+        if (sig_params != sym_params) {
+            c4m_add_error(ctx->file_ctx,
+                          c4m_err_num_params,
+                          call_loc,
+                          call_name,
+                          c4m_box_u64(sig_params - 1),
+                          c4m_box_u64(sym_params - 1));
+            return NULL;
+        }
+
+        if (!(sym->flags & C4M_F_FN_PASS_DONE)) {
+            info->deferred = 1;
+            set_node_type(call_loc,
+                          c4m_tspec_get_param(info->sig, sig_params - 1));
+            return info;
+        }
+
+        c4m_merge_types(c4m_global_copy(sym->type), info->sig);
+        set_node_type(call_loc, c4m_tspec_get_param(info->sig, sig_params - 1));
+
+        return info;
+
+    default:
+        c4m_add_error(ctx->file_ctx,
+                      c4m_err_calling_non_fn,
+                      call_loc,
+                      call_name,
+                      c4m_sym_kind_name(sym));
+
+        return NULL;
+    }
+    // TODO: ADD CFG NODE.
+    // TODO: Fix def/use up for this.
 }
 
 static void base_check_pass_dispatch(pass2_ctx *);
@@ -226,9 +412,108 @@ is_def_context(pass2_ctx *ctx)
 }
 
 static c4m_scope_entry_t *
-sym_lookup(pass2_ctx *ctx, c4m_utf8_t *name, bool add_du)
+sym_lookup(pass2_ctx *ctx, c4m_utf8_t *name)
 {
     c4m_scope_entry_t *result;
+    c4m_spec_t        *spec = ctx->spec;
+    c4m_utf8_t        *dot  = c4m_new_utf8(".");
+
+    // First, if it's specified in the spec, we consider it there,
+    // even if it's not in the symbol table.
+
+    if (spec != NULL) {
+        c4m_xlist_t     *parts     = c4m_str_xsplit(name, dot);
+        c4m_attr_info_t *attr_info = c4m_get_attr_info(spec, parts);
+
+        switch (attr_info->kind) {
+        case c4m_attr_user_def_field:
+            if (c4m_xlist_len(parts) == 1) {
+                break;
+            }
+            // fallthrough
+        case c4m_attr_field:
+
+            result = hatrack_dict_get(ctx->attr_scope->symbols, name, NULL);
+            if (result == NULL) {
+                result             = c4m_add_inferred_symbol(ctx->file_ctx,
+                                                 ctx->attr_scope,
+                                                 name);
+                result->other_info = attr_info;
+            }
+            return result;
+
+        case c4m_attr_object_type:
+            c4m_add_error(ctx->file_ctx,
+                          c4m_err_spec_needs_field,
+                          ctx->node,
+                          name,
+                          c4m_new_utf8("named section"));
+            return NULL;
+        case c4m_attr_singleton:
+            c4m_add_error(ctx->file_ctx,
+                          c4m_err_spec_needs_field,
+                          ctx->node,
+                          name,
+                          c4m_new_utf8("singleton (unnamed) section"));
+            return NULL;
+
+        case c4m_attr_instance:
+            c4m_add_error(ctx->file_ctx,
+                          c4m_err_spec_needs_field,
+                          ctx->node,
+                          name,
+                          c4m_new_utf8("section instance"));
+            return NULL;
+
+        case c4m_attr_invalid:
+            if (c4m_xlist_len(parts) == 1) {
+                // If it's not explicitly by the spec, then we
+                // treat it as a variable not an attribute.
+                break;
+            }
+            switch (attr_info->err) {
+            case c4m_attr_err_sec_under_field:
+                c4m_add_error(ctx->file_ctx,
+                              c4m_err_field_not_spec,
+                              ctx->node,
+                              name,
+                              attr_info->err_arg);
+                break;
+            case c4m_attr_err_field_not_allowed:
+                c4m_add_error(ctx->file_ctx,
+                              c4m_err_field_not_spec,
+                              ctx->node,
+                              name,
+                              attr_info->err_arg);
+                break;
+            case c4m_attr_err_no_such_sec:
+                c4m_add_error(ctx->file_ctx,
+                              c4m_err_undefined_section,
+                              ctx->node,
+                              attr_info->err_arg);
+                break;
+            case c4m_attr_err_sec_not_allowed:
+                c4m_add_error(ctx->file_ctx,
+                              c4m_err_section_not_allowed,
+                              ctx->node,
+                              attr_info->err_arg);
+            default:
+                unreachable();
+            }
+
+            return NULL;
+        }
+    }
+    else {
+        // TODO: Object resolution.
+        if (c4m_str_find(name, dot) != -1) {
+            // TODO: lookup first.
+            result = c4m_add_inferred_symbol(ctx->file_ctx,
+                                             ctx->attr_scope,
+                                             name);
+            return result;
+        }
+    }
 
     result = c4m_symbol_lookup(ctx->local_scope,
                                ctx->file_ctx->module_scope,
@@ -236,33 +521,22 @@ sym_lookup(pass2_ctx *ctx, c4m_utf8_t *name, bool add_du)
                                ctx->attr_scope,
                                name);
 
-    if (!result || !add_du) {
-        return NULL;
-    }
-
-    if (is_def_context(ctx)) {
-        add_def(ctx, result);
-    }
-    else {
-        add_use(ctx, result);
-    }
-
     return result;
 }
 
 static c4m_scope_entry_t *
 lookup_or_add(pass2_ctx *ctx, c4m_utf8_t *name)
 {
-    c4m_scope_entry_t *result = sym_lookup(ctx, name, true);
-    if (result) {
-        return result;
+    c4m_scope_entry_t *result = sym_lookup(ctx, name);
+
+    if (!result) {
+        result = c4m_add_inferred_symbol(ctx->file_ctx,
+                                         ctx->local_scope,
+                                         name);
     }
-    result = c4m_add_inferred_symbol(ctx->file_ctx,
-                                     ctx->local_scope,
-                                     name);
 
     if (is_def_context(ctx)) {
-        add_def(ctx, result);
+        add_def(ctx, result, true);
     }
     else {
         add_use(ctx, result);
@@ -295,20 +569,25 @@ handle_index(pass2_ctx *ctx)
             container_type  = c4m_merge_types(tmp, container_type);
 
             if (num_kids == 3) {
-                // TODO: error: Slice not allowed on dicts.
+                c4m_add_error(ctx->file_ctx,
+                              c4m_err_slice_on_dict,
+                              ctx->node);
                 return;
             }
         }
     }
 
-    call_resolution_info_t *info = c4m_gc_alloc(call_resolution_info_t);
+    call_resolution_info_t *info;
 
     if (num_kids == 3) {
         process_child(ctx, 2);
         ix2_type = get_pnode_type(ctx->node->children[2]);
 
         if (!c4m_tspec_is_int_type(ix2_type) && !c4m_tspec_is_tvar(ix2_type)) {
-            // Error: slice requires int indicies.
+            c4m_add_error(ctx->file_ctx,
+                          c4m_err_bad_slice_ix,
+                          ctx->node);
+            return;
         }
 
         if (c4m_tspec_is_tvar(ix1_type)) {
@@ -319,33 +598,69 @@ handle_index(pass2_ctx *ctx)
             c4m_merge_types(ix1_type, c4m_tspec_i32());
         }
 
-        info->name          = c4m_new_utf8("__slice__");
-        info->loc           = ctx->node;
-        info->container_ret = node_type;
-        info->sig           = c4m_tspec_fn_va(info->container_ret,
-                                    3,
-                                    container_type,
-                                    ix1_type,
-                                    ix2_type);
+        info = initial_function_resolution(
+            ctx,
+            c4m_new_utf8("__slice__"),
+            c4m_tspec_varargs_fn(node_type,
+                                 3,
+                                 container_type,
+                                 ix1_type,
+                                 ix2_type),
+            ctx->node);
+
+        info->deferred_container_type = container_type;
     }
     else {
-        info->name          = c4m_new_utf8("__index__");
-        info->loc           = ctx->node;
-        info->container_ret = node_type;
-        info->sig           = c4m_tspec_fn_va(info->container_ret,
-                                    2,
-                                    container_type,
-                                    ix1_type);
+        info = initial_function_resolution(
+            ctx,
+            c4m_new_utf8("__index__"),
+            c4m_tspec_varargs_fn(node_type,
+                                 2,
+                                 container_type,
+                                 ix1_type),
+            ctx->node);
+
+        info->deferred_container_type = container_type;
     }
 
     c4m_xlist_append(ctx->deferred_calls, info);
 
     def_use_context_exit(ctx);
+
+    pnode->extra_info = info;
 }
 
 static void
 handle_call(pass2_ctx *ctx)
 {
+    c4m_xlist_t *stashed_uses = ctx->current_rhs_uses;
+
+    use_context_enter(ctx);
+    start_data_flow(ctx);
+
+    c4m_tree_node_t *saved    = ctx->node;
+    int              n        = saved->num_kids;
+    c4m_xlist_t     *argtypes = c4m_new(c4m_tspec_xlist(c4m_tspec_typespec()));
+    c4m_utf8_t      *fname    = node_text(saved->children[0]);
+    c4m_pnode_t     *pnode;
+
+    for (int i = 1; i < n; i++) {
+        ctx->node = saved->children[i];
+        pnode     = get_pnode(ctx->node);
+        base_check_pass_dispatch(ctx);
+        c4m_xlist_append(argtypes, pnode->type);
+    }
+
+    c4m_type_t *fn_type;
+
+    pnode       = get_pnode(saved);
+    pnode->type = c4m_tspec_typevar();
+    fn_type     = c4m_tspec_fn(pnode->type, argtypes, false);
+
+    initial_function_resolution(ctx, fname, fn_type, saved);
+
+    ctx->current_rhs_uses = stashed_uses;
+    def_use_context_exit(ctx);
 }
 
 static void
@@ -427,10 +742,10 @@ loop_push_ix_var(pass2_ctx *ctx, c4m_loop_info_t *li)
                                             ctx->local_scope,
                                             ix_var_name);
 
-    li->loop_ix->flags = C4M_F_ALL_SYM_FLAGS;
+    li->loop_ix->flags = C4M_F_ALL_CONTAINER_FLAGS;
     li->loop_ix->type  = c4m_tspec_u32();
 
-    add_def(ctx, li->loop_ix);
+    add_def(ctx, li->loop_ix, false);
 
     if (li->label != NULL) {
         li->label_ix = c4m_str_concat(li->label, ix_var_name);
@@ -440,17 +755,20 @@ loop_push_ix_var(pass2_ctx *ctx, c4m_loop_info_t *li)
                               NULL,
                               NULL,
                               li->label_ix)) {
-            // TODO: error, dupe loop label.
+            c4m_add_error(ctx->file_ctx,
+                          c4m_err_dupe_label,
+                          ctx->node,
+                          li->label);
             return;
         }
 
         li->named_loop_ix        = c4m_add_inferred_symbol(ctx->file_ctx,
                                                     ctx->local_scope,
                                                     li->label_ix);
-        li->named_loop_ix->flags = C4M_F_ALL_SYM_FLAGS;
+        li->named_loop_ix->flags = C4M_F_ALL_CONTAINER_FLAGS;
         li->named_loop_ix->type  = c4m_tspec_u32();
 
-        add_def(ctx, li->named_loop_ix);
+        add_def(ctx, li->named_loop_ix, false);
     }
 }
 
@@ -480,6 +798,8 @@ handle_for(pass2_ctx *ctx)
     c4m_cfg_node_t  *entrance;
     c4m_cfg_node_t  *branch;
     int              expr_ix = 0;
+
+    start_data_flow(ctx);
 
     li->ranged = pnode->extra_info == NULL;
 
@@ -553,10 +873,10 @@ handle_for(pass2_ctx *ctx)
     li->loop_last        = c4m_add_or_replace_symbol(ctx->file_ctx,
                                               ctx->local_scope,
                                               last_var_name);
-    li->loop_last->flags = C4M_F_ALL_SYM_FLAGS;
+    li->loop_last->flags = C4M_F_ALL_CONTAINER_FLAGS;
     li->loop_last->type  = c4m_tspec_u32();
 
-    add_def(ctx, li->loop_last);
+    add_def(ctx, li->loop_last, true);
 
     if (li->label != NULL) {
         li->label_last             = c4m_to_utf8(c4m_str_concat(li->label,
@@ -564,10 +884,10 @@ handle_for(pass2_ctx *ctx)
         li->named_loop_last        = c4m_add_inferred_symbol(ctx->file_ctx,
                                                       ctx->local_scope,
                                                       li->label_last);
-        li->named_loop_last->flags = C4M_F_ALL_SYM_FLAGS;
+        li->named_loop_last->flags = C4M_F_ALL_CONTAINER_FLAGS;
         li->named_loop_last->type  = c4m_tspec_u32();
 
-        add_def(ctx, li->named_loop_last);
+        add_def(ctx, li->loop_last, false);
     }
 
     // Now, process the assignment of the variable(s) to put per-loop
@@ -585,7 +905,10 @@ handle_for(pass2_ctx *ctx)
         var2_name = node_text(var_node2);
 
         if (!strcmp(var1_name->data, var2_name->data)) {
-            printf("TODO: Add an ERROR here for the name collision.\n");
+            c4m_add_error(ctx->file_ctx,
+                          c4m_err_iter_name_conflict,
+                          var_node2);
+            return;
         }
     }
 
@@ -597,14 +920,17 @@ handle_for(pass2_ctx *ctx)
     li->lvar_1                   = c4m_add_or_replace_symbol(ctx->file_ctx,
                                            ctx->local_scope,
                                            var1_name);
-    li->lvar_1->flags            = C4M_F_ALL_SYM_FLAGS;
+    li->lvar_1->flags            = C4M_F_ALL_CONTAINER_FLAGS;
     li->lvar_1->declaration_node = var_node1;
 
     if (li->shadowed_lvar_1 != NULL) {
-        // TODO: Warn about the shadowing.:
+        c4m_add_warning(ctx->file_ctx,
+                        c4m_warn_shadowed_var,
+                        ctx->node,
+                        var1_name,
+                        c4m_sym_kind_name(li->shadowed_lvar_1),
+                        c4m_sym_get_best_ref_loc(li->lvar_1));
     }
-
-    add_def(ctx, li->lvar_1);
 
     if (var2_name) {
         li->shadowed_lvar_2          = c4m_symbol_lookup(ctx->local_scope,
@@ -615,14 +941,23 @@ handle_for(pass2_ctx *ctx)
         li->lvar_2                   = c4m_add_or_replace_symbol(ctx->file_ctx,
                                                ctx->local_scope,
                                                var2_name);
-        li->lvar_2->flags            = C4M_F_ALL_SYM_FLAGS;
+        li->lvar_2->flags            = C4M_F_ALL_CONTAINER_FLAGS;
         li->lvar_2->declaration_node = var_node2;
 
         if (li->shadowed_lvar_2 != NULL) {
-            // TODO: Warn about the shadowing.
+            c4m_add_warning(ctx->file_ctx,
+                            c4m_warn_shadowed_var,
+                            ctx->node,
+                            var2_name,
+                            c4m_sym_kind_name(li->shadowed_lvar_2),
+                            c4m_sym_get_best_ref_loc(li->lvar_2));
         }
 
-        add_def(ctx, li->lvar_2);
+        add_def(ctx, li->lvar_1, false);
+        add_def(ctx, li->lvar_2, true);
+    }
+    else {
+        add_def(ctx, li->lvar_1, true);
     }
 
     // Okay, now we need to add the branch node to the CFG.
@@ -682,42 +1017,43 @@ handle_for(pass2_ctx *ctx)
     // Finally, do type checking based on the type of loop. The type
     // will always be contained in the second non-label subtree of the
     // loop node. We stashed that above as `container_pnode`.
-    //
-    // If there are two variables, we can infer that the container is
-    // a dictionary, and compare. Otherwise, if the inferred type
-    // isn't a container type, then we give an error.
 
-    if (li->lvar_2 != NULL) {
-        c4m_merge_types(c4m_tspec_dict(li->lvar_1->type, li->lvar_2->type),
-                        container_pnode->type);
+    //
+    //
+    if (li->ranged) {
+        // Ranged fors are easy enough. The assigned variable is
+        // always based on the range type.
+        c4m_merge_types(li->lvar_1->type, container_pnode->type);
     }
     else {
-        switch (c4m_tspec_get_base(container_pnode->type)) {
-        case C4M_DT_KIND_list:
-            c4m_merge_types(li->lvar_1->type,
-                            c4m_tspec_get_param(container_pnode->type, 0));
-            break;
-        case C4M_DT_KIND_dict:
-            if (c4m_tspec_get_num_params(container_pnode->type) == 1) {
-                c4m_merge_types(li->lvar_1->type,
-                                c4m_tspec_get_param(container_pnode->type, 0));
-            }
-            else {
-                printf("Need an error for dictionary not allowed...\n");
-            }
-            break;
-        case C4M_DT_KIND_type_var:
-            printf(
-                "For now, need an error saying some specificity "
-                "would be required on the container type.\n");
-            break;
-        default:
-            printf("Need an error here that the thing isn't a damn container.");
-            break;
+        // If there are two variables, we can infer that the container is
+        // a dictionary.
+        //
+        // Otherwise, if we have no info, it can be any set or list type.
+        //
+        // We never allow loops over tuples.
+
+        c4m_type_t *cinfo = NULL;
+
+        if (container_pnode->type == NULL) {
+            container_pnode->type = c4m_tspec_typevar();
+        }
+
+        cinfo = c4m_tspec_typevar();
+
+        if (li->lvar_2 != NULL) {
+            c4m_remove_list_options(cinfo);
+            c4m_remove_set_options(cinfo);
+            c4m_remove_tuple_options(cinfo);
+            c4m_merge_types(cinfo, container_pnode->type);
+        }
+        else {
+            cinfo = c4m_tspec_typevar();
+            c4m_remove_tuple_options(cinfo);
+            c4m_remove_dict_options(cinfo);
+            c4m_merge_types(container_pnode->type, cinfo);
         }
     }
-
-    // TODO: capture the data flows, not just the def/use order here.
 }
 
 static void
@@ -764,18 +1100,136 @@ handle_while(pass2_ctx *ctx)
 }
 
 static void
-handle_casing_statement(pass2_ctx *ctx)
+handle_range(pass2_ctx *ctx)
 {
+    process_children(ctx);
+    set_node_type(ctx->node,
+                  type_check_nodes(ctx->node->children[0],
+                                   ctx->node->children[1]));
+    c4m_merge_types(get_pnode_type(ctx->node), c4m_tspec_i64());
 }
 
 static void
+handle_casing_statement(pass2_ctx *ctx)
+{
+    process_children(ctx);
+}
+
+static void
+builtin_bincall(pass2_ctx *ctx)
+{
+    // Currently, this routine type checks based on the operation, and
+    // sets the expected return type.
+    //
+    // Here:
+    //
+    // 1. Comparison ops must have the same type, and the return type is
+    //    always bool.
+    //
+    // 2. All math ops take the same input type and returns the
+    //    same output type.
+    //
+    // 3. Eventually we will add a float div that is a special case,
+    //    but I'm still thinking about the syntax on that one, so it's
+    //    not implemented yet.
+    //
+    // Currently, we don't bother adding the call to the CFG, since in
+    // most cases this will be inlined, and not a real call.
+    //
+    // Once we add objects, we probably should add the call in for objects
+    // (TODO).
+
+    c4m_type_t    *tleft  = get_pnode_type(ctx->node->children[0]);
+    c4m_type_t    *tright = get_pnode_type(ctx->node->children[1]);
+    c4m_pnode_t   *pn     = get_pnode(ctx->node);
+    c4m_operator_t op     = (c4m_operator_t)pn->extra_info;
+
+    switch (op) {
+    case c4m_op_plus:
+    case c4m_op_minus:
+    case c4m_op_mul:
+    case c4m_op_mod:
+    case c4m_op_div:
+    case c4m_op_fdiv:
+    case c4m_op_shl:
+    case c4m_op_shr:
+    case c4m_op_bitand:
+    case c4m_op_bitor:
+    case c4m_op_bitxor:
+        set_node_type(ctx->node, c4m_merge_types(tleft, tright));
+        return;
+    case c4m_op_lt:
+    case c4m_op_lte:
+    case c4m_op_gt:
+    case c4m_op_gte:
+    case c4m_op_eq:
+    case c4m_op_neq:
+        c4m_merge_types(tleft, tright);
+        set_node_type(ctx->node, c4m_tspec_bool());
+        return;
+    default:
+        unreachable();
+    }
+}
+
+static void
+handle_binary_op(pass2_ctx *ctx)
+{
+    process_children(ctx);
+    builtin_bincall(ctx);
+}
+
+static void
+base_handle_assign(pass2_ctx *ctx, bool binop)
+{
+    c4m_tree_node_t *saved = ctx->node;
+
+    if (binop) {
+        ctx->node = saved->children[0];
+        // With binops, we process the LHS twice; once in a use context
+        // and once in a def context (below, after processing the RHS).
+        base_check_pass_dispatch(ctx);
+    }
+
+    ctx->node = saved->children[1];
+    start_data_flow(ctx);
+    base_check_pass_dispatch(ctx);
+
+    if (binop) {
+        ctx->node = saved;
+        builtin_bincall(ctx);
+    }
+
+    ctx->node = saved->children[0];
+
+    def_context_enter(ctx);
+    base_check_pass_dispatch(ctx);
+    def_use_context_exit(ctx);
+
+    if (!binop) {
+        c4m_merge_types(get_pnode_type(saved->children[0]),
+                        get_pnode_type(saved->children[1]));
+    }
+
+    ctx->node = saved;
+}
+
+static inline void
 handle_assign(pass2_ctx *ctx)
 {
+    base_handle_assign(ctx, false);
+}
+
+static inline void
+handle_binop_assign(pass2_ctx *ctx)
+{
+    base_handle_assign(ctx, true);
 }
 
 static void
 handle_section_decl(pass2_ctx *ctx)
 {
+    process_children(ctx);
 }
 
 static void
@@ -785,11 +1239,12 @@ handle_identifier(pass2_ctx *ctx)
     c4m_utf8_t  *id    = node_text(ctx->node);
 
     if (ctx->current_section_prefix != NULL) {
-        c4m_xlist_append(ctx->current_section_prefix, id);
+        id = c4m_cstr_format("{}.{}", ctx->current_section_prefix, id);
     }
-    else {
-        pnode->value = (void *)lookup_or_add(ctx, id);
-    }
+
+    c4m_scope_entry_t *sym = (void *)lookup_or_add(ctx, id);
+    pnode->value           = (void *)sym;
+    set_node_type(ctx->node, sym->type);
 }
 
 static void
@@ -809,6 +1264,21 @@ check_literal(pass2_ctx *ctx)
 static void
 handle_member(pass2_ctx *ctx)
 {
+    c4m_tree_node_t **kids     = ctx->node->children;
+    c4m_utf8_t       *sym_name = node_text(kids[0]);
+    c4m_utf8_t       *dot      = c4m_new_utf8(".");
+    c4m_pnode_t      *pnode    = get_pnode(ctx->node);
+
+    for (int i = 1; i < ctx->node->num_kids; i++) {
+        sym_name = c4m_str_concat(sym_name, dot);
+        sym_name = c4m_str_concat(sym_name, node_text(kids[i]));
+    }
+
+    if (ctx->current_section_prefix != NULL) {
+        sym_name = c4m_cstr_format("{}.{}", sym_name);
+    }
+
+    pnode->value = (void *)lookup_or_add(ctx, sym_name);
 }
 
 static void
@@ -839,13 +1309,9 @@ handle_cmp(pass2_ctx *ctx)
 }
 
 static void
-handle_binary_op(pass2_ctx *ctx)
-{
-}
-
-static void
 handle_unary_op(pass2_ctx *ctx)
 {
+    process_children(ctx);
 }
 
 static void
@@ -912,14 +1378,21 @@ base_check_pass_dispatch(pass2_ctx *ctx)
         handle_while(ctx);
         break;
 
+    case c4m_nt_range:
+        handle_range(ctx);
+        break;
+
     case c4m_nt_typeof:
     case c4m_nt_switch:
         handle_casing_statement(ctx);
         break;
 
     case c4m_nt_assign:
-    case c4m_nt_binary_assign_op:
         handle_assign(ctx);
+        break;
+
+    case c4m_nt_binary_assign_op:
+        handle_binop_assign(ctx);
         break;
 
     case c4m_nt_or:
@@ -992,8 +1465,9 @@ process_var_decls(pass2_ctx *ctx)
             c4m_tree_node_t   *tnode  = possible_assign->children[0];
             c4m_pnode_t       *tpnode = get_pnode(tnode);
 
-            add_def(ctx, sym);
+            start_data_flow(ctx);
             process_node(ctx, tnode);
+            add_def(ctx, sym, true);
 
             type_check_node_against_sym(ctx, tpnode, sym);
 
@@ -1054,7 +1528,7 @@ static void
 process_function_definitions(pass2_ctx *ctx)
 {
     for (int i = 0; i < c4m_xlist_len(ctx->func_nodes); i++) {
-        ctx->node                = c4m_xlist_get(ctx->func_nodes, 1, NULL);
+        ctx->node                = c4m_xlist_get(ctx->func_nodes, i, NULL);
         c4m_pnode_t       *pnode = c4m_tree_get_contents(ctx->node);
         c4m_scope_entry_t *sym   = (c4m_scope_entry_t *)pnode->value;
         ctx->local_scope         = pnode->static_scope;
@@ -1088,8 +1562,6 @@ module_check_pass(c4m_compile_ctx *cctx, c4m_file_compile_ctx *file_ctx)
         .loop_stack     = c4m_new(c4m_tspec_xlist(c4m_tspec_ref())),
         .deferred_calls = c4m_new(c4m_tspec_xlist(c4m_tspec_ref())),
     };
-
-    c4m_print_parse_node(file_ctx->parse_tree);
 
     check_module_toplevel(&ctx);
     process_function_definitions(&ctx);

--- a/src/con4m/frontend/check_pass.c
+++ b/src/con4m/frontend/check_pass.c
@@ -1,0 +1,344 @@
+#define C4M_USE_INTERNAL_API
+#include "con4m.h"
+
+typedef struct {
+    c4m_scope_t          *attr_scope;
+    c4m_scope_t          *global_scope;
+    c4m_spec_t           *spec;
+    c4m_compile_ctx      *compile;
+    c4m_file_compile_ctx *file_ctx;
+    __uint128_t           du_stack;
+    int                   du_stack_ix;
+    c4m_xlist_t          *errors;
+    // The above get initialized only once when we start processing a module.
+    // Everything below this comment gets updated for each function entry too.
+    c4m_scope_t          *local_scope;
+    c4m_tree_node_t      *node;
+    c4m_cfg_node_t       *cfg; // Current control-flow-graph node.
+    c4m_xlist_t          *func_nodes;
+    // Current fn decl object when in a fn. It's NULL in a module context.
+    c4m_fn_decl_t        *fn_decl;
+} pass2_ctx;
+
+static inline void
+def_context_enter(pass2_ctx *ctx)
+{
+    ctx->du_stack <<= 1;
+    ctx->du_stack |= 1;
+
+    if (++ctx->du_stack_ix == 128) {
+        C4M_CRAISE("Stack overflow in def/use tracker.");
+    }
+}
+
+static inline void
+def_use_context_exit(pass2_ctx *ctx)
+{
+    ctx->du_stack >>= 1;
+    ctx->du_stack_ix--;
+}
+
+static inline void
+use_context_enter(pass2_ctx *ctx)
+{
+    ctx->du_stack <<= 1;
+
+    if (++ctx->du_stack_ix == 128) {
+        C4M_CRAISE("Stack overflow in def/use tracker.");
+    }
+}
+
+static void
+process_children(pass2_ctx *ctx)
+{
+}
+
+static inline bool
+is_def_context(pass2_ctx *ctx)
+{
+    return (bool)ctx->du_stack & 0x1;
+}
+
+static void
+handle_index(pass2_ctx *ctx)
+{
+}
+
+static void
+handle_call(pass2_ctx *ctx)
+{
+}
+
+static void
+handle_label(pass2_ctx *ctx)
+{
+}
+
+static void
+handle_break(pass2_ctx *ctx)
+{
+}
+
+static void
+handle_continue(pass2_ctx *ctx)
+{
+}
+
+static void
+handle_for(pass2_ctx *ctx)
+{
+    process_children(ctx);
+}
+
+static void
+handle_while(pass2_ctx *ctx)
+{
+}
+
+static void
+handle_casing_statement(pass2_ctx *ctx)
+{
+}
+
+static void
+handle_assign(pass2_ctx *ctx)
+{
+}
+
+static void
+handle_enum_decl(pass2_ctx *ctx)
+{
+}
+
+static void
+handle_config_spec(pass2_ctx *ctx)
+{
+}
+
+static void
+handle_section_spec(pass2_ctx *ctx)
+{
+}
+
+static void
+handle_param_block(pass2_ctx *ctx)
+{
+}
+
+static void
+handle_extern_block(pass2_ctx *ctx)
+{
+}
+
+static void
+handle_use_stmt(pass2_ctx *ctx)
+{
+}
+
+static void
+handle_var_decl(pass2_ctx *ctx)
+{
+}
+
+static void
+handle_section_decl(pass2_ctx *ctx)
+{
+}
+
+static void
+handle_identifier(pass2_ctx *ctx)
+{
+}
+
+static void
+handle_literal(pass2_ctx *ctx)
+{
+}
+
+static void
+handle_member(pass2_ctx *ctx)
+{
+}
+
+static void
+pass_dispatch(pass2_ctx *ctx)
+{
+    c4m_pnode_t *pnode = c4m_tree_get_contents(ctx->node);
+
+    switch (pnode->kind) {
+    case c4m_nt_global_enum:
+    case c4m_nt_enum:
+        handle_enum_decl(ctx);
+        break;
+
+    case c4m_nt_func_def:
+        return;
+
+    case c4m_nt_variable_decls:
+        handle_var_decl(ctx);
+        break;
+
+    case c4m_nt_config_spec:
+        handle_config_spec(ctx);
+        break;
+
+    case c4m_nt_section_spec:
+        handle_section_spec(ctx);
+        break;
+
+    case c4m_nt_section:
+        handle_section_decl(ctx);
+        break;
+
+    case c4m_nt_param_block:
+        handle_param_block(ctx);
+        break;
+
+    case c4m_nt_extern_block:
+        handle_extern_block(ctx);
+        break;
+
+    case c4m_nt_use:
+        handle_use_stmt(ctx);
+        break;
+
+    case c4m_nt_identifier:
+        handle_identifier(ctx);
+        break;
+
+    case c4m_nt_member:
+        handle_member(ctx);
+        break;
+
+    case c4m_nt_simple_lit:
+    case c4m_nt_lit_list:
+    case c4m_nt_lit_dict:
+    case c4m_nt_lit_set:
+    case c4m_nt_lit_empty_dict_or_set:
+    case c4m_nt_lit_tuple:
+    case c4m_nt_lit_unquoted:
+    case c4m_nt_lit_callback:
+    case c4m_nt_lit_tspec:
+        handle_literal(ctx);
+        break;
+
+    case c4m_nt_index:
+        handle_index(ctx);
+        return;
+
+    case c4m_nt_call:
+        handle_call(ctx);
+        break;
+
+    case c4m_nt_label:
+        handle_label(ctx);
+        break;
+
+    case c4m_nt_break:
+        handle_break(ctx);
+        break;
+
+    case c4m_nt_continue:
+        handle_continue(ctx);
+        break;
+
+    case c4m_nt_for:
+        handle_for(ctx);
+        break;
+
+    case c4m_nt_while:
+        handle_while(ctx);
+        break;
+
+    case c4m_nt_typeof:
+    case c4m_nt_switch:
+        handle_casing_statement(ctx);
+        break;
+
+    case c4m_nt_assign:
+    case c4m_nt_binary_assign_op:
+        handle_assign(ctx);
+        return;
+
+    default:
+        process_children(ctx);
+        break;
+    }
+}
+
+static void
+check_pass_toplevel_dispatch(pass2_ctx *ctx)
+{
+}
+
+static void
+check_pass_fn_dispatch(pass2_ctx *ctx)
+{
+}
+
+static void
+check_module_toplevel(pass2_ctx *ctx)
+{
+    ctx->node          = ctx->file_ctx->parse_tree;
+    ctx->local_scope   = ctx->file_ctx->module_scope;
+    ctx->cfg           = c4m_cfg_enter_block(NULL, ctx->node);
+    ctx->file_ctx->cfg = ctx->cfg;
+    ctx->func_nodes    = c4m_new(c4m_tspec_xlist(c4m_tspec_ref()));
+
+    use_context_enter(ctx);
+    check_pass_toplevel_dispatch(ctx);
+    def_use_context_exit(ctx);
+    c4m_cfg_exit_block(ctx->cfg, ctx->file_ctx->parse_tree);
+}
+
+static void
+process_function_definitions(pass2_ctx *ctx)
+{
+    for (int i = 0; i < c4m_xlist_len(ctx->func_nodes); i++) {
+        ctx->node                = c4m_xlist_get(ctx->func_nodes, 1, NULL);
+        c4m_pnode_t       *pnode = c4m_tree_get_contents(ctx->node);
+        c4m_scope_entry_t *sym   = (c4m_scope_entry_t *)pnode->value;
+        ctx->local_scope         = pnode->static_scope;
+        ctx->cfg                 = c4m_cfg_enter_block(NULL, ctx->node);
+        ctx->fn_decl             = sym->value;
+        ctx->fn_decl->cfg        = ctx->cfg;
+
+        use_context_enter(ctx);
+        check_pass_fn_dispatch(ctx);
+        def_use_context_exit(ctx);
+        c4m_cfg_exit_block(ctx->cfg, ctx->node);
+    }
+}
+
+static void
+module_check_pass(c4m_compile_ctx *cctx, c4m_file_compile_ctx *file_ctx)
+{
+    // This should be checked before we get here, but belt and suspenders.
+    if (c4m_fatal_error_in_module(file_ctx)) {
+        return;
+    }
+
+    pass2_ctx ctx = {
+        .attr_scope   = cctx->final_attrs,
+        .global_scope = cctx->final_globals,
+        .spec         = cctx->final_spec,
+        .compile      = cctx,
+        .file_ctx     = file_ctx,
+        .du_stack     = 0,
+        .du_stack_ix  = 0,
+        .errors       = file_ctx->errors,
+    };
+
+    check_module_toplevel(&ctx);
+    process_function_definitions(&ctx);
+
+    return;
+}
+
+void
+c4m_check_pass(c4m_compile_ctx *cctx)
+{
+    for (int i = 0; i < c4m_xlist_len(cctx->module_ordering); i++) {
+        module_check_pass(cctx, c4m_xlist_get(cctx->module_ordering, i, NULL));
+    }
+}

--- a/src/con4m/frontend/check_pass.c
+++ b/src/con4m/frontend/check_pass.c
@@ -2,6 +2,35 @@
 #include "con4m.h"
 
 typedef struct {
+    c4m_utf8_t      *name;
+    c4m_type_t      *sig;
+    c4m_tree_node_t *loc;
+    // Return type of container for things like index operations,
+    // which will have to be checked later.
+    c4m_type_t      *container_ret;
+} call_resolution_info_t;
+
+typedef struct {
+    c4m_utf8_t        *label;
+    c4m_utf8_t        *label_ix;
+    c4m_utf8_t        *label_last;
+    c4m_tree_node_t   *prelude;
+    c4m_tree_node_t   *test;
+    c4m_tree_node_t   *body;
+    c4m_scope_entry_t *shadowed_ix;
+    c4m_scope_entry_t *loop_ix;
+    c4m_scope_entry_t *named_loop_ix;
+    c4m_scope_entry_t *shadowed_last;
+    c4m_scope_entry_t *loop_last;
+    c4m_scope_entry_t *named_loop_last;
+    c4m_scope_entry_t *lvar_1;
+    c4m_scope_entry_t *lvar_2;
+    c4m_scope_entry_t *shadowed_lvar_1;
+    c4m_scope_entry_t *shadowed_lvar_2;
+    bool               ranged;
+} c4m_loop_info_t;
+
+typedef struct {
     c4m_scope_t          *attr_scope;
     c4m_scope_t          *global_scope;
     c4m_spec_t           *spec;
@@ -9,7 +38,6 @@ typedef struct {
     c4m_file_compile_ctx *file_ctx;
     __uint128_t           du_stack;
     int                   du_stack_ix;
-    c4m_xlist_t          *errors;
     // The above get initialized only once when we start processing a module.
     // Everything below this comment gets updated for each function entry too.
     c4m_scope_t          *local_scope;
@@ -18,7 +46,111 @@ typedef struct {
     c4m_xlist_t          *func_nodes;
     // Current fn decl object when in a fn. It's NULL in a module context.
     c4m_fn_decl_t        *fn_decl;
+    c4m_xlist_t          *current_rhs_uses;
+    c4m_xlist_t          *current_section_prefix;
+    c4m_xlist_t          *loop_stack;
+    c4m_xlist_t          *deferred_calls;
 } pass2_ctx;
+
+static inline bool
+base_node_tcheck(c4m_pnode_t *pnode, c4m_type_t *type)
+{
+    return c4m_tspecs_are_compat(pnode->type, type);
+}
+
+static inline c4m_type_t *
+get_pnode_type(c4m_tree_node_t *node)
+{
+    c4m_pnode_t *pnode = get_pnode(node);
+    return pnode->type;
+}
+
+static void
+add_def(pass2_ctx *ctx, c4m_scope_entry_t *sym)
+{
+    ctx->cfg = c4m_cfg_add_def(ctx->cfg, ctx->node, sym, ctx->current_rhs_uses);
+
+    ctx->current_rhs_uses == NULL;
+}
+
+static void
+add_use(pass2_ctx *ctx, c4m_scope_entry_t *sym)
+{
+    ctx->cfg = c4m_cfg_add_use(ctx->cfg, ctx->node, sym);
+    if (ctx->current_rhs_uses) {
+        c4m_xlist_append(ctx->current_rhs_uses, sym);
+    }
+}
+
+static inline c4m_xlist_t *
+use_pattern(pass2_ctx *ctx, c4m_tpat_node_t *pat)
+{
+    return apply_pattern_on_node(ctx->node, pat);
+}
+
+static inline void
+type_check_node_against_sym(pass2_ctx         *ctx,
+                            c4m_pnode_t       *pnode,
+                            c4m_scope_entry_t *sym)
+{
+    if (pnode->type == NULL) {
+        pnode->type = c4m_tspec_typevar();
+    }
+
+    else {
+        if (c4m_tspec_is_error(pnode->type)) {
+            return; // Already errored for this node.
+        }
+    }
+
+    if (!c4m_tspec_is_error(sym->type)) {
+        if (base_node_tcheck(pnode, c4m_global_copy(sym->type))) {
+            return;
+        }
+        c4m_add_error(ctx->file_ctx,
+                      c4m_err_decl_mismatch,
+                      ctx->node,
+                      pnode->type,
+                      sym->type,
+                      c4m_node_get_loc_str(sym->declaration_node));
+    }
+    else {
+        if (base_node_tcheck(pnode, sym->type)) {
+            return;
+        }
+
+        c4m_add_error(ctx->file_ctx,
+                      c4m_err_inconsistent_type,
+                      ctx->node,
+                      pnode->type,
+                      sym->name,
+                      sym->type);
+
+        // Maybe make this an option; supress further type errors for
+        // this symbol.
+        sym->type = c4m_tspec_error();
+    }
+}
+
+static inline c4m_type_t *
+type_check_nodes(c4m_tree_node_t *n1, c4m_tree_node_t *n2)
+{
+    c4m_pnode_t *pnode1 = get_pnode(n1);
+    c4m_pnode_t *pnode2 = get_pnode(n2);
+
+    return c4m_merge_types(pnode1->type, pnode2->type);
+}
+
+static void base_check_pass_dispatch(pass2_ctx *);
+
+static inline void
+process_node(pass2_ctx *ctx, c4m_tree_node_t *n)
+{
+    c4m_tree_node_t *saved = ctx->node;
+    ctx->node              = n;
+    base_check_pass_dispatch(ctx);
+    ctx->node = saved;
+}
 
 static inline void
 def_context_enter(pass2_ctx *ctx)
@@ -51,6 +183,40 @@ use_context_enter(pass2_ctx *ctx)
 static void
 process_children(pass2_ctx *ctx)
 {
+    c4m_tree_node_t *saved = ctx->node;
+    int              n     = saved->num_kids;
+
+    for (int i = 0; i < n; i++) {
+        ctx->node = saved->children[i];
+        base_check_pass_dispatch(ctx);
+    }
+
+    // Handle propogations automatically for unary nodes.
+    // binary nodes are on their own.
+    if (n == 1) {
+        c4m_pnode_t *my_pnode  = get_pnode(saved);
+        c4m_pnode_t *kid_pnode = get_pnode(saved->children[0]);
+
+        my_pnode->value = kid_pnode->value;
+        my_pnode->type  = kid_pnode->type;
+    }
+
+    ctx->node = saved;
+}
+
+static inline int
+num_children(pass2_ctx *ctx)
+{
+    return ctx->node->num_kids;
+}
+
+static inline void
+process_child(pass2_ctx *ctx, int i)
+{
+    c4m_tree_node_t *saved = ctx->node;
+    ctx->node              = saved->children[i];
+    base_check_pass_dispatch(ctx);
+    ctx->node = saved;
 }
 
 static inline bool
@@ -59,9 +225,122 @@ is_def_context(pass2_ctx *ctx)
     return (bool)ctx->du_stack & 0x1;
 }
 
+static c4m_scope_entry_t *
+sym_lookup(pass2_ctx *ctx, c4m_utf8_t *name, bool add_du)
+{
+    c4m_scope_entry_t *result;
+
+    result = c4m_symbol_lookup(ctx->local_scope,
+                               ctx->file_ctx->module_scope,
+                               ctx->global_scope,
+                               ctx->attr_scope,
+                               name);
+
+    if (!result || !add_du) {
+        return NULL;
+    }
+
+    if (is_def_context(ctx)) {
+        add_def(ctx, result);
+    }
+    else {
+        add_use(ctx, result);
+    }
+
+    return result;
+}
+
+static c4m_scope_entry_t *
+lookup_or_add(pass2_ctx *ctx, c4m_utf8_t *name)
+{
+    c4m_scope_entry_t *result = sym_lookup(ctx, name, true);
+    if (result) {
+        return result;
+    }
+    result = c4m_add_inferred_symbol(ctx->file_ctx,
+                                     ctx->local_scope,
+                                     name);
+
+    if (is_def_context(ctx)) {
+        add_def(ctx, result);
+    }
+    else {
+        add_use(ctx, result);
+    }
+
+    return result;
+}
+
 static void
 handle_index(pass2_ctx *ctx)
 {
+    c4m_pnode_t *pnode     = get_pnode(ctx->node);
+    int          num_kids  = num_children(ctx);
+    c4m_type_t  *node_type = c4m_tspec_typevar();
+    c4m_type_t  *container_type;
+    c4m_type_t  *ix1_type;
+    c4m_type_t  *ix2_type;
+
+    assert(pnode->type == NULL);
+
+    process_child(ctx, 0);
+    container_type = get_pnode_type(ctx->node->children[0]);
+    use_context_enter(ctx);
+    process_child(ctx, 1);
+    ix1_type = get_pnode_type(ctx->node->children[1]);
+
+    if (!c4m_tspec_is_int_type(ix1_type)) {
+        if (!c4m_tspec_is_tvar(ix1_type)) {
+            c4m_type_t *tmp = c4m_tspec_dict(ix1_type, c4m_tspec_typevar());
+            container_type  = c4m_merge_types(tmp, container_type);
+
+            if (num_kids == 3) {
+                // TODO: error: Slice not allowed on dicts.
+                return;
+            }
+        }
+    }
+
+    call_resolution_info_t *info = c4m_gc_alloc(call_resolution_info_t);
+
+    if (num_kids == 3) {
+        process_child(ctx, 2);
+        ix2_type = get_pnode_type(ctx->node->children[2]);
+
+        if (!c4m_tspec_is_int_type(ix2_type) && !c4m_tspec_is_tvar(ix2_type)) {
+            // Error: slice requires int indicies.
+        }
+
+        if (c4m_tspec_is_tvar(ix1_type)) {
+            c4m_merge_types(ix1_type, c4m_tspec_i32());
+        }
+
+        if (c4m_tspec_is_tvar(ix1_type)) {
+            c4m_merge_types(ix1_type, c4m_tspec_i32());
+        }
+
+        info->name          = c4m_new_utf8("__slice__");
+        info->loc           = ctx->node;
+        info->container_ret = node_type;
+        info->sig           = c4m_tspec_fn_va(info->container_ret,
+                                    3,
+                                    container_type,
+                                    ix1_type,
+                                    ix2_type);
+    }
+    else {
+        info->name          = c4m_new_utf8("__index__");
+        info->loc           = ctx->node;
+        info->container_ret = node_type;
+        info->sig           = c4m_tspec_fn_va(info->container_ret,
+                                    2,
+                                    container_type,
+                                    ix1_type);
+    }
+
+    c4m_xlist_append(ctx->deferred_calls, info);
+
+    def_use_context_exit(ctx);
 }
 
 static void
@@ -70,29 +349,418 @@ handle_call(pass2_ctx *ctx)
 }
 
 static void
-handle_label(pass2_ctx *ctx)
-{
-}
-
-static void
 handle_break(pass2_ctx *ctx)
 {
+    c4m_tree_node_t *n     = ctx->node;
+    c4m_utf8_t      *label = NULL;
+
+    if (c4m_tree_get_number_children(n) != 0) {
+        label = node_text(n->children[0]);
+    }
+
+    ctx->cfg = c4m_cfg_add_break(ctx->cfg, n, label);
+    int i    = c4m_xlist_len(ctx->loop_stack);
+
+    while (i--) {
+        c4m_loop_info_t *li = c4m_xlist_get(ctx->loop_stack, i, NULL);
+        if (!label || (li->label && !strcmp(label->data, li->label->data))) {
+            c4m_pnode_t *npnode = get_pnode(n);
+            npnode->extra_info  = li;
+            return;
+        }
+    }
+
+    c4m_add_error(ctx->file_ctx,
+                  c4m_err_label_target,
+                  n,
+                  label,
+                  c4m_new_utf8("break"));
 }
 
 static void
 handle_continue(pass2_ctx *ctx)
 {
+    c4m_tree_node_t *n     = ctx->node;
+    c4m_utf8_t      *label = NULL;
+
+    if (c4m_tree_get_number_children(n) != 0) {
+        label = node_text(n->children[0]);
+    }
+
+    ctx->cfg = c4m_cfg_add_continue(ctx->cfg, n, label);
+    int i    = c4m_xlist_len(ctx->loop_stack);
+
+    while (i--) {
+        c4m_loop_info_t *li = c4m_xlist_get(ctx->loop_stack, i, NULL);
+        if (!label || (li->label && !strcmp(label->data, li->label->data))) {
+            c4m_pnode_t *npnode = get_pnode(n);
+            npnode->extra_info  = li;
+            return;
+        }
+    }
+
+    c4m_add_error(ctx->file_ctx,
+                  c4m_err_label_target,
+                  n,
+                  label,
+                  c4m_new_utf8("continue"));
+}
+
+static c4m_utf8_t *ix_var_name   = NULL;
+static c4m_utf8_t *last_var_name = NULL;
+
+static void
+loop_push_ix_var(pass2_ctx *ctx, c4m_loop_info_t *li)
+{
+    if (ix_var_name == NULL) {
+        ix_var_name   = c4m_new_utf8("$i");
+        last_var_name = c4m_new_utf8("$last");
+        c4m_gc_register_root(&ix_var_name, 1);
+    }
+
+    li->shadowed_ix = c4m_symbol_lookup(ctx->local_scope,
+                                        NULL,
+                                        NULL,
+                                        NULL,
+                                        ix_var_name);
+    li->loop_ix     = c4m_add_or_replace_symbol(ctx->file_ctx,
+                                            ctx->local_scope,
+                                            ix_var_name);
+
+    li->loop_ix->flags = C4M_F_ALL_SYM_FLAGS;
+    li->loop_ix->type  = c4m_tspec_u32();
+
+    add_def(ctx, li->loop_ix);
+
+    if (li->label != NULL) {
+        li->label_ix = c4m_str_concat(li->label, ix_var_name);
+
+        if (c4m_symbol_lookup(ctx->local_scope,
+                              NULL,
+                              NULL,
+                              NULL,
+                              li->label_ix)) {
+            // TODO: error, dupe loop label.
+            return;
+        }
+
+        li->named_loop_ix        = c4m_add_inferred_symbol(ctx->file_ctx,
+                                                    ctx->local_scope,
+                                                    li->label_ix);
+        li->named_loop_ix->flags = C4M_F_ALL_SYM_FLAGS;
+        li->named_loop_ix->type  = c4m_tspec_u32();
+
+        add_def(ctx, li->named_loop_ix);
+    }
+}
+
+static void
+loop_pop_ix_var(pass2_ctx *ctx, c4m_loop_info_t *li)
+{
+    hatrack_dict_remove(ctx->local_scope->symbols, ix_var_name);
+
+    if (li->label_ix != NULL) {
+        hatrack_dict_remove(ctx->local_scope->symbols, li->label_ix);
+    }
+
+    if (li->shadowed_ix != NULL) {
+        hatrack_dict_put(ctx->local_scope->symbols,
+                         ix_var_name,
+                         li->shadowed_ix);
+    }
 }
 
 static void
 handle_for(pass2_ctx *ctx)
 {
-    process_children(ctx);
+    c4m_loop_info_t *li    = c4m_gc_alloc(c4m_loop_info_t);
+    c4m_pnode_t     *pnode = get_pnode(ctx->node);
+    c4m_tree_node_t *n     = ctx->node;
+    c4m_xlist_t     *vars  = use_pattern(ctx, c4m_loop_vars);
+    c4m_cfg_node_t  *entrance;
+    c4m_cfg_node_t  *branch;
+    int              expr_ix = 0;
+
+    li->ranged = pnode->extra_info == NULL;
+
+    pnode->extra_info = li;
+
+    if (node_has_type(n->children[0], c4m_nt_label)) {
+        expr_ix++;
+        li->label = node_text(n->children[0]);
+    }
+
+    c4m_xlist_append(ctx->loop_stack, li);
+
+    // First, process either the container to unpack or the range
+    // expressions. We do this before the CFG entrance node, as when
+    // this isn't already a literal, we only want to do it once before
+    // we loop.
+
+    ctx->node                    = n->children[expr_ix + 1];
+    c4m_pnode_t *container_pnode = get_pnode(ctx->node);
+    base_check_pass_dispatch(ctx);
+
+    // Now we start the loop's CFG block. The flow graph will evaluate
+    // this part every time we get back to the top of the loop.  We
+    // actually skip adding a 'use' here for the container (as if we
+    // just moved the contents to a temporary). Instead, we need to
+    // add defs for any iteration variables after we start the block,
+    // but before we branch.
+
+    entrance = c4m_cfg_enter_block(ctx->cfg, n);
+    ctx->cfg = entrance;
+
+    // At this point, set up the iteration variables...  `push_ix_var`
+    // sets up `$i` and `label$i` (if a label is provided), so that
+    // code in the block below can reference it.
+    //
+    // We manually set up `$last`, which is only available in for
+    // loops. It's set to the last iteration number we'll do if
+    // there's no early exit. So when `$i == $last`, you are on the
+    // last iteration of the loop.
+    //
+    // If used, `$i` gets updated each iteration with the number of
+    // iterations through the loop that have successfully
+    // completed. The lifetime of this variable is only the lifetime
+    // of the loop; you cannot use it outside the loop.
+    //
+    // `$last` also cannot be used outside the loop. And it is not
+    // reevaluated each loop, just once when starting the loop.
+    //
+    // If the variable isn't referenced, we'll just ignore the symbol
+    // later.
+    //
+    // Note that we also track here when loops are nested, so that if
+    // $i is used when nested, we can give a warning. But we only give
+    // that warning if we see a use of $i once there is definitely
+    // nesting.
+    //
+    // It might be worth making that an error, since the alternative
+    // is still available: add a label and use `label$i` or `label$last`
+    //
+    // Additionally, I'm thinking about disallowing `$` in all
+    // user-defined symbols.
+
+    loop_push_ix_var(ctx, li);
+
+    li->shadowed_last = c4m_symbol_lookup(ctx->local_scope,
+                                          NULL,
+                                          NULL,
+                                          NULL,
+                                          last_var_name);
+
+    li->loop_last        = c4m_add_or_replace_symbol(ctx->file_ctx,
+                                              ctx->local_scope,
+                                              last_var_name);
+    li->loop_last->flags = C4M_F_ALL_SYM_FLAGS;
+    li->loop_last->type  = c4m_tspec_u32();
+
+    add_def(ctx, li->loop_last);
+
+    if (li->label != NULL) {
+        li->label_last             = c4m_to_utf8(c4m_str_concat(li->label,
+                                                    last_var_name));
+        li->named_loop_last        = c4m_add_inferred_symbol(ctx->file_ctx,
+                                                      ctx->local_scope,
+                                                      li->label_last);
+        li->named_loop_last->flags = C4M_F_ALL_SYM_FLAGS;
+        li->named_loop_last->type  = c4m_tspec_u32();
+
+        add_def(ctx, li->named_loop_last);
+    }
+
+    // Now, process the assignment of the variable(s) to put per-loop
+    // values into.  Instead of keeping nested scopes, if we see
+    // shadowing, we will stash the old symbol until the loop's
+    // done. We also will warn about the shadowing.
+
+    c4m_tree_node_t *var_node1 = c4m_xlist_get(vars, 0, NULL);
+    c4m_tree_node_t *var_node2;
+    c4m_utf8_t      *var1_name = node_text(var_node1);
+    c4m_utf8_t      *var2_name = NULL;
+
+    if (c4m_xlist_len(vars) == 2) {
+        var_node2 = c4m_xlist_get(vars, 1, NULL);
+        var2_name = node_text(var_node2);
+
+        if (!strcmp(var1_name->data, var2_name->data)) {
+            printf("TODO: Add an ERROR here for the name collision.\n");
+        }
+    }
+
+    li->shadowed_lvar_1          = c4m_symbol_lookup(ctx->local_scope,
+                                            NULL,
+                                            NULL,
+                                            NULL,
+                                            var1_name);
+    li->lvar_1                   = c4m_add_or_replace_symbol(ctx->file_ctx,
+                                           ctx->local_scope,
+                                           var1_name);
+    li->lvar_1->flags            = C4M_F_ALL_SYM_FLAGS;
+    li->lvar_1->declaration_node = var_node1;
+
+    if (li->shadowed_lvar_1 != NULL) {
+        // TODO: Warn about the shadowing.:
+    }
+
+    add_def(ctx, li->lvar_1);
+
+    if (var2_name) {
+        li->shadowed_lvar_2          = c4m_symbol_lookup(ctx->local_scope,
+                                                NULL,
+                                                NULL,
+                                                NULL,
+                                                var2_name);
+        li->lvar_2                   = c4m_add_or_replace_symbol(ctx->file_ctx,
+                                               ctx->local_scope,
+                                               var2_name);
+        li->lvar_2->flags            = C4M_F_ALL_SYM_FLAGS;
+        li->lvar_2->declaration_node = var_node2;
+
+        if (li->shadowed_lvar_2 != NULL) {
+            // TODO: Warn about the shadowing.
+        }
+
+        add_def(ctx, li->lvar_2);
+    }
+
+    // Okay, now we need to add the branch node to the CFG.
+
+    branch   = c4m_cfg_block_new_branch_node(ctx->cfg, 2, li->label, ctx->node);
+    ctx->cfg = c4m_cfg_enter_block(branch, n->children[expr_ix]);
+
+    branch->contents.branches.branch_targets[0] = ctx->cfg;
+
+    // Now, process that body. The body gets its own block in the CFG,
+    // which makes this a bit clunkier than it needs to be.
+    expr_ix += 2;
+    ctx->node = n->children[expr_ix];
+
+    base_check_pass_dispatch(ctx);
+    c4m_cfg_exit_block(ctx->cfg, n);
+    c4m_cfg_node_t *tmp = c4m_cfg_enter_block(branch, n->children[expr_ix]);
+
+    // This sets up an empty block for the code that runs when the
+    // loop condition is false.
+    branch->contents.branches.branch_targets[1] = tmp;
+    c4m_cfg_exit_block(tmp, n);
+    ctx->cfg = entrance->contents.block_entrance.exit_node;
+
+    // Here, it's time to clean up. We need to reset the tree and the
+    // loop stack, and remove our iteration variable(s) from the
+    // scope.  Plus, if any variables were shadowed, we need to
+    // restore them.
+
+    c4m_xlist_pop(ctx->loop_stack);
+    ctx->node = n;
+
+    loop_pop_ix_var(ctx, li);
+
+    hatrack_dict_remove(ctx->local_scope->symbols, last_var_name);
+
+    if (li->label_last != NULL) {
+        hatrack_dict_remove(ctx->local_scope->symbols, li->label_last);
+    }
+
+    if (li->shadowed_last != NULL) {
+        hatrack_dict_put(ctx->local_scope->symbols,
+                         last_var_name,
+                         li->shadowed_last);
+    }
+    if (li->shadowed_lvar_1 != NULL) {
+        hatrack_dict_put(ctx->local_scope->symbols,
+                         var1_name,
+                         li->shadowed_lvar_1);
+    }
+    if (li->shadowed_lvar_2 != NULL) {
+        hatrack_dict_put(ctx->local_scope->symbols,
+                         var2_name,
+                         li->shadowed_lvar_2);
+    }
+
+    // Finally, do type checking based on the type of loop. The type
+    // will always be contained in the second non-label subtree of the
+    // loop node. We stashed that above as `container_pnode`.
+    //
+    // If there are two variables, we can infer that the container is
+    // a dictionary, and compare. Otherwise, if the inferred type
+    // isn't a container type, then we give an error.
+
+    if (li->lvar_2 != NULL) {
+        c4m_merge_types(c4m_tspec_dict(li->lvar_1->type, li->lvar_2->type),
+                        container_pnode->type);
+    }
+    else {
+        switch (c4m_tspec_get_base(container_pnode->type)) {
+        case C4M_DT_KIND_list:
+            c4m_merge_types(li->lvar_1->type,
+                            c4m_tspec_get_param(container_pnode->type, 0));
+            break;
+        case C4M_DT_KIND_dict:
+            if (c4m_tspec_get_num_params(container_pnode->type) == 1) {
+                c4m_merge_types(li->lvar_1->type,
+                                c4m_tspec_get_param(container_pnode->type, 0));
+            }
+            else {
+                printf("Need an error for dictionary not allowed...\n");
+            }
+            break;
+        case C4M_DT_KIND_type_var:
+            printf(
+                "For now, need an error saying some specificity "
+                "would be required on the container type.\n");
+            break;
+        default:
+            printf("Need an error here that the thing isn't a damn container.");
+            break;
+        }
+    }
+
+    // TODO: capture the data flows, not just the def/use order here.
 }
 
 static void
 handle_while(pass2_ctx *ctx)
 {
+    int              expr_ix = 0;
+    c4m_tree_node_t *n       = ctx->node;
+    c4m_pnode_t     *p       = get_pnode(n);
+    c4m_loop_info_t *li      = c4m_gc_alloc(c4m_loop_info_t);
+    c4m_cfg_node_t  *entrance;
+    c4m_cfg_node_t  *branch;
+
+    p->extra_info = li;
+    c4m_xlist_append(ctx->loop_stack, li);
+
+    if (node_has_type(n->children[0], c4m_nt_label)) {
+        expr_ix++;
+        li->label = node_text(n->children[0]);
+    }
+
+    loop_push_ix_var(ctx, li);
+
+    entrance  = c4m_cfg_enter_block(ctx->cfg, n);
+    ctx->cfg  = entrance;
+    ctx->node = n->children[expr_ix++];
+    base_check_pass_dispatch(ctx);
+    branch   = c4m_cfg_block_new_branch_node(ctx->cfg, 2, li->label, ctx->node);
+    ctx->cfg = c4m_cfg_enter_block(branch, n->children[expr_ix]);
+
+    branch->contents.branches.branch_targets[0] = ctx->cfg;
+    ctx->node                                   = n->children[expr_ix];
+
+    base_check_pass_dispatch(ctx);
+    c4m_cfg_exit_block(ctx->cfg, n);
+    c4m_cfg_node_t *tmp = c4m_cfg_enter_block(branch, n->children[expr_ix]);
+
+    branch->contents.branches.branch_targets[1] = tmp;
+    c4m_cfg_exit_block(tmp, n);
+    ctx->cfg = entrance->contents.block_entrance.exit_node;
+
+    c4m_xlist_pop(ctx->loop_stack);
+    ctx->node = n;
+    loop_pop_ix_var(ctx, li);
 }
 
 static void
@@ -106,41 +774,6 @@ handle_assign(pass2_ctx *ctx)
 }
 
 static void
-handle_enum_decl(pass2_ctx *ctx)
-{
-}
-
-static void
-handle_config_spec(pass2_ctx *ctx)
-{
-}
-
-static void
-handle_section_spec(pass2_ctx *ctx)
-{
-}
-
-static void
-handle_param_block(pass2_ctx *ctx)
-{
-}
-
-static void
-handle_extern_block(pass2_ctx *ctx)
-{
-}
-
-static void
-handle_use_stmt(pass2_ctx *ctx)
-{
-}
-
-static void
-handle_var_decl(pass2_ctx *ctx)
-{
-}
-
-static void
 handle_section_decl(pass2_ctx *ctx)
 {
 }
@@ -148,11 +781,29 @@ handle_section_decl(pass2_ctx *ctx)
 static void
 handle_identifier(pass2_ctx *ctx)
 {
+    c4m_pnode_t *pnode = get_pnode(ctx->node);
+    c4m_utf8_t  *id    = node_text(ctx->node);
+
+    if (ctx->current_section_prefix != NULL) {
+        c4m_xlist_append(ctx->current_section_prefix, id);
+    }
+    else {
+        pnode->value = (void *)lookup_or_add(ctx, id);
+    }
 }
 
 static void
-handle_literal(pass2_ctx *ctx)
+check_literal(pass2_ctx *ctx)
 {
+    // Right now, we don't try to fold sub-items.
+    c4m_pnode_t *pnode = get_pnode(ctx->node);
+
+    if (!c4m_is_partial_lit(pnode->value)) {
+        pnode->type = c4m_get_my_type(pnode->value);
+    }
+    else {
+        pnode->type = ((c4m_partial_lit_t *)pnode->value)->type;
+    }
 }
 
 static void
@@ -161,45 +812,60 @@ handle_member(pass2_ctx *ctx)
 }
 
 static void
-pass_dispatch(pass2_ctx *ctx)
+handle_binary_logical_op(pass2_ctx *ctx)
+{
+    c4m_type_t  *btype = c4m_tspec_bool();
+    c4m_pnode_t *kid1  = get_pnode(ctx->node->children[0]);
+    c4m_pnode_t *kid2  = get_pnode(ctx->node->children[1]);
+    c4m_pnode_t *pn    = get_pnode(ctx->node);
+
+    process_children(ctx);
+    if (!(base_node_tcheck(kid1, btype) && base_node_tcheck(kid2, btype))) {
+        pn->type = btype;
+    }
+    else {
+        pn->type = c4m_tspec_error();
+    }
+}
+
+static void
+handle_cmp(pass2_ctx *ctx)
+{
+    c4m_tree_node_t *tn = ctx->node;
+    c4m_pnode_t     *pn = get_pnode(tn);
+
+    process_children(ctx);
+    pn->type = type_check_nodes(tn->children[0], tn->children[1]);
+}
+
+static void
+handle_binary_op(pass2_ctx *ctx)
+{
+}
+
+static void
+handle_unary_op(pass2_ctx *ctx)
+{
+}
+
+static void
+base_check_pass_dispatch(pass2_ctx *ctx)
 {
     c4m_pnode_t *pnode = c4m_tree_get_contents(ctx->node);
 
     switch (pnode->kind) {
     case c4m_nt_global_enum:
     case c4m_nt_enum:
-        handle_enum_decl(ctx);
-        break;
-
     case c4m_nt_func_def:
-        return;
-
     case c4m_nt_variable_decls:
-        handle_var_decl(ctx);
-        break;
-
     case c4m_nt_config_spec:
-        handle_config_spec(ctx);
-        break;
-
     case c4m_nt_section_spec:
-        handle_section_spec(ctx);
-        break;
-
+    case c4m_nt_param_block:
+    case c4m_nt_extern_block:
+    case c4m_nt_use:
+        return;
     case c4m_nt_section:
         handle_section_decl(ctx);
-        break;
-
-    case c4m_nt_param_block:
-        handle_param_block(ctx);
-        break;
-
-    case c4m_nt_extern_block:
-        handle_extern_block(ctx);
-        break;
-
-    case c4m_nt_use:
-        handle_use_stmt(ctx);
         break;
 
     case c4m_nt_identifier:
@@ -219,7 +885,7 @@ pass_dispatch(pass2_ctx *ctx)
     case c4m_nt_lit_unquoted:
     case c4m_nt_lit_callback:
     case c4m_nt_lit_tspec:
-        handle_literal(ctx);
+        check_literal(ctx);
         break;
 
     case c4m_nt_index:
@@ -228,10 +894,6 @@ pass_dispatch(pass2_ctx *ctx)
 
     case c4m_nt_call:
         handle_call(ctx);
-        break;
-
-    case c4m_nt_label:
-        handle_label(ctx);
         break;
 
     case c4m_nt_break:
@@ -258,17 +920,114 @@ pass_dispatch(pass2_ctx *ctx)
     case c4m_nt_assign:
     case c4m_nt_binary_assign_op:
         handle_assign(ctx);
-        return;
+        break;
+
+    case c4m_nt_or:
+    case c4m_nt_and:
+        handle_binary_logical_op(ctx);
+        break;
+
+    case c4m_nt_cmp:
+        handle_cmp(ctx);
+        break;
+
+    case c4m_nt_binary_op:
+        handle_binary_op(ctx);
+        break;
+
+    case c4m_nt_unary_op:
+        handle_unary_op(ctx);
+        break;
 
     default:
         process_children(ctx);
         break;
+    }
+
+    if (pnode->type == NULL) {
+        pnode->type = c4m_tspec_typevar();
+    }
+}
+
+static void check_pass_toplevel_dispatch(pass2_ctx *);
+
+static inline void
+process_toplevel_children(pass2_ctx *ctx)
+{
+    c4m_tree_node_t *saved = ctx->node;
+    int              n     = saved->num_kids;
+
+    for (int i = 0; i < n; i++) {
+        ctx->node = saved->children[i];
+        check_pass_toplevel_dispatch(ctx);
+    }
+
+    ctx->node = saved;
+}
+
+static void
+process_var_decls(pass2_ctx *ctx)
+{
+    c4m_tree_node_t  *cur  = ctx->node;
+    int               num  = cur->num_kids;
+    c4m_tree_node_t **kids = cur->children;
+
+    for (int i = 1; i < num; i++) {
+        c4m_tree_node_t *decl_node       = kids[i];
+        int              last            = decl_node->num_kids - 1;
+        c4m_tree_node_t *possible_assign = decl_node->children[last];
+        c4m_pnode_t     *pnode           = get_pnode(possible_assign);
+
+        if (pnode->kind == c4m_nt_assign) {
+            ctx->node                 = possible_assign;
+            c4m_tree_node_t *var_node = decl_node->children[--last];
+            c4m_pnode_t     *vpnode   = get_pnode(var_node);
+
+            if (vpnode->kind != c4m_nt_identifier && last) {
+                var_node = decl_node->children[last - 1];
+                vpnode   = get_pnode(var_node);
+            }
+
+            c4m_scope_entry_t *sym    = (c4m_scope_entry_t *)vpnode->value;
+            c4m_tree_node_t   *tnode  = possible_assign->children[0];
+            c4m_pnode_t       *tpnode = get_pnode(tnode);
+
+            add_def(ctx, sym);
+            process_node(ctx, tnode);
+
+            type_check_node_against_sym(ctx, tpnode, sym);
+
+            ctx->node = cur;
+        }
     }
 }
 
 static void
 check_pass_toplevel_dispatch(pass2_ctx *ctx)
 {
+    c4m_pnode_t *pnode = c4m_tree_get_contents(ctx->node);
+
+    switch (pnode->kind) {
+    case c4m_nt_module:
+        process_toplevel_children(ctx);
+        return;
+    case c4m_nt_variable_decls:
+        process_var_decls(ctx);
+        return;
+    case c4m_nt_func_def:
+        c4m_xlist_append(ctx->func_nodes, ctx->node);
+        return;
+    case c4m_nt_enum:
+    case c4m_nt_global_enum:
+    case c4m_nt_param_block:
+    case c4m_nt_extern_block:
+    case c4m_nt_use:
+        // Absolutely 0 to do for these until we generate code.
+        return;
+    default:
+        base_check_pass_dispatch(ctx);
+        return;
+    }
 }
 
 static void
@@ -288,7 +1047,7 @@ check_module_toplevel(pass2_ctx *ctx)
     use_context_enter(ctx);
     check_pass_toplevel_dispatch(ctx);
     def_use_context_exit(ctx);
-    c4m_cfg_exit_block(ctx->cfg, ctx->file_ctx->parse_tree);
+    // c4m_cfg_exit_block(ctx->cfg, ctx->file_ctx->parse_tree);
 }
 
 static void
@@ -319,15 +1078,18 @@ module_check_pass(c4m_compile_ctx *cctx, c4m_file_compile_ctx *file_ctx)
     }
 
     pass2_ctx ctx = {
-        .attr_scope   = cctx->final_attrs,
-        .global_scope = cctx->final_globals,
-        .spec         = cctx->final_spec,
-        .compile      = cctx,
-        .file_ctx     = file_ctx,
-        .du_stack     = 0,
-        .du_stack_ix  = 0,
-        .errors       = file_ctx->errors,
+        .attr_scope     = cctx->final_attrs,
+        .global_scope   = cctx->final_globals,
+        .spec           = cctx->final_spec,
+        .compile        = cctx,
+        .file_ctx       = file_ctx,
+        .du_stack       = 0,
+        .du_stack_ix    = 0,
+        .loop_stack     = c4m_new(c4m_tspec_xlist(c4m_tspec_ref())),
+        .deferred_calls = c4m_new(c4m_tspec_xlist(c4m_tspec_ref())),
     };
+
+    c4m_print_parse_node(file_ctx->parse_tree);
 
     check_module_toplevel(&ctx);
     process_function_definitions(&ctx);

--- a/src/con4m/frontend/compile.c
+++ b/src/con4m/frontend/compile.c
@@ -831,6 +831,7 @@ merge_one_plain_scope(c4m_compile_ctx      *cctx,
                                    NULL);
         if (c4m_merge_symbols(fctx, new_sym, old_sym)) {
             hatrack_dict_put(global->symbols, new_sym->name, old_sym);
+            new_sym->linked_symbol = old_sym;
         }
     }
 }

--- a/src/con4m/frontend/compile.c
+++ b/src/con4m/frontend/compile.c
@@ -965,5 +965,7 @@ c4m_compile_from_entry_point(c4m_str_t *location)
         return result;
     }
 
+    c4m_check_pass(result);
+
     return result;
 }

--- a/src/con4m/frontend/decl_pass.c
+++ b/src/con4m/frontend/decl_pass.c
@@ -464,6 +464,7 @@ handle_param_block(pass1_ctx *ctx)
     c4m_pnode_t             *pnode     = get_pnode(root);
     c4m_tree_node_t         *name_node = c4m_tree_get_child(root, 0);
     c4m_utf8_t              *sym_name  = node_text(name_node);
+    c4m_utf8_t              *dot       = c4m_new_utf8(".");
     int                      nkids     = c4m_tree_get_number_children(root);
     c4m_scope_entry_t       *sym;
     bool                     attr;
@@ -481,7 +482,7 @@ handle_param_block(pass1_ctx *ctx)
         int num_members = c4m_tree_get_number_children(name_node);
 
         for (int i = 1; i < num_members; i++) {
-            sym_name = c4m_str_concat(sym_name, c4m_new_utf8("."));
+            sym_name = c4m_str_concat(sym_name, dot);
             sym_name = c4m_str_concat(sym_name,
                                       node_text(
                                           c4m_tree_get_child(name_node, i)));
@@ -973,7 +974,7 @@ extract_fn_sig_info(pass1_ctx       *ctx,
     c4m_tree_node_t *retnode = get_match_on_node(tree, c4m_return_extract);
 
     if (!retnode) {
-        info->return_info.type = c4m_tspec_void();
+        info->return_info.type = c4m_tspec_typevar();
     }
     else {
         info->return_info.type = c4m_node_to_type(ctx->file_ctx,

--- a/src/con4m/frontend/decl_pass.c
+++ b/src/con4m/frontend/decl_pass.c
@@ -422,7 +422,7 @@ handle_var_decl(pass1_ctx *ctx)
                     c4m_pnode_t *initpn   = get_pnode(init);
                     c4m_type_t  *inf_type = c4m_get_my_type(initpn->value);
 
-                    if (!is_partial_type(inf_type)) {
+                    if (!c4m_is_partial_type(inf_type)) {
                         sym->value = initpn->value;
                         sym->type  = inf_type;
                     }

--- a/src/con4m/frontend/decl_pass.c
+++ b/src/con4m/frontend/decl_pass.c
@@ -305,6 +305,9 @@ handle_enum_decl(pass1_ctx *ctx)
                                                   sk_enum_val,
                                                   NULL,
                                                   true);
+
+        item_sym->flags |= C4M_F_DECLARED_CONST;
+
         if (idsym) {
             item_sym->type = idsym->type;
         }
@@ -324,7 +327,7 @@ handle_enum_decl(pass1_ctx *ctx)
         c4m_merge_types(inferred_type, c4m_tspec_i64());
     }
 
-#ifndef C4M_PASS1_UNIT_TESTS
+#ifdef C4M_PASS1_UNIT_TESTS
     if (id == NULL) {
         printf("Anonymous enum (%lld kids).\n", c4m_xlist_len(items));
     }

--- a/src/con4m/frontend/decl_pass.c
+++ b/src/con4m/frontend/decl_pass.c
@@ -935,6 +935,9 @@ handle_func_decl(pass1_ctx *ctx)
         sym->value         = (void *)decl;
     }
 
+    c4m_pnode_t *pnode = get_pnode(tnode);
+    pnode->value       = (c4m_obj_t)sym;
+
     process_children(ctx);
 }
 

--- a/src/con4m/frontend/errors.c
+++ b/src/con4m/frontend/errors.c
@@ -921,6 +921,27 @@ static error_info_t error_info[] = {
         "The type of the object being switched on ([em]{}[/])",
         true,
     },
+    [c4m_err_concrete_typeof] = {
+        c4m_err_concrete_typeof,
+        "concrete_typeof",
+        "[em]typeof[/] requires the expression to be of a variable type, "
+        "but in this context it is always a [em]{}",
+        true,
+    },
+    [c4m_warn_type_overlap] = {
+        c4m_warn_type_overlap,
+        "type_overlap",
+        "This case in the [em]typeof[/] statement has a type [em]{}[/] "
+        "that overlaps with a previous case type: [em]{}[/]",
+        true,
+    },
+    [c4m_err_dead_branch] = {
+        c4m_err_dead_branch,
+        "dead_branch",
+        "This type case ([em]{}[/] is not compatable with the constraints "
+        "for the variable you're testing (i.e., this is not a subtype)",
+        true,
+    },
     [c4m_err_last] = {
         c4m_err_last,
         "last",

--- a/src/con4m/frontend/errors.c
+++ b/src/con4m/frontend/errors.c
@@ -463,12 +463,19 @@ static error_info_t error_info[] = {
         "Declared type may not have a negative value.",
         false,
     },
+    [c4m_err_parse_for_assign_vars] = {
+        c4m_err_parse_for_assign_vars,
+        "for_assign_vars",
+        "Too many assignment variables in [em]for[/] loop. Must have one in "
+        "most cases, and two when iterating over a dictionary type.",
+        false,
+    },
     [c4m_err_invalid_redeclaration] = {
         c4m_err_invalid_redeclaration,
         "invalid_redeclaration",
         "Re-declaration of [em]{}[/] is not allowed here; "
         "previous declaration of "
-        "{} was here: [i]{}:{}:{}[/]",
+        "{} was here: [i]{}[/]",
         true,
     },
     [c4m_err_omit_string_enum_value] = {
@@ -725,6 +732,52 @@ static error_info_t error_info[] = {
         "The root section already has a validator; currently only a single "
         "validator is supported.",
         false,
+    },
+    [c4m_err_decl_mismatch] = {
+        c4m_err_decl_mismatch,
+        "decl_mismatch",
+        "Right-hand side of assignment has a type [em]({})[/] that is not "
+        "compatable with the declared type of the left-hand side [em]({})[/]. "
+        "Previous declaration location is: [i]{}[/]",
+        true,
+    },
+    [c4m_err_inconsistent_type] = {
+        c4m_err_inconsistent_type,
+        "inconsistent_type",
+        "The type here [em]({})[/] is not compatable with the "
+        "declared type of this vairable [em]({})[/]. "
+        "Declaration location is: [i]{}[/]",
+        true,
+
+    },
+    [c4m_err_decl_mask] = {
+        c4m_err_decl_mask,
+        "decl_mask",
+        "This variable cannot be declared in the [em]{}[/] scope because "
+        "there is already a {}-level declaration in the same module at: [i]{}",
+        true,
+    },
+    [c4m_warn_attr_mask] = {
+        c4m_warn_attr_mask,
+        "attr_mask",
+        "This module-level declaration shares a name with an attribute."
+        "The module definition will be used throughout this module, "
+        "and the attribute will not be available.",
+        false,
+    },
+    [c4m_err_attr_mask] = {
+        c4m_err_attr_mask,
+        "attr_mask",
+        "This global declaration is invalid, because it has the same "
+        "name as an existing attribute.",
+        false,
+    },
+    [c4m_err_label_target] = {
+        c4m_err_label_target,
+        "label_target",
+        "The label target [em]{}[/] for this [i]{}[/] statement is not an "
+        "enclosing loop.",
+        true,
     },
     [c4m_err_last] = {
         c4m_err_last,

--- a/src/con4m/frontend/errors.c
+++ b/src/con4m/frontend/errors.c
@@ -287,6 +287,14 @@ static error_info_t error_info[] = {
         "Invalid declaration; cannot be both global and local ([em]var[/])",
         false,
     },
+    [c4m_err_parse_decl_const_not_const] = {
+        c4m_err_parse_decl_const_not_const,
+        "const_not_const",
+        "Cannot declare variables to be both "
+        "[em]once[/] (each instantiation can be set dynamically once) and "
+        "[em]const[/] (must have a value that can be fully computed before running).",
+        false,
+    },
     [c4m_err_parse_case_else_or_end] = {
         c4m_err_parse_case_else_or_end,
         "case_else_or_end",
@@ -987,6 +995,13 @@ static error_info_t error_info[] = {
         "call_type_err",
         "Type inferred at call site ([em]{}[/]) is not compatiable with "
         "the implementated type ([em]{}[/]).",
+        true,
+    },
+    [c4m_err_single_def] = {
+        c4m_err_single_def,
+        "single_def",
+        "Variable declared using [em]{}[/] may only be assigned in a single "
+        "location. The first declaration is: [i]{}[/]",
         true,
     },
     [c4m_err_last] = {

--- a/src/con4m/frontend/errors.c
+++ b/src/con4m/frontend/errors.c
@@ -745,10 +745,16 @@ static error_info_t error_info[] = {
         c4m_err_inconsistent_type,
         "inconsistent_type",
         "The type here [em]({})[/] is not compatable with the "
-        "declared type of this vairable [em]({})[/]. "
+        "declared type of this variable [em]({})[/]. "
         "Declaration location is: [i]{}[/]",
         true,
-
+    },
+    [c4m_err_inconsistent_infer_type] = {
+        c4m_err_inconsistent_infer_type,
+        "inconsistent_type",
+        "The type here [em]({})[/] is not compatable with the "
+        "expected type: [em]({})[/]. ",
+        true,
     },
     [c4m_err_decl_mask] = {
         c4m_err_decl_mask,
@@ -888,6 +894,25 @@ static error_info_t error_info[] = {
         "Cannot iterate over this value, as it is not a container type "
         "(current type is [em]{}[/])",
         true,
+    },
+    [c4m_err_unary_minus_type] = {
+        c4m_err_unary_minus_type,
+        "unary_minus_type",
+        "Unary minus currently only allowed on signed int types.",
+        false,
+    },
+    [c4m_err_cannot_cmp] = {
+        c4m_err_cannot_cmp,
+        "cannot_cmp",
+        "The two sides of the comparison have incompatible types: "
+        "[em]{}[/] vs [em]{}[/]",
+        true,
+    },
+    [c4m_err_range_type] = {
+        c4m_err_range_type,
+        "range_type",
+        "Ranges must consist of two int values.",
+        false,
     },
     [c4m_err_last] = {
         c4m_err_last,

--- a/src/con4m/frontend/errors.c
+++ b/src/con4m/frontend/errors.c
@@ -1004,6 +1004,41 @@ static error_info_t error_info[] = {
         "location. The first declaration is: [i]{}[/]",
         true,
     },
+    [c4m_warn_unused_decl] = {
+        c4m_warn_unused_decl,
+        "unused_decl",
+        "Declared variable [em]{}[/] is unused.",
+        true,
+    },
+    [c4m_err_global_remote_def] = {
+        c4m_err_global_remote_def,
+        "global_remote_def",
+        "Global variable [em]{}[/] can only be set in the module that first "
+        "declares it. The symbol's origin is: [i]{}",
+        true,
+    },
+    [c4m_err_global_remote_unused] = {
+        c4m_err_global_remote_unused,
+        "global_remote_unused",
+        "Global variable [em]{}[/] is imported via the [i]global[/] keyword, "
+        "but is not used here.",
+        true,
+    },
+    [c4m_info_unused_global_decl] = {
+        c4m_info_unused_global_decl,
+        "unused_global_decl",
+        "Global variable",
+        true,
+    },
+    [c4m_global_def_without_use] = {
+        c4m_global_def_without_use,
+        "def_without_use",
+        "This module is the first to declare the global variable[em]{}[/], "
+        "but it is not explicitly initialized. It will be set to a default "
+        "value at the beginning of the program.",
+        true,
+    },
+
     [c4m_err_last] = {
         c4m_err_last,
         "last",

--- a/src/con4m/frontend/errors.c
+++ b/src/con4m/frontend/errors.c
@@ -779,6 +779,116 @@ static error_info_t error_info[] = {
         "enclosing loop.",
         true,
     },
+    [c4m_err_fn_not_found] = {
+        c4m_err_fn_not_found,
+        "fn_not_found",
+        "Could not find an implementation for the function [em]{}[/].",
+        true,
+    },
+    [c4m_err_num_params] = {
+        c4m_err_num_params,
+        "num_params",
+        "Wrong number of parameters in call to function [em]{}[/]. "
+        "Call site used [i]{}[/] parameters, but the implementation of "
+        "that function requires [i]{}[/] parameters.",
+        true,
+    },
+    [c4m_err_calling_non_fn] = {
+        c4m_err_calling_non_fn,
+        "calling_non_fn",
+        "Cannot call [em]{}[/]; it is a [i]{}[/] not a function.",
+        true,
+    },
+    [c4m_err_spec_needs_field] = {
+        c4m_err_spec_needs_field,
+        "spec_needs_field",
+        "Attribute specification says [em]{}[/] must be a [i]{}[/]. It cannot "
+        "be used as a field here.",
+        true,
+    },
+    [c4m_err_field_not_spec] = {
+        c4m_err_field_not_spec,
+        "field_not_spec",
+        "Attribute [em]{}[/] does not follow the specticiation. The component "
+        "[em]{}[/] is expected to refer to a field, not a "
+        "configuration section.",
+        true,
+    },
+    [c4m_err_undefined_section] = {
+        c4m_err_undefined_section,
+        "undefined_section",
+        "The config file spec doesn't support a section named [em]{}[/].",
+        true,
+    },
+    [c4m_err_section_not_allowed] = {
+        c4m_err_section_not_allowed,
+        "section_not_allowed",
+        "The config file spec does not allow [em]{}[/] to be a subsection "
+        "here.",
+        true,
+    },
+    [c4m_err_slice_on_dict] = {
+        c4m_err_slice_on_dict,
+        "slice_on_dict",
+        "The slice operator is not supported for data types using dictionary "
+        "syntax (e.g., dictionaries or sets).",
+        false,
+    },
+    [c4m_err_bad_slice_ix] = {
+        c4m_err_bad_slice_ix,
+        "bad_slice_ix",
+        "The slice operator only supports integer indices.",
+        false,
+    },
+    [c4m_err_dupe_label] = {
+        c4m_err_dupe_label,
+        "dupe_label",
+        "The loop label [em]{}[/] cannot be used in multiple nested loops. "
+        "Note that, in the future, this constraint might apply per-function "
+        "context as well.",
+        true,
+    },
+    [c4m_err_iter_name_conflict] = {
+        c4m_err_iter_name_conflict,
+        "iter_name_conflict",
+        "Loop iteration over a dictionary requires two different loop "
+        "variable names. Rename one of them.",
+        false,
+    },
+    [c4m_warn_shadowed_var] = {
+        c4m_warn_shadowed_var,
+        "shadowed_var",
+        "Declaration of [em]{}[/] shadows a [i]{}[/] that would otherwise "
+        "be in scope here. Shadow value's first location: [i]{}[/]",
+        true,
+    },
+    [c4m_err_dict_one_var_for] = {
+        c4m_err_dict_one_var_for,
+        "dict_one_var_for",
+        "When using [em]for[/] loops to iterate over a dictionary, "
+        "you need to define two variables, one to hold the [i]key[/], "
+        "the other to hold the associated value.",
+        false,
+    },
+    [c4m_err_future_dynamic_typecheck] = {
+        c4m_err_future_dynamic_typecheck,
+        "future_dynamic_typecheck",
+        "There isn't enough syntactic context at this point for the system "
+        "to properly keep track of type info. Usually this happens when "
+        "using containers, when we cannot determine, for instance, dict vs. "
+        "set vs. list. In the future, this will be fine; in some cases "
+        "we will keep more type info, and in others, we will convert to "
+        "a runtime check. But for now, please add a type annotation that "
+        "at least unambiguously specifies a container type.",
+        false,
+    },
+    [c4m_err_iterate_on_non_container] = {
+        c4m_err_iterate_on_non_container,
+        "iterate_on_non_container",
+        "Cannot iterate over this value, as it is not a container type "
+        "(current type is [em]{}[/])",
+        true,
+    },
     [c4m_err_last] = {
         c4m_err_last,
         "last",

--- a/src/con4m/frontend/errors.c
+++ b/src/con4m/frontend/errors.c
@@ -654,6 +654,78 @@ static error_info_t error_info[] = {
         "HTTP and HTTPS support is not yet back in Con4m.",
         false,
     },
+    [c4m_info_recursive_use] = {
+        c4m_info_recursive_use,
+        "recursive_use",
+        "This [em]use[/] creates a cyclic import. Items imported from here "
+        "will be available, but if there are analysis conflicts in redeclared "
+        "symbols, the errors could end up confusing.",
+        false,
+    },
+    [c4m_err_self_recursive_use] = {
+        c4m_err_self_recursive_use,
+        "self_recursive_use",
+
+        "[em]use[/] statements are not allowed to directly import the current "
+        "module.",
+        false,
+    },
+    [c4m_err_redecl_kind] = {
+        c4m_err_redecl_kind,
+        "redecl_kind",
+        "Global symbol [em]{}[/] was previously declared as a [i]{}[/], so "
+        "cannot be redeclared as a [i]{}[/]. Previous declaration was: "
+        "[strong]{}[/]",
+        true,
+    },
+    [c4m_err_no_redecl] = {
+        c4m_err_no_redecl,
+        "no_redecl",
+        "Redeclaration of [i]{}[/] [em]{}[/] is not allowed. Previous "
+        "definition's location was: [strong]{}[/]",
+        true,
+    },
+    [c4m_err_redecl_neq_generics] = {
+        c4m_err_redecl_neq_generics,
+        "redecl_neq_generics",
+        "Redeclaration of [em]{}[/] uses {} type when "
+        "re-declared in a different module (redeclarations that name a "
+        "type, must name the exact same time as in other modules). "
+        "Previous type was: [em]{}[/] vs. current type: [em]{}[/]."
+        "Previous definition's location was: [strong]{}[/]",
+        true,
+    },
+    [c4m_err_spec_redef_section] = {
+        c4m_err_spec_redef_section,
+        "redef_section",
+        "Redefinition of [i]confspec[/] sections is not allowed. You can "
+        "add data to the [i]root[/] section, but no named sections may "
+        "appear twice in any program. Previous declaration of "
+        "section [em]{}[/] was: [strong]{}[/]",
+        true,
+    },
+    [c4m_err_spec_redef_field] = {
+        c4m_err_spec_redef_field,
+        "redef_field",
+        "Redefinition of [i]confspec[/] fields are not allowed. You can "
+        "add new fields to the [i]root[/] section, but no new ones. "
+        "Previous declaration of field [em]{}[/] was: [strong]{}[/]",
+        true,
+    },
+    [c4m_err_spec_locked] = {
+        c4m_err_spec_locked,
+        "spec_locked",
+        "The configuration file spec has been programatically locked, "
+        "and as such, cannot be changed here.",
+        false,
+    },
+    [c4m_err_dupe_validator] = {
+        c4m_err_dupe_validator,
+        "dupe_validator",
+        "The root section already has a validator; currently only a single "
+        "validator is supported.",
+        false,
+    },
     [c4m_err_last] = {
         c4m_err_last,
         "last",

--- a/src/con4m/frontend/errors.c
+++ b/src/con4m/frontend/errors.c
@@ -752,8 +752,8 @@ static error_info_t error_info[] = {
     [c4m_err_inconsistent_infer_type] = {
         c4m_err_inconsistent_infer_type,
         "inconsistent_type",
-        "The type here [em]({})[/] is not compatable with the "
-        "expected type: [em]({})[/]. ",
+        "The previous type, [em]{}[/], is not compatable with the "
+        "type used in this context ([em]{}[/]). ",
         true,
     },
     [c4m_err_decl_mask] = {
@@ -940,6 +940,53 @@ static error_info_t error_info[] = {
         "dead_branch",
         "This type case ([em]{}[/] is not compatable with the constraints "
         "for the variable you're testing (i.e., this is not a subtype)",
+        true,
+    },
+    [c4m_err_no_ret] = {
+        c4m_err_no_ret,
+        "no_ret",
+        "Function was declared with a return type [em]{}[/em], but no "
+        "values were returned.",
+        true,
+    },
+    [c4m_err_use_no_def] = {
+        c4m_err_use_no_def,
+        "use_no_def",
+        "Variable is used, but not ever set.",
+        false,
+    },
+    [c4m_err_declared_incompat] = {
+        c4m_err_declared_incompat,
+        "declared_incompat",
+        "The declared type ([em]{}[/]) is not compatable with the type as "
+        "used in the function ([em]{}[/])",
+        true,
+    },
+    [c4m_err_too_general] = {
+        c4m_err_too_general,
+        "too_general",
+        "The declared type ([em]{}[/]) is more generic than the implementation "
+        "requires ([em]{}[/]). Please use the more specific type (or remove "
+        "the declaration)",
+        true,
+    },
+    [c4m_warn_unused_param] = {
+        c4m_warn_unused_param,
+        "unused_param",
+        "The parameter [em]{}[/] is declared, but not used.",
+        true,
+    },
+    [c4m_warn_def_without_use] = {
+        c4m_warn_def_without_use,
+        "def_without_use",
+        "Variable [em]{}[/] is explicitly declared, but not used.",
+        true,
+    },
+    [c4m_err_call_type_err] = {
+        c4m_err_call_type_err,
+        "call_type_err",
+        "Type inferred at call site ([em]{}[/]) is not compatiable with "
+        "the implementated type ([em]{}[/]).",
         true,
     },
     [c4m_err_last] = {

--- a/src/con4m/frontend/errors.c
+++ b/src/con4m/frontend/errors.c
@@ -914,6 +914,13 @@ static error_info_t error_info[] = {
         "Ranges must consist of two int values.",
         false,
     },
+    [c4m_err_switch_case_type] = {
+        c4m_err_switch_case_type,
+        "switch_case_type",
+        "This switch branch has a type ([em]{}[/]) that doesn't match"
+        "The type of the object being switched on ([em]{}[/])",
+        true,
+    },
     [c4m_err_last] = {
         c4m_err_last,
         "last",

--- a/src/con4m/frontend/lex.c
+++ b/src/con4m/frontend/lex.c
@@ -169,6 +169,7 @@ output_token(lex_state_t *state, c4m_token_kind_t kind)
 {
     c4m_token_t *tok  = c4m_gc_alloc(c4m_token_t);
     tok->kind         = kind;
+    tok->module       = state->ctx;
     tok->start_ptr    = state->start;
     tok->end_ptr      = state->pos;
     tok->token_id     = ++state->token_id;

--- a/src/con4m/frontend/lex.c
+++ b/src/con4m/frontend/lex.c
@@ -653,6 +653,8 @@ init_keywords()
     add_keyword("in", c4m_tt_in);
     add_keyword("var", c4m_tt_var);
     add_keyword("global", c4m_tt_global);
+    add_keyword("once", c4m_tt_once);
+    add_keyword("let", c4m_tt_let);
     add_keyword("private", c4m_tt_private);
     add_keyword("const", c4m_tt_const);
     add_keyword("is", c4m_tt_cmp);

--- a/src/con4m/frontend/parse.c
+++ b/src/con4m/frontend/parse.c
@@ -3643,7 +3643,6 @@ section(parse_ctx *ctx, c4m_tree_node_t *node)
     c4m_pnode_t *lhs = (c4m_pnode_t *)c4m_tree_get_contents(node);
 
     if (lhs->kind != c4m_nt_expression || !c4m_tree_get_number_children(node)) {
-        printf("Bad start 1.\n");
 bad_start:
         raise_err_at_node(ctx,
                           current_parse_node(ctx),
@@ -3654,13 +3653,12 @@ bad_start:
     lhs = c4m_tree_get_contents(c4m_tree_get_child(node, 0));
 
     if (lhs->kind != c4m_nt_identifier) {
-        printf("Bad start 2.\n");
         goto bad_start;
     }
 
     c4m_tree_node_t *result = temporary_tree(ctx, c4m_nt_section);
 
-    adopt_kid(ctx, node);
+    adopt_kid(ctx, c4m_tree_get_child(node, 0));
 
     switch (match(ctx,
                   c4m_tt_identifier,
@@ -4144,6 +4142,10 @@ c4m_parse(c4m_file_compile_ctx *file_ctx)
     prime_tokens(&ctx);
 
     file_ctx->parse_tree = module(&ctx);
+
+    if (file_ctx->parse_tree == NULL) {
+        file_ctx->fatal_errors = 1;
+    }
 
     return file_ctx->parse_tree != NULL;
 }

--- a/src/con4m/frontend/parse.c
+++ b/src/con4m/frontend/parse.c
@@ -4083,7 +4083,11 @@ repr_one_node(c4m_pnode_t *one)
 
     c4m_utf8_t *result = c4m_cstr_format(fmt, name, xtra, doc);
 
-    //    c4m_print(c4m_hex_dump(result->data, result->byte_len));
+    if (one->type != NULL) {
+        result = c4m_str_concat(result,
+                                c4m_cstr_format("[h6]{}", one->type));
+    }
+
     return result;
 }
 

--- a/src/con4m/frontend/parse.c
+++ b/src/con4m/frontend/parse.c
@@ -941,7 +941,7 @@ simple_lit(parse_ctx *ctx)
                 break;
 
             default:
-                C4M_CRAISE("Reached supposedly unreachable code.");
+                unreachable();
             }
 
             c4m_error_from_token(ctx->file_ctx, err, tok, mod, syntax_kind);
@@ -3587,7 +3587,7 @@ bad_start:
     case c4m_tt_lbrace:
         break;
     default:
-        abort(); // Should be unreachable.
+        unreachable();
     }
 
     body(ctx, (c4m_pnode_t *)c4m_tree_get_contents(result));

--- a/src/con4m/frontend/scope.c
+++ b/src/con4m/frontend/scope.c
@@ -406,11 +406,14 @@ c4m_format_scope(c4m_scope_t *scope)
         }
 
         c4m_type_t *symtype = c4m_get_sym_type(entry);
-        symtype             = c4m_resolve_type_aliases(symtype, c4m_global_type_env);
+        symtype             = c4m_resolve_type_aliases(symtype,
+                                           c4m_global_type_env);
 
         c4m_xlist_append(row,
                          c4m_cstr_format("[em]{} [/][i]({})",
-                                         internal_type_repr(symtype, memos, &nexttid),
+                                         internal_type_repr(symtype,
+                                                            memos,
+                                                            &nexttid),
                                          kind));
 
         if (c4m_sym_is_declared_const(entry)) {

--- a/src/con4m/frontend/scope.c
+++ b/src/con4m/frontend/scope.c
@@ -14,6 +14,30 @@ static char *symbol_kind_names[sk_num_sym_kinds] = {
 };
 // clang-format on
 
+static inline c4m_utf8_t *
+sym_kind_name(c4m_scope_entry_t *sym)
+{
+    return c4m_new_utf8(symbol_kind_names[sym->kind]);
+}
+
+static inline int32_t *
+sym_line_no(const c4m_scope_entry_t *sym)
+{
+    c4m_pnode_t *pnode = c4m_tree_get_contents(sym->declaration_node);
+    c4m_token_t *tok   = pnode->token;
+
+    return c4m_box_i32(tok->line_no);
+}
+
+static inline int32_t *
+sym_line_offset(const c4m_scope_entry_t *sym)
+{
+    c4m_pnode_t *pnode = c4m_tree_get_contents(sym->declaration_node);
+    c4m_token_t *tok   = pnode->token;
+
+    return c4m_box_i32(tok->line_offset + 1);
+}
+
 c4m_scope_t *
 c4m_new_scope(c4m_scope_t *parent, c4m_scope_kind kind)
 {
@@ -51,9 +75,7 @@ c4m_declare_symbol(c4m_file_compile_ctx *ctx,
         return entry;
     }
 
-    c4m_scope_entry_t *old   = hatrack_dict_get(scope->symbols, name, NULL);
-    c4m_pnode_t       *pnode = c4m_tree_get_contents(old->declaration_node);
-    c4m_token_t       *tok   = pnode->token;
+    c4m_scope_entry_t *old = hatrack_dict_get(scope->symbols, name, NULL);
 
     if (success != NULL) {
         *success = false;
@@ -67,10 +89,10 @@ c4m_declare_symbol(c4m_file_compile_ctx *ctx,
                   c4m_err_invalid_redeclaration,
                   node,
                   name,
-                  c4m_new_utf8(symbol_kind_names[old->kind]),
+                  sym_kind_name(old),
                   old->path,
-                  c4m_box_i32(tok->line_no),
-                  c4m_box_i32(tok->line_offset + 1));
+                  sym_line_no(old),
+                  sym_line_offset(old));
 
     return old;
 }
@@ -89,4 +111,147 @@ c4m_scope_entry_t *
 c4m_lookup_symbol(c4m_scope_t *scope, c4m_utf8_t *name)
 {
     return hatrack_dict_get(scope->symbols, name, NULL);
+}
+
+// Used for declaration comparisons. use_declared_type is passed when
+// the ORIGINAL symbol had a declared type. If it doesn't, then we are
+// comparing against a third place, which had an explicit decl, which
+// will have the type stored in inferred_type.
+
+static void
+type_cmp_exact_match(c4m_file_compile_ctx *new_ctx,
+                     c4m_scope_entry_t    *new_sym,
+                     c4m_scope_entry_t    *old_sym,
+                     bool                  use_declared_type)
+{
+    c4m_type_t *t1 = new_sym->declared_type;
+    c4m_type_t *t2;
+
+    if (use_declared_type == true) {
+        t2 = old_sym->declared_type;
+    }
+    else {
+        t2 = old_sym->inferred_type;
+    }
+
+    switch (c4m_type_cmp_exact(t1, t2)) {
+    case c4m_type_match_exact:
+        // Link any type variables together now.
+        old_sym->inferred_type = c4m_merge_types(t1, t2);
+        return;
+    case c4m_type_match_left_more_specific:
+        // Even if the authoritative symbol did not have a declared
+        // type, it got the field set whenever some other version of
+        // the symbol explicitly declared. So it's the previous
+        // location to complain about.
+        c4m_add_error(new_ctx,
+                      c4m_err_redecl_neq_generics,
+                      new_sym->declaration_node,
+                      new_sym->name,
+                      c4m_new_utf8("a less generic / more concrete"),
+                      c4m_value_obj_repr(t2),
+                      c4m_value_obj_repr(t1),
+                      c4m_node_get_loc_str(old_sym->declaration_node));
+        return;
+    case c4m_type_match_right_more_specific:
+        c4m_add_error(new_ctx,
+                      c4m_err_redecl_neq_generics,
+                      new_sym->declaration_node,
+                      new_sym->name,
+                      c4m_new_utf8("a more generic / less concrete"),
+                      c4m_value_obj_repr(t2),
+                      c4m_value_obj_repr(t1),
+                      c4m_node_get_loc_str(old_sym->declaration_node));
+        return;
+    case c4m_type_match_both_have_more_generic_bits:
+        c4m_add_error(new_ctx,
+                      c4m_err_redecl_neq_generics,
+                      new_sym->declaration_node,
+                      new_sym->name,
+                      c4m_new_utf8("a type with different generic parts"),
+                      c4m_value_obj_repr(t2),
+                      c4m_value_obj_repr(t1),
+                      c4m_node_get_loc_str(old_sym->declaration_node));
+        return;
+    case c4m_type_cant_match:
+        c4m_add_error(new_ctx,
+                      c4m_err_redecl_neq_generics,
+                      new_sym->declaration_node,
+                      new_sym->name,
+                      c4m_new_utf8("a completely incompatible"),
+                      c4m_value_obj_repr(t2),
+                      c4m_value_obj_repr(t1),
+                      c4m_node_get_loc_str(old_sym->declaration_node));
+        return;
+    }
+}
+
+// This is meant for statically merging global symbols that exist in
+// multiple modules, etc.
+//
+// This happens BEFORE any type inferencing happens, so we only need
+// to compare when exact types are provided.
+
+bool
+c4m_merge_symbols(c4m_file_compile_ctx *ctx1,
+                  c4m_scope_entry_t    *sym1,
+                  c4m_scope_entry_t    *sym2)
+{
+    if (sym1->kind != sym2->kind) {
+        c4m_add_error(ctx1,
+                      c4m_err_redecl_kind,
+                      sym1->declaration_node,
+                      sym1->name,
+                      sym_kind_name(sym2),
+                      sym_kind_name(sym1),
+                      c4m_node_get_loc_str(sym2->declaration_node));
+        return false;
+    }
+
+    switch (sym1->kind) {
+    case sk_func:
+    case sk_extern_func:
+    case sk_enum_type:
+    case sk_enum_val:
+        c4m_add_error(ctx1,
+                      c4m_err_no_redecl,
+                      sym1->declaration_node,
+                      sym1->name,
+                      sym_kind_name(sym1),
+                      c4m_node_get_loc_str(sym2->declaration_node));
+        return false;
+
+    case sk_variable:
+        if (sym1->declared_type != c4m_tspec_error()) {
+            if (sym2->declared_type != c4m_tspec_error()) {
+                type_cmp_exact_match(ctx1, sym1, sym2, true);
+            }
+            else {
+                if (sym2->declaration_node != NULL) {
+                    type_cmp_exact_match(ctx1, sym1, sym2, false);
+                    // Track the most recent declaration in case
+                    // other declarations fail.
+                    sym2->declaration_node = sym1->declaration_node;
+                }
+                else {
+                    // Same; sym2 was chosen as authoritative, but
+                    // it didn't have a type. So if there's ever an error
+                    // complaining about a type relative to the declared
+                    // type, since there isn't a base declaration, we
+                    // just give the most recent one, and keep that
+                    // in declaration_node.
+                    sym2->inferred_type    = sym1->declared_type;
+                    sym2->declaration_node = sym1->declaration_node;
+                }
+            }
+        }
+
+        sym1->authoritative_symbol = sym2;
+
+        return true;
+    default:
+        // For instance, we never call this on scopes
+        // that hold sk_module symbols or sk_formal symbols.
+        unreachable();
+    }
 }

--- a/src/con4m/frontend/scope.c
+++ b/src/con4m/frontend/scope.c
@@ -385,8 +385,20 @@ c4m_format_scope(c4m_scope_t *scope)
 
         c4m_xlist_append(row, entry->name);
 
-        if (entry->kind == sk_variable && entry->flags & C4M_F_DECLARED_CONST) {
-            c4m_xlist_append(row, c4m_new_utf8("const"));
+        if (entry->kind == sk_variable) {
+            if (entry->flags & C4M_F_DECLARED_CONST) {
+                c4m_xlist_append(row, c4m_new_utf8("const"));
+            }
+            else {
+                if (entry->flags & C4M_F_USER_IMMUTIBLE) {
+                    c4m_xlist_append(row, c4m_new_utf8("loop var"));
+                }
+                else {
+                    c4m_xlist_append(row,
+                                     c4m_new_utf8(
+                                         c4m_symbol_kind_names[entry->kind]));
+                }
+            }
         }
         else {
             c4m_xlist_append(row,
@@ -406,7 +418,7 @@ c4m_format_scope(c4m_scope_t *scope)
                 c4m_xlist_append(row, c4m_cstr_format("[red]not set[/]"));
             }
             else {
-                if (is_partial_type(c4m_get_my_type(entry->value))) {
+                if (c4m_is_partial_type(c4m_get_my_type(entry->value))) {
                     c4m_xlist_append(row, c4m_cstr_format("[yellow]TBD"));
                 }
                 else {

--- a/src/con4m/frontend/specs.c
+++ b/src/con4m/frontend/specs.c
@@ -7,7 +7,6 @@ c4m_new_spec()
 
     result->section_specs = c4m_new(c4m_tspec_dict(c4m_tspec_utf8(),
                                                    c4m_tspec_ref()));
-    result->errors        = c4m_new(c4m_tspec_xlist(c4m_tspec_ref()));
 
     return result;
 }

--- a/src/con4m/frontend/specs.c
+++ b/src/con4m/frontend/specs.c
@@ -10,3 +10,86 @@ c4m_new_spec()
 
     return result;
 }
+
+c4m_attr_info_t *
+c4m_get_attr_info(c4m_spec_t *spec, c4m_xlist_t *fqn)
+{
+    c4m_attr_info_t *result = c4m_gc_alloc(c4m_attr_info_t);
+
+    if (!spec || !spec->root_section) {
+        result->kind = c4m_attr_user_def_field;
+        return result;
+    }
+
+    c4m_spec_section_t *cur_sec = spec->root_section;
+    int                 i       = 0;
+    int                 n       = c4m_xlist_len(fqn) - 1;
+
+    while (true) {
+        c4m_utf8_t       *cur_name = c4m_to_utf8(c4m_xlist_get(fqn, i, NULL));
+        c4m_spec_field_t *field    = hatrack_dict_get(cur_sec->fields,
+                                                   cur_name,
+                                                   NULL);
+        if (field != NULL) {
+            if (i != n) {
+                result->err = c4m_attr_err_sec_under_field;
+                return result;
+            }
+            else {
+                result->info.field_info = field;
+                result->kind            = c4m_attr_field;
+                return result;
+            }
+        }
+
+        cur_sec = hatrack_dict_get(spec->section_specs, cur_name, NULL);
+
+        if (cur_sec == NULL) {
+            if (i == n) {
+                if (cur_sec->user_def_ok) {
+                    result->kind = c4m_attr_user_def_field;
+                    return result;
+                }
+                else {
+                    result->err     = c4m_attr_err_field_not_allowed;
+                    result->err_arg = cur_name;
+                    return result;
+                }
+            }
+            else {
+                result->err_arg = cur_name;
+                result->err     = c4m_attr_err_no_such_sec;
+                return result;
+            }
+        }
+
+        if (!c4m_set_contains(cur_sec->allowed_sections, cur_name)) {
+            if (!c4m_set_contains(cur_sec->required_sections, cur_name)) {
+                result->err_arg = cur_name;
+                result->err     = c4m_attr_err_sec_not_allowed;
+                return result;
+            }
+        }
+
+        if (i == n) {
+            result->info.sec_info = cur_sec;
+            if (cur_sec->singleton) {
+                result->kind = c4m_attr_singleton;
+            }
+            else {
+                result->kind = c4m_attr_object_type;
+            }
+
+            return result;
+        }
+
+        if (cur_sec->singleton != 0) {
+            i += 1;
+            if (i == n) {
+                result->kind = c4m_attr_instance;
+                return result;
+            }
+        }
+        i += 1;
+    }
+}

--- a/src/con4m/frontend/treematch.c
+++ b/src/con4m/frontend/treematch.c
@@ -34,6 +34,7 @@ c4m_tpat_node_t *c4m_sym_decls;
 c4m_tpat_node_t *c4m_sym_names;
 c4m_tpat_node_t *c4m_sym_type;
 c4m_tpat_node_t *c4m_sym_init;
+c4m_tpat_node_t *c4m_loop_vars;
 
 void
 setup_treematch_patterns()
@@ -115,6 +116,9 @@ setup_treematch_patterns()
                          tcount_content(c4m_nt_identifier, 1, max_nodes, 0),
                          tcount_content(c4m_nt_lit_tspec, 0, 1, 0),
                          tcount_content(c4m_nt_assign, 0, 1, 1));
+    c4m_loop_vars         = tfind(c4m_nt_variable_decls,
+                          0,
+                          tcount_content(c4m_nt_identifier, 1, 2, 1));
 
     c4m_gc_register_root(&c4m_first_kid_id, 1);
     c4m_gc_register_root(&c4m_enum_items, 1);
@@ -134,6 +138,7 @@ setup_treematch_patterns()
     c4m_gc_register_root(&c4m_sym_names, 1);
     c4m_gc_register_root(&c4m_sym_type, 1);
     c4m_gc_register_root(&c4m_sym_init, 1);
+    c4m_gc_register_root(&c4m_loop_vars, 1);
 }
 
 c4m_obj_t

--- a/src/con4m/frontend/treematch.c
+++ b/src/con4m/frontend/treematch.c
@@ -449,7 +449,7 @@ c4m_node_to_type(c4m_file_compile_ctx *ctx,
         return c4m_tspec_fn(t, args, va);
 
     default:
-        C4M_CRAISE("Reached code that should be unreachable.");
+        unreachable();
     }
 }
 

--- a/src/con4m/frontend/treematch.c
+++ b/src/con4m/frontend/treematch.c
@@ -37,6 +37,8 @@ c4m_tpat_node_t *c4m_sym_init;
 c4m_tpat_node_t *c4m_loop_vars;
 c4m_tpat_node_t *c4m_case_branches;
 c4m_tpat_node_t *c4m_case_else;
+c4m_tpat_node_t *c4m_elif_branches;
+c4m_tpat_node_t *c4m_else_condition;
 
 void
 setup_treematch_patterns()
@@ -131,6 +133,18 @@ setup_treematch_patterns()
                            tcontent(nt_any, 0),
                            tcount_content(c4m_nt_case, 1, max_nodes, 0),
                            tcount_content(c4m_nt_else, 0, 1, 1));
+    c4m_elif_branches     = tmatch(nt_any,
+                               0,
+                               tcontent(c4m_nt_cmp, 0),
+                               tcontent(c4m_nt_body, 0),
+                               tcount_content(c4m_nt_elif, 0, max_nodes, 1),
+                               tcount_content(c4m_nt_else, 0, 1, 0));
+    c4m_else_condition    = tmatch(nt_any,
+                                0,
+                                tcontent(c4m_nt_cmp, 0),
+                                tcontent(c4m_nt_body, 0),
+                                tcount_content(c4m_nt_elif, 0, max_nodes, 0),
+                                tcount_content(c4m_nt_else, 0, 1, 1));
 
     c4m_gc_register_root(&c4m_first_kid_id, 1);
     c4m_gc_register_root(&c4m_enum_items, 1);
@@ -153,6 +167,8 @@ setup_treematch_patterns()
     c4m_gc_register_root(&c4m_loop_vars, 1);
     c4m_gc_register_root(&c4m_case_branches, 1);
     c4m_gc_register_root(&c4m_case_else, 1);
+    c4m_gc_register_root(&c4m_elif_branches, 1);
+    c4m_gc_register_root(&c4m_else_condition, 1);
 }
 
 c4m_obj_t

--- a/src/con4m/frontend/treematch.c
+++ b/src/con4m/frontend/treematch.c
@@ -17,9 +17,11 @@ tcmp(int64_t kind_as_64, c4m_tree_node_t *node)
 }
 
 c4m_tpat_node_t *c4m_first_kid_id = NULL;
+c4m_tpat_node_t *c4m_2nd_kid_id;
 c4m_tpat_node_t *c4m_enum_items;
 c4m_tpat_node_t *c4m_member_prefix;
 c4m_tpat_node_t *c4m_member_last;
+c4m_tpat_node_t *c4m_func_mods;
 c4m_tpat_node_t *c4m_use_uri;
 c4m_tpat_node_t *c4m_extern_params;
 c4m_tpat_node_t *c4m_extern_return;
@@ -51,6 +53,11 @@ setup_treematch_patterns()
                               0,
                               tmatch(c4m_nt_identifier, 1),
                               tcount_content(nt_any, 0, max_nodes, 0));
+    c4m_2nd_kid_id    = tmatch(nt_any,
+                            0,
+                            tcontent(nt_any, 0),
+                            tmatch(c4m_nt_identifier, 1),
+                            tcount_content(nt_any, 0, max_nodes, 0));
     // Skips the identifier if there, and returns all the enum items,
     // regardless of the subtree shape.
     c4m_enum_items    = tmatch(nt_any,
@@ -68,15 +75,16 @@ setup_treematch_patterns()
                               0,
                               tcount(c4m_nt_identifier, 0, max_nodes, 1),
                               tmatch(c4m_nt_identifier, 0));
-
-    c4m_extern_params = tfind(
-        c4m_nt_extern_sig,
-        0,
-        tcount_content(c4m_nt_extern_param, 0, max_nodes, 1),
-        tcount_content(c4m_nt_lit_tspec_return_type,
-                       0,
-                       1,
-                       0));
+    c4m_func_mods     = tfind(c4m_nt_func_mods,
+                          0,
+                          tcount(c4m_nt_func_mod, 0, max_nodes, 1));
+    c4m_extern_params = tfind(c4m_nt_extern_sig,
+                              0,
+                              tcount_content(c4m_nt_extern_param, 0, max_nodes, 1),
+                              tcount_content(c4m_nt_lit_tspec_return_type,
+                                             0,
+                                             1,
+                                             0));
     c4m_extern_return = tfind(
         c4m_nt_extern_sig,
         0,
@@ -147,9 +155,11 @@ setup_treematch_patterns()
                                 tcount_content(c4m_nt_else, 0, 1, 1));
 
     c4m_gc_register_root(&c4m_first_kid_id, 1);
+    c4m_gc_register_root(&c4m_2nd_kid_id, 1);
     c4m_gc_register_root(&c4m_enum_items, 1);
     c4m_gc_register_root(&c4m_member_prefix, 1);
     c4m_gc_register_root(&c4m_member_last, 1);
+    c4m_gc_register_root(&c4m_func_mods, 1);
     c4m_gc_register_root(&c4m_use_uri, 1);
     c4m_gc_register_root(&c4m_extern_params, 1);
     c4m_gc_register_root(&c4m_extern_return, 1);

--- a/src/con4m/frontend/treematch.c
+++ b/src/con4m/frontend/treematch.c
@@ -35,6 +35,8 @@ c4m_tpat_node_t *c4m_sym_names;
 c4m_tpat_node_t *c4m_sym_type;
 c4m_tpat_node_t *c4m_sym_init;
 c4m_tpat_node_t *c4m_loop_vars;
+c4m_tpat_node_t *c4m_case_branches;
+c4m_tpat_node_t *c4m_case_else;
 
 void
 setup_treematch_patterns()
@@ -119,6 +121,16 @@ setup_treematch_patterns()
     c4m_loop_vars         = tfind(c4m_nt_variable_decls,
                           0,
                           tcount_content(c4m_nt_identifier, 1, 2, 1));
+    c4m_case_branches     = tmatch(c4m_nt_switch,
+                               0,
+                               tcontent(c4m_nt_expression, 0),
+                               tcount_content(c4m_nt_case, 1, max_nodes, 1),
+                               tcount_content(c4m_nt_else, 0, 1, 0));
+    c4m_case_else         = tmatch(c4m_nt_switch,
+                           0,
+                           tcontent(c4m_nt_expression, 0),
+                           tcount_content(c4m_nt_case, 1, max_nodes, 0),
+                           tcount_content(c4m_nt_else, 0, 1, 1));
 
     c4m_gc_register_root(&c4m_first_kid_id, 1);
     c4m_gc_register_root(&c4m_enum_items, 1);
@@ -139,6 +151,8 @@ setup_treematch_patterns()
     c4m_gc_register_root(&c4m_sym_type, 1);
     c4m_gc_register_root(&c4m_sym_init, 1);
     c4m_gc_register_root(&c4m_loop_vars, 1);
+    c4m_gc_register_root(&c4m_case_branches, 1);
+    c4m_gc_register_root(&c4m_case_else, 1);
 }
 
 c4m_obj_t

--- a/src/con4m/frontend/treematch.c
+++ b/src/con4m/frontend/treematch.c
@@ -121,14 +121,14 @@ setup_treematch_patterns()
     c4m_loop_vars         = tfind(c4m_nt_variable_decls,
                           0,
                           tcount_content(c4m_nt_identifier, 1, 2, 1));
-    c4m_case_branches     = tmatch(c4m_nt_switch,
+    c4m_case_branches     = tmatch(nt_any,
                                0,
-                               tcontent(c4m_nt_expression, 0),
+                               tcontent(nt_any, 0),
                                tcount_content(c4m_nt_case, 1, max_nodes, 1),
                                tcount_content(c4m_nt_else, 0, 1, 0));
-    c4m_case_else         = tmatch(c4m_nt_switch,
+    c4m_case_else         = tmatch(nt_any,
                            0,
-                           tcontent(c4m_nt_expression, 0),
+                           tcontent(nt_any, 0),
                            tcount_content(c4m_nt_case, 1, max_nodes, 0),
                            tcount_content(c4m_nt_else, 0, 1, 1));
 

--- a/src/con4m/frontend/treematch.c
+++ b/src/con4m/frontend/treematch.c
@@ -201,7 +201,7 @@ node_literal(c4m_file_compile_ctx *ctx,
         ERROR_ON_BAD_LITMOD(ctx, base_type, node, litmod, "list");
 
         n       = c4m_tree_get_number_children(node);
-        partial = c4m_new(c4m_tspec_partial_lit(), n, base_type);
+        partial = c4m_new(c4m_tspec_partial_lit(), n, base_type, node);
 
         c4m_xlist_append(partial->type->details->items, c4m_tspec_typevar());
 
@@ -227,12 +227,12 @@ handle_dict_or_litmodded_but_empty:
         ERROR_ON_BAD_LITMOD(ctx, base_type, node, litmod, "dict");
 
         n       = c4m_tree_get_number_children(node);
-        partial = c4m_new(c4m_tspec_partial_lit(), n, base_type);
+        partial = c4m_new(c4m_tspec_partial_lit(), n, base_type, node);
 
         c4m_xlist_append(partial->type->details->items, c4m_tspec_typevar());
         c4m_xlist_append(partial->type->details->items, c4m_tspec_typevar());
 
-        for (int i = 0; i < n; n++) {
+        for (int i = 0; i < n; i++) {
             one               = node_literal(ctx,
                                c4m_tree_get_child(node, i),
                                type_ctx);
@@ -253,7 +253,7 @@ handle_dict_or_litmodded_but_empty:
         ERROR_ON_BAD_LITMOD(ctx, base_type, node, litmod, "set");
 
         n       = c4m_tree_get_number_children(node);
-        partial = c4m_new(c4m_tspec_partial_lit(), n, base_type);
+        partial = c4m_new(c4m_tspec_partial_lit(), n, base_type, node);
 
         c4m_xlist_append(partial->type->details->items, c4m_tspec_typevar());
 

--- a/src/con4m/literals.c
+++ b/src/con4m/literals.c
@@ -4,6 +4,71 @@ static c4m_dict_t *mod_map[ST_MAX] = {
     NULL,
 };
 
+// TODO: Change this when adding objects.
+static int       container_bitfield_words = (C4M_NUM_BUILTIN_DTS + 63) / 64;
+static uint64_t *list_types               = NULL;
+static uint64_t *dict_types;
+static uint64_t *set_types;
+static uint64_t *tuple_types;
+static uint64_t *all_container_types;
+
+static inline void
+no_more_containers()
+{
+    all_container_types = c4m_gc_array_alloc(uint64_t,
+                                             container_bitfield_words);
+
+    for (int i = 0; i < container_bitfield_words; i++) {
+        all_container_types[i] = list_types[i] | dict_types[i];
+        all_container_types[i] |= set_types[i] | tuple_types[i];
+    }
+}
+
+static void
+initialize_container_bitfields()
+{
+    if (list_types == NULL) {
+        list_types  = c4m_gc_array_alloc(uint64_t, container_bitfield_words);
+        dict_types  = c4m_gc_array_alloc(uint64_t, container_bitfield_words);
+        set_types   = c4m_gc_array_alloc(uint64_t, container_bitfield_words);
+        tuple_types = c4m_gc_array_alloc(uint64_t, container_bitfield_words);
+        c4m_gc_register_root(&list_types, 1);
+        c4m_gc_register_root(&dict_types, 1);
+        c4m_gc_register_root(&set_types, 1);
+        c4m_gc_register_root(&tuple_types, 1);
+        c4m_gc_register_root(&all_container_types, 1);
+    }
+}
+
+void
+c4m_register_container_type(c4m_builtin_t    bi,
+                            c4m_lit_syntax_t st,
+                            bool             alt_syntax)
+{
+    initialize_container_bitfields();
+    int word = ((int)bi) / 64;
+    int bit  = ((int)bi) % 64;
+
+    switch (st) {
+    case ST_List:
+        list_types[word] |= 1UL << bit;
+        return;
+    case ST_Dict:
+        if (alt_syntax) {
+            set_types[word] |= 1UL << bit;
+        }
+        else {
+            dict_types[word] |= 1UL << bit;
+        }
+        return;
+    case ST_Tuple:
+        tuple_types[word] |= 1UL << bit;
+        return;
+    default:
+        unreachable();
+    }
+}
+
 void
 c4m_register_literal(c4m_lit_syntax_t st, char *mod, c4m_builtin_t bi)
 {
@@ -11,6 +76,23 @@ c4m_register_literal(c4m_lit_syntax_t st, char *mod, c4m_builtin_t bi)
                           c4m_new_utf8(mod),
                           (void *)(int64_t)bi)) {
         C4M_CRAISE("Duplicate literal modifier for this syntax type.");
+    }
+
+    switch (st) {
+    case ST_List:
+    case ST_Tuple:
+        c4m_register_container_type(bi, st, false);
+        return;
+    case ST_Dict:
+        if (bi == C4M_T_SET) {
+            c4m_register_container_type(bi, st, true);
+        }
+        else {
+            c4m_register_container_type(bi, st, false);
+        }
+        return;
+    default:
+        return;
     }
 }
 
@@ -125,6 +207,7 @@ c4m_init_literal_handling()
         c4m_register_literal(ST_Tuple, "", C4M_T_TUPLE);
         c4m_register_literal(ST_Tuple, "t", C4M_T_TUPLE);
         c4m_register_literal(ST_Tuple, "tuple", C4M_T_TUPLE);
+        no_more_containers();
     }
 }
 
@@ -223,3 +306,188 @@ const c4m_vtable_t c4m_partial_lit_vtable = {
         [C4M_BI_CONSTRUCTOR] = (c4m_vtable_entry)partial_literal_init,
     },
 };
+
+int
+c4m_get_num_bitfield_words()
+{
+    return container_bitfield_words;
+}
+
+uint64_t *
+c4m_get_list_bitfield()
+{
+    c4m_init_literal_handling();
+
+    uint64_t *result = c4m_gc_array_alloc(uint64_t, container_bitfield_words);
+    for (int i = 0; i < container_bitfield_words; i++) {
+        result[i] = list_types[i];
+    }
+
+    return result;
+}
+
+uint64_t *
+c4m_get_dict_bitfield()
+{
+    c4m_init_literal_handling();
+
+    uint64_t *result = c4m_gc_array_alloc(uint64_t, container_bitfield_words);
+    for (int i = 0; i < container_bitfield_words; i++) {
+        result[i] = dict_types[i];
+    }
+
+    return result;
+}
+
+uint64_t *
+c4m_get_set_bitfield()
+{
+    c4m_init_literal_handling();
+
+    uint64_t *result = c4m_gc_array_alloc(uint64_t, container_bitfield_words);
+    for (int i = 0; i < container_bitfield_words; i++) {
+        result[i] = set_types[i];
+    }
+
+    return result;
+}
+
+uint64_t *
+c4m_get_tuple_bitfield()
+{
+    c4m_init_literal_handling();
+
+    uint64_t *result = c4m_gc_array_alloc(uint64_t, container_bitfield_words);
+    for (int i = 0; i < container_bitfield_words; i++) {
+        result[i] = tuple_types[i];
+    }
+
+    return result;
+}
+
+uint64_t *
+c4m_get_all_containers_bitfield()
+{
+    c4m_init_literal_handling();
+
+    uint64_t *result = c4m_gc_array_alloc(uint64_t, container_bitfield_words);
+    for (int i = 0; i < container_bitfield_words; i++) {
+        result[i] = all_container_types[i];
+    }
+
+    return result;
+}
+
+bool
+c4m_partial_inference(c4m_type_t *t)
+{
+    tv_options_t *tsi = t->details->tsi;
+
+    for (int i = 0; i < container_bitfield_words; i++) {
+        if (tsi->container_options[i] ^ all_container_types[i]) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+uint64_t *
+c4m_get_no_containers_bitfield()
+{
+    c4m_init_literal_handling();
+
+    return c4m_gc_array_alloc(uint64_t, container_bitfield_words);
+}
+
+bool
+c4m_list_syntax_possible(c4m_type_t *t)
+{
+    tv_options_t *tsi = t->details->tsi;
+
+    for (int i = 0; i < container_bitfield_words; i++) {
+        if (tsi->container_options[i] & list_types[i]) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool
+c4m_dict_syntax_possible(c4m_type_t *t)
+{
+    tv_options_t *tsi = t->details->tsi;
+
+    for (int i = 0; i < container_bitfield_words; i++) {
+        if (tsi->container_options[i] & dict_types[i]) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool
+c4m_set_syntax_possible(c4m_type_t *t)
+{
+    tv_options_t *tsi = t->details->tsi;
+
+    for (int i = 0; i < container_bitfield_words; i++) {
+        if (tsi->container_options[i] & set_types[i]) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool
+c4m_tuple_syntax_possible(c4m_type_t *t)
+{
+    tv_options_t *tsi = t->details->tsi;
+
+    for (int i = 0; i < container_bitfield_words; i++) {
+        if (tsi->container_options[i] & tuple_types[i]) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+void
+c4m_remove_list_options(c4m_type_t *t)
+{
+    tv_options_t *tsi = t->details->tsi;
+    for (int i = 0; i < container_bitfield_words; i++) {
+        tsi->container_options[i] &= ~(list_types[i]);
+    }
+}
+
+void
+c4m_remove_set_options(c4m_type_t *t)
+{
+    tv_options_t *tsi = t->details->tsi;
+    for (int i = 0; i < container_bitfield_words; i++) {
+        tsi->container_options[i] &= ~(set_types[i]);
+    }
+}
+
+void
+c4m_remove_dict_options(c4m_type_t *t)
+{
+    tv_options_t *tsi = t->details->tsi;
+    for (int i = 0; i < container_bitfield_words; i++) {
+        tsi->container_options[i] &= ~(dict_types[i]);
+    }
+}
+
+void
+c4m_remove_tuple_options(c4m_type_t *t)
+{
+    tv_options_t *tsi = t->details->tsi;
+    for (int i = 0; i < container_bitfield_words; i++) {
+        tsi->container_options[i] &= ~(tuple_types[i]);
+    }
+}

--- a/src/con4m/literals.c
+++ b/src/con4m/literals.c
@@ -267,20 +267,69 @@ c4m_parse_simple_lit(c4m_token_t *tok)
     return err;
 }
 
+bool
+c4m_type_has_list_syntax(c4m_type_t *t)
+{
+    uint64_t bi      = t->details->base_type->typeid;
+    int      word    = ((int)bi) / 64;
+    int      bit     = ((int)bi) % 64;
+    uint64_t to_test = 1UL << bit;
+
+    return list_types[word] & to_test;
+}
+
+bool
+c4m_type_has_dict_syntax(c4m_type_t *t)
+{
+    uint64_t bi      = t->details->base_type->typeid;
+    int      word    = ((int)bi) / 64;
+    int      bit     = ((int)bi) % 64;
+    uint64_t to_test = 1UL << bit;
+
+    return dict_types[word] & to_test;
+}
+
+bool
+c4m_type_has_set_syntax(c4m_type_t *t)
+{
+    uint64_t bi      = t->details->base_type->typeid;
+    int      word    = ((int)bi) / 64;
+    int      bit     = ((int)bi) % 64;
+    uint64_t to_test = 1UL << bit;
+
+    return set_types[word] & to_test;
+}
+
+bool
+c4m_type_has_tuple_syntax(c4m_type_t *t)
+{
+    uint64_t bi      = t->details->base_type->typeid;
+    int      word    = ((int)bi) / 64;
+    int      bit     = ((int)bi) % 64;
+    uint64_t to_test = 1UL << bit;
+
+    return tuple_types[word] & to_test;
+}
+
 static void
 partial_literal_init(c4m_partial_lit_t *partial, va_list args)
 {
-    int           n         = va_arg(args, int);
-    c4m_builtin_t base_type = va_arg(args, c4m_builtin_t);
+    int              n         = va_arg(args, int);
+    c4m_builtin_t    base_type = va_arg(args, c4m_builtin_t);
+    c4m_tree_node_t *node      = va_arg(args, c4m_tree_node_t *);
 
     partial->num_items = n;
     partial->items     = c4m_gc_array_alloc(c4m_obj_t, n);
     partial->type      = c4m_new(c4m_tspec_typespec(),
                             c4m_global_type_env,
                             base_type);
+    partial->node      = node;
 
     if (!n) {
         partial->empty_container = 1;
+        if (base_type == C4M_T_VOID) {
+            partial->empty_dict_or_set = 1;
+        }
         return;
     }
 

--- a/src/con4m/object.c
+++ b/src/con4m/object.c
@@ -423,7 +423,8 @@ const c4m_dt_info_t c4m_base_type_info[C4M_NUM_BUILTIN_DTS] = {
         .vtable    = &c4m_partial_lit_vtable,
         .dt_kind   = C4M_DT_KIND_internal,
         .hash_fn   = HATRACK_DICT_KEY_TYPE_OBJ_PTR,
-    }};
+    },
+};
 
 c4m_obj_t
 _c4m_new(c4m_type_t *type, ...)

--- a/src/con4m/object.c
+++ b/src/con4m/object.c
@@ -470,15 +470,18 @@ c4m_gc_ptr_info(c4m_builtin_t dtid)
     return (uint64_t *)c4m_base_type_info[dtid].ptr_info;
 }
 
-static const char *repr_err = "Held type does not have a __repr__ function.";
-
 c4m_str_t *
 c4m_value_obj_repr(c4m_obj_t obj)
 {
     // This does NOT work on direct values.
     c4m_repr_fn ptr = (c4m_repr_fn)c4m_vtable(obj)->methods[C4M_BI_TO_STR];
     if (!ptr) {
-        C4M_CRAISE(repr_err);
+        c4m_type_t *t = c4m_get_my_type(obj);
+        uint64_t    x = c4m_tspec_get_data_type_info(t)->typeid;
+
+        return c4m_cstr_format("{}@{:x}",
+                               c4m_new_utf8(c4m_base_type_info[x].name),
+                               c4m_box_u64((uint64_t)obj));
     }
     return (*ptr)(obj, C4M_REPR_VALUE);
 }
@@ -490,7 +493,9 @@ c4m_repr(void *item, c4m_type_t *t, to_str_use_t how)
     c4m_repr_fn p = (c4m_repr_fn)c4m_base_type_info[x].vtable->methods[C4M_BI_TO_STR];
 
     if (!p) {
-        C4M_CRAISE(repr_err);
+        return c4m_cstr_format("{}@{:x}",
+                               c4m_new_utf8(c4m_base_type_info[x].name),
+                               c4m_box_u64((uint64_t)item));
     }
 
     return (*p)(item, how);

--- a/src/con4m/path.c
+++ b/src/con4m/path.c
@@ -1,4 +1,4 @@
-#define C4M_INTERNAL_API
+#define C4M_USE_INTERNAL_API
 
 #include "con4m.h"
 

--- a/src/con4m/tree_pattern.c
+++ b/src/con4m/tree_pattern.c
@@ -401,6 +401,7 @@ kid_match_from(search_ctx_t    *ctx,
 
             ctx->captures = merge_captures(ctx->captures, one_set);
         }
+
         return true;
     }
 
@@ -440,6 +441,13 @@ kid_match_from(search_ctx_t    *ctx,
                            next_child + i,
                            next_pattern,
                            next_contents)) {
+            ctx->captures = merge_captures(ctx->captures, copy);
+            if (kid_capture_ix < c4m_xlist_len(kid_captures)) {
+                c4m_set_t *one_set = c4m_xlist_get(kid_captures,
+                                                   kid_capture_ix,
+                                                   NULL);
+                ctx->captures      = merge_captures(ctx->captures, one_set);
+            }
             return true;
         }
         else {

--- a/src/con4m/types.c
+++ b/src/con4m/types.c
@@ -488,11 +488,7 @@ c4m_tspec_copy(c4m_type_t *node, c4m_type_env_t *env)
         return result;
     }
     else {
-        result = c4m_new(c4m_tspec_typespec(),
-                         c4m_kw("name",
-                                c4m_ka(ts_from->name),
-                                "base_id",
-                                c4m_ka(ts_from->base_type->typeid)));
+        result = c4m_new(c4m_tspec_typespec(), env, ts_from->base_type->typeid);
     }
 
     int          n       = c4m_tspec_get_num_params(node);

--- a/src/con4m/types.c
+++ b/src/con4m/types.c
@@ -1172,20 +1172,15 @@ internal_repr_tv(c4m_type_t *t, c4m_dict_t *memos, int64_t *nexttv)
 
         if (num) {
             c4m_type_t *sub = c4m_tspec_get_param(t, 0);
-            c4m_utf8_t *one = internal_type_repr(
-                c4m_resolve_type_aliases(sub,
-                                         c4m_global_type_env),
-                memos,
-                nexttv);
+            c4m_utf8_t *one = internal_type_repr(sub, memos, nexttv);
+
             res = c4m_cstr_format("{}{}", res, one);
         }
 
         for (int i = 1; i < num; i++) {
-            c4m_utf8_t *one = internal_type_repr(
-                c4m_resolve_type_aliases(c4m_tspec_get_param(t, i),
-                                         c4m_global_type_env),
-                memos,
-                nexttv);
+            c4m_utf8_t *one = internal_type_repr(c4m_tspec_get_param(t, i),
+                                                 memos,
+                                                 nexttv);
 
             res = c4m_cstr_format("{}, {}", res, one);
         }
@@ -1301,6 +1296,8 @@ first_loop_start:
 c4m_str_t *
 internal_type_repr(c4m_type_t *t, c4m_dict_t *memos, int64_t *nexttv)
 {
+    t = c4m_resolve_type_aliases(t, c4m_global_type_env);
+
     c4m_type_info_t *info = t->details;
 
     switch (info->base_type->dt_kind) {

--- a/src/con4m/xlist.c
+++ b/src/con4m/xlist.c
@@ -70,6 +70,16 @@ c4m_xlist_append(c4m_xlist_t *list, void *item)
     return;
 }
 
+void *
+c4m_xlist_pop(c4m_xlist_t *list)
+{
+    if (list->append_ix == 0) {
+        C4M_CRAISE("Pop called on empty xlist.");
+    }
+
+    return c4m_xlist_get(list, --list->append_ix, NULL);
+}
+
 void
 c4m_xlist_plus_eq(c4m_xlist_t *l1, c4m_xlist_t *l2)
 {
@@ -392,6 +402,12 @@ c4m_xlist_contains(c4m_xlist_t *list, c4m_obj_t item)
     c4m_type_t *item_type = c4m_get_my_type(item);
 
     for (int i = 0; i < len; i++) {
+        if (!item_type) {
+            // Don't know why ref is giving me no item type yet,
+            // so this is a tmp fix.
+            return item == c4m_xlist_get(list, i, NULL);
+        }
+
         if (c4m_eq(item_type, item, c4m_xlist_get(list, i, NULL))) {
             return true;
         }

--- a/src/hatrack/support/hatrack_common.c
+++ b/src/hatrack/support/hatrack_common.c
@@ -35,5 +35,5 @@ hatrack_quicksort_cmp(const void *bucket1, const void *bucket2)
     item1 = (hatrack_view_t *)bucket1;
     item2 = (hatrack_view_t *)bucket2;
 
-    return item2->sort_epoch - item1->sort_epoch;
+    return item1->sort_epoch - item2->sort_epoch;
 }

--- a/src/tests/test.c
+++ b/src/tests/test.c
@@ -62,10 +62,6 @@ test1()
     c4m_str_t *s3 = c4m_new(c4m_tspec_utf8(),
                             c4m_kw("cstring", c4m_ka(" magic?\n")));
 
-    // c4m_gc_register_root(&s1, 1);
-    // c4m_gc_register_root(&s2, 1);
-    // c4m_gc_register_root(&s3, 1);
-
     c4m_ansi_render(s1, sout);
     c4m_ansi_render(s2, sout);
     c4m_ansi_render(s3, sout);
@@ -86,9 +82,6 @@ test1()
     printf("That was at %p\n", s);
 
     c4m_break_info_t *g;
-
-    // c4m_gc_register_root(&s, 1);
-    // c4m_gc_register_root(&g, 1);
 
     g = c4m_get_grapheme_breaks(s, 1, 10);
 
@@ -253,8 +246,6 @@ test4()
 
     c4m_dict_t *d = c4m_new(c4m_tspec_dict(c4m_tspec_utf8(),
                                            c4m_tspec_ref()));
-
-    c4m_gc_register_root(&d, 1);
 
     hatrack_dict_put(d, w1, "w1");
     hatrack_dict_put(d, w2, "w2");
@@ -762,7 +753,6 @@ main(int argc, char **argv, char **envp)
         test1();
         // style1 = apply_bg_color(style1, "alice blue");
         c4m_str_t *to_slice = test2();
-        // c4m_gc_register_root(&to_slice, 1);
         test3(to_slice);
         to_slice = NULL;
         test4();

--- a/src/tests/test.c
+++ b/src/tests/test.c
@@ -649,6 +649,7 @@ test_compiler()
 
     // c4m_clean_environment();
     // c4m_print(c4m_format_global_type_environment());
+    c4m_print_parse_node(ctx->entry_point->parse_tree);
 }
 #else
 #define test_compiler(...)

--- a/src/tests/test.c
+++ b/src/tests/test.c
@@ -618,10 +618,10 @@ test_compiler()
 
         ctx = c4m_compile_from_entry_point(path);
 
-        c4m_print(c4m_format_tokens(ctx->entry_point));
+        // c4m_print(c4m_format_tokens(ctx->entry_point));
 
         if (ctx->entry_point->parse_tree) {
-            c4m_print(c4m_format_parse_tree(ctx->entry_point));
+            // c4m_print(c4m_format_parse_tree(ctx->entry_point));
         }
 
         c4m_print(c4m_cstr_format("[atomic lime]info: [/] Finished parsing: {}",
@@ -632,7 +632,23 @@ test_compiler()
         if (err_output != NULL) {
             c4m_print(err_output);
         }
+        else {
+            c4m_print(c4m_cfg_repr(ctx->entry_point->cfg));
+            c4m_print(c4m_rich_lit("[h2]Global Scope"));
+            c4m_print(c4m_format_scope(ctx->final_globals));
+            c4m_print(c4m_rich_lit("[h2]Module Scope for entry point module"));
+            c4m_print(c4m_format_scope(ctx->entry_point->module_scope));
+        }
     }
+    c4m_print(c4m_str_to_type(c4m_new_utf8("(dict[`x, list[int]]) -> int")));
+
+    // TODO: We need to mark unlocked types with sub-variables at some point,
+    // so they don't get clobbered.
+    //
+    // E.g.,  (dict[`x, list[int]]) -> int
+
+    // c4m_clean_environment();
+    // c4m_print(c4m_format_global_type_environment());
 }
 #else
 #define test_compiler(...)

--- a/tests/decls.c4m
+++ b/tests/decls.c4m
@@ -1,3 +1,16 @@
 global const x: int
-const y, z: int, x: bool = 8
-var a, b = 2, c
+const y = -12, z: int, abc : bool = true, xyz: int = 8000
+var a, b: int = 2, c = 4
+cxcsd
+foo: for moo, moo2 in [1,2,3,4] {
+  n
+  break foo
+}
+x
+for l from 1 to 10 {
+  m
+  break;
+}
+for zzzz from qwerty[2] to 100 {
+dsflkjfslkdj
+}

--- a/tests/decls.c4m
+++ b/tests/decls.c4m
@@ -8,12 +8,12 @@ global const x: int
 const y = -12, z: int, abc : bool = true, xyz: int = 8000
 var a, b: int = 2, c = 4
 cxcsd
-foo: for moo, moo2 in [1,2,3,4] {
+foo: for moo, moo2 in { 1 : "foo", 2: "4" } {
   n
   break foo
 }
 x
-for lololo from 1 to 10 {
+for lololo from 1 to "fuck" {
   m
   break;
 }
@@ -34,4 +34,7 @@ oopsie = xyz + y
 
 if (noidea == 2) {
   noidea += 1
+}
+if (2 < "foo") {
+   x = - "foo"
 }

--- a/tests/decls.c4m
+++ b/tests/decls.c4m
@@ -1,3 +1,9 @@
+func testfn(f: int, g: int) {
+  return f + g
+}
+
+var noidea
+
 global const x: int
 const y = -12, z: int, abc : bool = true, xyz: int = 8000
 var a, b: int = 2, c = 4
@@ -7,10 +13,25 @@ foo: for moo, moo2 in [1,2,3,4] {
   break foo
 }
 x
-for l from 1 to 10 {
+for lololo from 1 to 10 {
   m
   break;
 }
-for zzzz from qwerty[2] to 100 {
-dsflkjfslkdj
+
+for zzzz in qwerty {
+  dsflkjfslkdj
+}
+
+# Re
+# AWS module
+
+
+var bar = 2, boz = 5
+
+testfn(bar, boz);
+
+oopsie = xyz + y
+
+if (noidea == 2) {
+  noidea += 1
 }

--- a/tests/decls2.c4m
+++ b/tests/decls2.c4m
@@ -13,7 +13,7 @@ foo: for moo, moo2 in { 1 : "foo", 2: "4" } {
   break foo
 }
 x
-for lololo from 1 to 2 {
+for lololo from 1 to "oops" {
   m
   break;
 }
@@ -35,13 +35,6 @@ oopsie = xyz + y
 if (noidea == 2) {
   noidea += 1
 }
-if (2 < foo) {
-   x = - 18
+if (2 < "foo") {
+   x = - "foo"
 }
-
-index_test = foobar[2]
-
-foobar = [1,2]
-
-assert(foobar == [4])
-//assert(foobar == [index_test])

--- a/tests/enum2.c4m
+++ b/tests/enum2.c4m
@@ -1,0 +1,7 @@
+enum { E1, E2 }
+enum strenum { C1 = "foo", C2 = "bar" }
+enum strenum2 { C3 = "foo", C4 = "bar", C5 = "boz", }
+// todo: local is broke
+enum global intenum {
+  X = 1, Y, Z
+}

--- a/tests/fib.c4m
+++ b/tests/fib.c4m
@@ -1,4 +1,5 @@
 func n(m: int) -> int {
+
 if m == 1 {
     return 1
   }

--- a/tests/fib.c4m
+++ b/tests/fib.c4m
@@ -1,9 +1,20 @@
-func n(m) {
-  if m <= 1 {
+func n(m: int) -> int {
+if m == 1 {
     return 1
   }
-  
-  return n(m - 1) + n(m - 2)
+  elif m == 0 {
+    return 1
+  }
+  elif m > 1 {
+    return n(m - 1) + n(m - 2)
+  }
+  else {
+    return -1;
+  }
+}
+
+func foo(x) {
+  x + x
 }
 
 assert n(18) == 4181

--- a/tests/sections.c4m
+++ b/tests/sections.c4m
@@ -8,15 +8,15 @@ hello {
 
 hello {
   world {
-  
+        y = foo
   }
 }
 
 # These no longer work, as it is too easy to do this on accident.
 # But the error probably should be improved.
 
-hello world
-hello "world"
+//hello world
+//hello "world"
 
 # This should not work; should give a use-before-def.
 # But for now this is disabled.

--- a/tests/switch.c4m
+++ b/tests/switch.c4m
@@ -9,3 +9,5 @@ switch x {
     else:
         y = -1
   }
+
+y *= 2

--- a/tests/switch.c4m
+++ b/tests/switch.c4m
@@ -1,0 +1,11 @@
+
+switch x {
+    case a:
+       y = x 
+    case b:
+       y = 1 + x
+    case c:
+       y = 100 + x
+    else:
+        y = -1
+  }

--- a/tests/typeof.c4m
+++ b/tests/typeof.c4m
@@ -1,0 +1,13 @@
+
+typeof x {
+    case int:
+       y = x 
+    case bool:
+       z = x
+    case string:
+       a = "foo" + x
+    case list[`x]:
+      y = 1
+    else:
+        y = -1
+  }

--- a/tests/typeof.c4m
+++ b/tests/typeof.c4m
@@ -6,8 +6,10 @@ typeof x {
        z = x
     case string:
        a = "foo" + x
+       qwerty = uio
     case list[`x]:
       y = 1
     else:
         y = -1
   }
+z = false


### PR DESCRIPTION
The second pass is done enough to move on to code generation. It:

1. Type checks everything, including non-declared symbols.
2. Builds full control flow graphs that contain execution-ordered defs/uses.
3. Adds in auto-declared variables; `$result` for functions, `$i` for loops, and `$last` for `for` loops.
4. I redid the way that generic types are done so that they implicitly track what known container types can / cannot match. This, plus the willingness to generate type-cased calls will allow me to avoid the problem of having to declare param types when the only thing you do to it is index it, for instance (which has always been the case in the Nim c4m). I don't think there is anything at all that *needs* a written type for disambiguation at the moment, and very little will require dynamic checks.

There are some things I'm leaving for later:

1. I have not done the walk of the CFG yet to generate error messages about use-before-def problems, returns on every branch, etc. But the graph is otherwise completely built.
2.  While I erase `$result` from function scopes if it isn't used, I'm not yet erasing the loop variables when they're not used (I intend to deal when doing codegen).
3. Because of that lack of erasure, I don't yet warn when something like `$i` is ambiguous. However, there is a disambiguation scheme; if you label loops, `label$i` and, if appropriate, `label$last` are available. Again, I was planning on adding these warnings in code gen.
5. Most of the builtin operations (like addition, etc) are essentially converted into magic (polymorphic) function calls, like `__add__`. I am not yet statically binding where possible; this too I expect to do at code gen (generating type casing when static binding isn't possible).
6. Though I wasn't planning on re-doing constant folding until later, I didn't go ahead and do it :)
7. There are probably plenty of bugs / issues to shake out, including a few already on my list... most significantly, I keep forgetting to check, but I think I might have forgotten to make functions from imported modules available outside the module (which won't be much work, but will be natural to handle in codegen).