### PR TITLE
A handful of fixes for compiler warnings

### DIFF
--- a/include/con4m/exception.h
+++ b/include/con4m/exception.h
@@ -217,7 +217,7 @@ c4m_raise_errno()
     c4m_raise_errcode(errno);
 }
 
-#define unreachable()                                       \
+#define c4m_unreachable()                                   \
     {                                                       \
         c4m_utf8_t *s = c4m_cstr_format(                    \
             "Reached code that the developer "              \

--- a/src/con4m/frontend/cfg.c
+++ b/src/con4m/frontend/cfg.c
@@ -618,6 +618,7 @@ cfg_process_node(cfg_ctx *ctx, c4m_cfg_node_t *node, c4m_cfg_node_t *parent)
                          &node->sometimes_live);
         return NULL;
     }
+    c4m_unreachable();
 }
 
 // The input will be the module, plus any d/u info that we inherit, which

--- a/src/con4m/frontend/cfg_repr.c
+++ b/src/con4m/frontend/cfg_repr.c
@@ -323,7 +323,7 @@ du_format_node(c4m_cfg_node_t *n)
         sometimes_live = n->sometimes_live;
         break;
     default:
-        unreachable();
+        c4m_unreachable();
     }
 
     if (liveness_info == NULL) {
@@ -505,7 +505,7 @@ c4m_cfg_repr_internal(c4m_cfg_node_t  *node,
     switch (node->kind) {
     case c4m_cfg_block_entrance:
     case c4m_cfg_node_branch:
-        unreachable();
+        c4m_unreachable();
     case c4m_cfg_block_exit:
         link = node->contents.flow.next_node;
 

--- a/src/con4m/frontend/check_pass.c
+++ b/src/con4m/frontend/check_pass.c
@@ -616,7 +616,7 @@ sym_lookup(pass2_ctx *ctx, c4m_utf8_t *name)
                               ctx->node,
                               attr_info->err_arg);
             default:
-                unreachable();
+                c4m_unreachable();
             }
 
             return NULL;
@@ -1635,7 +1635,7 @@ builtin_bincall(pass2_ctx *ctx)
         set_node_type(ctx, ctx->node, c4m_tspec_bool());
         return;
     default:
-        unreachable();
+        c4m_unreachable();
     }
 }
 

--- a/src/con4m/frontend/check_pass.c
+++ b/src/con4m/frontend/check_pass.c
@@ -615,6 +615,7 @@ sym_lookup(pass2_ctx *ctx, c4m_utf8_t *name)
                               c4m_err_section_not_allowed,
                               ctx->node,
                               attr_info->err_arg);
+                break;
             default:
                 c4m_unreachable();
             }

--- a/src/con4m/frontend/decl_pass.c
+++ b/src/con4m/frontend/decl_pass.c
@@ -516,7 +516,7 @@ handle_param_block(pass1_ctx *ctx)
             prop->default_value = node_literal(ctx->file_ctx, lit, NULL);
             break;
         default:
-            unreachable();
+            c4m_unreachable();
         }
     }
 

--- a/src/con4m/frontend/parse.c
+++ b/src/con4m/frontend/parse.c
@@ -961,7 +961,7 @@ simple_lit(parse_ctx *ctx)
                 break;
 
             default:
-                unreachable();
+                c4m_unreachable();
             }
 
             c4m_error_from_token(ctx->file_ctx, err, tok, mod, syntax_kind);
@@ -3726,7 +3726,7 @@ bad_start:
     case c4m_tt_lbrace:
         break;
     default:
-        unreachable();
+        c4m_unreachable();
     }
 
     body(ctx, (c4m_pnode_t *)c4m_tree_get_contents(result));

--- a/src/con4m/frontend/scope.c
+++ b/src/con4m/frontend/scope.c
@@ -42,7 +42,7 @@ c4m_sym_get_best_ref_loc(c4m_scope_entry_t *sym)
         return c4m_node_get_loc_str(node);
     }
 
-    unreachable();
+    c4m_unreachable();
 }
 
 void
@@ -319,7 +319,7 @@ c4m_merge_symbols(c4m_file_compile_ctx *ctx1,
     default:
         // For instance, we never call this on scopes
         // that hold sk_module symbols or sk_formal symbols.
-        unreachable();
+        c4m_unreachable();
     }
 }
 

--- a/src/con4m/frontend/treematch.c
+++ b/src/con4m/frontend/treematch.c
@@ -494,7 +494,7 @@ c4m_node_to_type(c4m_file_compile_ctx *ctx,
         return c4m_tspec_fn(t, args, va);
 
     default:
-        unreachable();
+        c4m_unreachable();
     }
 }
 

--- a/src/con4m/literals.c
+++ b/src/con4m/literals.c
@@ -65,7 +65,7 @@ c4m_register_container_type(c4m_builtin_t    bi,
         tuple_types[word] |= 1UL << bit;
         return;
     default:
-        unreachable();
+        c4m_unreachable();
     }
 }
 

--- a/src/con4m/marshal.c
+++ b/src/con4m/marshal.c
@@ -200,8 +200,7 @@ c4m_unmarshal_compact_type(c4m_stream_t *s)
         c4m_type_hash(result, c4m_global_type_env);
         return result;
     }
-    // unreachable
-    abort();
+    c4m_unreachable();
 }
 
 void

--- a/src/con4m/types.c
+++ b/src/con4m/types.c
@@ -298,7 +298,7 @@ type_hash_and_dedupe(c4m_type_t **nodeptr, c4m_type_env_t *env)
         hatrack_dict_add(env->store, (void *)node->typeid, node);
         return node->typeid;
     case C4M_DT_KIND_type_var:
-        unreachable();
+        c4m_unreachable();
     default:
         ctx.env      = env;
         ctx.sha      = c4m_new(c4m_tspec_hash());
@@ -1109,7 +1109,7 @@ unify_sub_nodes:
         // Either not implemented yet or covered before the switch.
         // These are all implemented in the Nim checker but won't
         // be moved until Con4m is using them.
-        unreachable();
+        c4m_unreachable();
     }
 
     type_hash_and_dedupe(&result, env);


### PR DESCRIPTION
* c23 adds `unreachable` to `stddef.h` (https://en.cppreference.com/w/c/program/unreachable) Looks like gcc got around to adding this, at least as of 13.2.1. I'm not sure what gcc version I was using before, but a recent `dnf update` must've upgraded it.
* missing break in switch case somehow slipped thru
* missing return fixed with `c4m_unreachable()`
* unused copy/pasted code from dict to set removed