### PR TITLE
Remove private stuff from public hatrack headers

### DIFF
--- a/include/hatrack.h
+++ b/include/hatrack.h
@@ -20,6 +20,7 @@
  */
 
 #include "hatrack/base.h"
+#include "hatrack/hatomic.h"
 
 // Our dictionary algorithms
 #include "hatrack/crown.h"

--- a/include/hatrack.h
+++ b/include/hatrack.h
@@ -20,14 +20,6 @@
  */
 
 #include "hatrack/base.h"
-#include "hatrack/debug.h"
-#include "hatrack/malloc.h"
-
-#include "hatrack/counters.h"
-#include "hatrack/mmm.h"
-#include "hatrack/gate.h"
-#include "hatrack/hatrack_common.h"
-#include "hatrack/lohat_common.h"
 
 // Our dictionary algorithms
 #include "hatrack/crown.h"

--- a/include/hatrack.h
+++ b/include/hatrack.h
@@ -23,9 +23,7 @@
 #include "hatrack/debug.h"
 #include "hatrack/malloc.h"
 
-#include "hatrack/xxhash.h"
 #include "hatrack/counters.h"
-#include "hatrack/hatomic.h"
 #include "hatrack/mmm.h"
 #include "hatrack/gate.h"
 #include "hatrack/hatrack_common.h"

--- a/include/hatrack/arr64.h
+++ b/include/hatrack/arr64.h
@@ -54,17 +54,17 @@ typedef struct {
 } arr64_t;
 
 // clang-format off
-arr64_t      *arr64_new               (uint64_t);
-void          arr64_init              (arr64_t *, uint64_t);
-void          arr64_set_ret_callback  (arr64_t *, arr64_callback_t);
-void          arr64_set_eject_callback(arr64_t *, arr64_callback_t);
-void          arr64_cleanup           (arr64_t *);
-void          arr64_delete            (arr64_t *);
-void         *arr64_get               (arr64_t *, uint64_t, int *);
-bool          arr64_set               (arr64_t *, uint64_t, void *);
-void          arr64_grow              (arr64_t *, uint64_t);
-void          arr64_shrink            (arr64_t *, uint64_t);
-uint32_t      arr64_len               (arr64_t *);
-arr64_view_t *arr64_view              (arr64_t *);
-void         *arr64_view_next         (arr64_view_t *, bool *);
-void          arr64_view_delete       (arr64_view_t *);
+HATRACK_EXTERN arr64_t      *arr64_new               (uint64_t);
+HATRACK_EXTERN void          arr64_init              (arr64_t *, uint64_t);
+HATRACK_EXTERN void          arr64_set_ret_callback  (arr64_t *, arr64_callback_t);
+HATRACK_EXTERN void          arr64_set_eject_callback(arr64_t *, arr64_callback_t);
+HATRACK_EXTERN void          arr64_cleanup           (arr64_t *);
+HATRACK_EXTERN void          arr64_delete            (arr64_t *);
+HATRACK_EXTERN void         *arr64_get               (arr64_t *, uint64_t, int *);
+HATRACK_EXTERN bool          arr64_set               (arr64_t *, uint64_t, void *);
+HATRACK_EXTERN void          arr64_grow              (arr64_t *, uint64_t);
+HATRACK_EXTERN void          arr64_shrink            (arr64_t *, uint64_t);
+HATRACK_EXTERN uint32_t      arr64_len               (arr64_t *);
+HATRACK_EXTERN arr64_view_t *arr64_view              (arr64_t *);
+HATRACK_EXTERN void         *arr64_view_next         (arr64_view_t *, bool *);
+HATRACK_EXTERN void          arr64_view_delete       (arr64_view_t *);

--- a/include/hatrack/arr64.h
+++ b/include/hatrack/arr64.h
@@ -25,9 +25,6 @@
 
 #include "base.h"
 
-#define ARR64_MIN_STORE_SZ_LOG 4
-
-// clang-format off
 typedef void (*arr64_callback_t)(void *);
 
 typedef uint64_t arr64_item_t;
@@ -45,17 +42,18 @@ typedef struct {
 struct arr64_store_t {
     uint64_t                 store_size;
     _Atomic uint64_t         array_size;
-    _Atomic (arr64_store_t *)next;
+    _Atomic(arr64_store_t *) next;
     _Atomic bool             claimed;
     arr64_cell_t             cells[];
 };
 
 typedef struct {
-    arr64_callback_t          ret_callback;
-    arr64_callback_t          eject_callback;
-    _Atomic (arr64_store_t  *)store;
+    arr64_callback_t         ret_callback;
+    arr64_callback_t         eject_callback;
+    _Atomic(arr64_store_t *) store;
 } arr64_t;
 
+// clang-format off
 arr64_t      *arr64_new               (uint64_t);
 void          arr64_init              (arr64_t *, uint64_t);
 void          arr64_set_ret_callback  (arr64_t *, arr64_callback_t);
@@ -70,15 +68,3 @@ uint32_t      arr64_len               (arr64_t *);
 arr64_view_t *arr64_view              (arr64_t *);
 void         *arr64_view_next         (arr64_view_t *, bool *);
 void          arr64_view_delete       (arr64_view_t *);
-
-enum64(arr64_enum_t,
-       ARR64_USED   = 0x00000000000000001,
-       ARR64_MOVED  = 0x00000000000000002,
-       ARR64_MOVING = 0x00000000000000004
-       );
-
-enum {
-    ARR64_OK,
-    ARR64_OOB,
-    ARR64_UNINITIALIZED
-};

--- a/include/hatrack/base.h
+++ b/include/hatrack/base.h
@@ -30,3 +30,7 @@
 #include <stdatomic.h>
 
 #include <pthread.h>
+
+#ifndef HATRACK_EXTERN
+#define HATRACK_EXTERN extern
+#endif

--- a/include/hatrack/capq.h
+++ b/include/hatrack/capq.h
@@ -48,10 +48,7 @@
 #pragma once
 
 #include "base.h"
-#include "hatomic.h"
-#include "hq.h"
 
-// clang-format off
 typedef struct {
     void    *item;
     uint64_t state;
@@ -64,7 +61,7 @@ typedef _Atomic capq_item_t capq_cell_t;
 typedef struct capq_store_t capq_store_t;
 
 struct capq_store_t {
-    _Atomic (capq_store_t *)next_store;
+    _Atomic(capq_store_t *) next_store;
     uint64_t                size;
     _Atomic uint64_t        enqueue_index;
     _Atomic uint64_t        dequeue_index;
@@ -72,26 +69,11 @@ struct capq_store_t {
 };
 
 typedef struct {
-    _Atomic (capq_store_t *)store;
+    _Atomic(capq_store_t *) store;
     _Atomic int64_t         len;
 } capq_t;
 
-enum {
-    CAPQ_EMPTY              = 0x0000000000000000,
-    CAPQ_ENQUEUED           = 0x1000000000000000,
-    CAPQ_DEQUEUED           = 0x2000000000000000,
-    CAPQ_MOVED              = 0x4000000000000000,
-    CAPQ_MOVING             = 0x8000000000000000,
-    CAPQ_FLAG_MASK          = 0xf000000000000000,
-    CAPQ_STORE_INITIALIZING = 0xffffffffffffffff
-};
-
-static inline int64_t
-capq_len(hq_t *self)
-{
-    return atomic_read(&self->len);
-}
-
+// clang-format off
 capq_t    *capq_new        (void);
 capq_t    *capq_new_size   (uint64_t);
 void       capq_init       (capq_t *);
@@ -102,68 +84,4 @@ uint64_t   capq_enqueue    (capq_t *, void *);
 capq_top_t capq_top        (capq_t *, bool *);
 bool       capq_cap        (capq_t *, uint64_t);
 void      *capq_dequeue    (capq_t *, bool *);
-
-static inline uint64_t
-capq_set_enqueued(uint64_t ix)
-{
-    return CAPQ_ENQUEUED | ix;
-}
-
-static inline bool
-capq_is_moving(uint64_t state)
-{
-    return state & CAPQ_MOVING;
-}
-
-static inline bool
-capq_is_moved(uint64_t state)
-{
-    return state & CAPQ_MOVED;
-}
-
-static inline bool
-capq_is_enqueued(uint64_t state)
-{
-    return state & CAPQ_ENQUEUED;
-}
-
-static inline bool
-capq_is_dequeued(uint64_t state)
-{
-    return state & CAPQ_DEQUEUED;
-}
-
-static inline uint64_t
-capq_extract_epoch(uint64_t state)
-{
-    return state & ~(CAPQ_FLAG_MASK);
-}
-
-static inline uint64_t
-capq_ix(uint64_t seq, uint64_t sz)
-{
-    return seq & (sz-1);
-}
-
-static inline uint64_t
-capq_set_state_dequeued(uint64_t state)
-{
-    return (state & ~CAPQ_ENQUEUED) | CAPQ_DEQUEUED;
-}
-
-static inline uint64_t
-capq_clear_moving(uint64_t state)
-{
-    return state & (~(CAPQ_MOVING|CAPQ_MOVED));
-}
-
-// Precondition-- we are looking at the right epoch.
-static inline bool
-capq_should_return(uint64_t state)
-{
-    if (capq_is_enqueued(state) || capq_is_dequeued(state)) {
-	return true;
-    }
-
-    return false;
-}
+uint64_t   capq_len        (capq_t *);

--- a/include/hatrack/capq.h
+++ b/include/hatrack/capq.h
@@ -74,14 +74,14 @@ typedef struct {
 } capq_t;
 
 // clang-format off
-capq_t    *capq_new        (void);
-capq_t    *capq_new_size   (uint64_t);
-void       capq_init       (capq_t *);
-void       capq_init_size  (capq_t *, uint64_t);
-void       capq_cleanup    (capq_t *);
-void       capq_delete     (capq_t *);
-uint64_t   capq_enqueue    (capq_t *, void *);
-capq_top_t capq_top        (capq_t *, bool *);
-bool       capq_cap        (capq_t *, uint64_t);
-void      *capq_dequeue    (capq_t *, bool *);
-uint64_t   capq_len        (capq_t *);
+HATRACK_EXTERN capq_t    *capq_new        (void);
+HATRACK_EXTERN capq_t    *capq_new_size   (uint64_t);
+HATRACK_EXTERN void       capq_init       (capq_t *);
+HATRACK_EXTERN void       capq_init_size  (capq_t *, uint64_t);
+HATRACK_EXTERN void       capq_cleanup    (capq_t *);
+HATRACK_EXTERN void       capq_delete     (capq_t *);
+HATRACK_EXTERN uint64_t   capq_enqueue    (capq_t *, void *);
+HATRACK_EXTERN capq_top_t capq_top        (capq_t *, bool *);
+HATRACK_EXTERN bool       capq_cap        (capq_t *, uint64_t);
+HATRACK_EXTERN void      *capq_dequeue    (capq_t *, bool *);
+HATRACK_EXTERN uint64_t   capq_len        (capq_t *);

--- a/include/hatrack/counters.h
+++ b/include/hatrack/counters.h
@@ -175,8 +175,8 @@ hatrack_yn_ctr_f(uint64_t id)
     return 0;
 }
 
-void counters_output_delta(void);
-void counters_output_alltime(void);
+HATRACK_EXTERN void counters_output_delta(void);
+HATRACK_EXTERN void counters_output_alltime(void);
 
 #define HATRACK_CTR_ON(id) atomic_fetch_add(&hatrack_counters[id], 1)
 #define HATRACK_CTR_OFF(id)

--- a/include/hatrack/crown.h
+++ b/include/hatrack/crown.h
@@ -109,7 +109,6 @@ hatrack_view_t *crown_view_slow  (crown_t *, uint64_t *, bool);
  * MMM. But, they should be considered "friend" functions, and not
  * part of the public API.
  */
-#ifdef HATRACK_INTERNAL_API
 crown_store_t    *crown_store_new    (uint64_t);
 void             *crown_store_get    (crown_store_t *, hatrack_hash_t, bool *);
 void             *crown_store_put    (crown_store_t *, crown_t *,
@@ -120,4 +119,3 @@ bool              crown_store_add    (crown_store_t *, crown_t *,
 				      hatrack_hash_t, void *, uint64_t);
 void             *crown_store_remove (crown_store_t *, crown_t *,
 				      hatrack_hash_t, bool *, uint64_t);
-#endif

--- a/include/hatrack/crown.h
+++ b/include/hatrack/crown.h
@@ -64,18 +64,18 @@ typedef struct {
 } crown_t;
 
 // clang-format off
-crown_t        *crown_new        (void);
-crown_t        *crown_new_size   (char);
-void            crown_init       (crown_t *);
-void            crown_init_size  (crown_t *, char);
-void            crown_cleanup    (crown_t *);
-void            crown_delete     (crown_t *);
-void           *crown_get        (crown_t *, hatrack_hash_t, bool *);
-void           *crown_put        (crown_t *, hatrack_hash_t, void *, bool *);
-void           *crown_replace    (crown_t *, hatrack_hash_t, void *, bool *);
-bool            crown_add        (crown_t *, hatrack_hash_t, void *);
-void           *crown_remove     (crown_t *, hatrack_hash_t, bool *);
-uint64_t        crown_len        (crown_t *);
-hatrack_view_t *crown_view       (crown_t *, uint64_t *, bool);
-hatrack_view_t *crown_view_fast  (crown_t *, uint64_t *, bool);
-hatrack_view_t *crown_view_slow  (crown_t *, uint64_t *, bool);
+HATRACK_EXTERN crown_t        *crown_new        (void);
+HATRACK_EXTERN crown_t        *crown_new_size   (char);
+HATRACK_EXTERN void            crown_init       (crown_t *);
+HATRACK_EXTERN void            crown_init_size  (crown_t *, char);
+HATRACK_EXTERN void            crown_cleanup    (crown_t *);
+HATRACK_EXTERN void            crown_delete     (crown_t *);
+HATRACK_EXTERN void           *crown_get        (crown_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *crown_put        (crown_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *crown_replace    (crown_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN bool            crown_add        (crown_t *, hatrack_hash_t, void *);
+HATRACK_EXTERN void           *crown_remove     (crown_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN uint64_t        crown_len        (crown_t *);
+HATRACK_EXTERN hatrack_view_t *crown_view       (crown_t *, uint64_t *, bool);
+HATRACK_EXTERN hatrack_view_t *crown_view_fast  (crown_t *, uint64_t *, bool);
+HATRACK_EXTERN hatrack_view_t *crown_view_slow  (crown_t *, uint64_t *, bool);

--- a/include/hatrack/crown.h
+++ b/include/hatrack/crown.h
@@ -29,34 +29,10 @@
 #include "base.h"
 #include "hatrack_common.h"
 
-#ifdef HATRACK_32_BIT_HOP_TABLE
-
-#define CROWN_HOME_BIT 0x80000000
-
-typedef uint32_t hop_t;
-
-#define CLZ(n) __builtin_clzl(n)
-
-#else
-
-#define CROWN_HOME_BIT 0x8000000000000000
-
-typedef uint64_t hop_t;
-
-#define CLZ(n) __builtin_clzll(n)
-
-#endif
-
 typedef struct {
     void    *item;
     uint64_t info;
 } crown_record_t;
-
-enum64(crown_flag_t,
-       CROWN_F_MOVING   = 0x8000000000000000,
-       CROWN_F_MOVED    = 0x4000000000000000,
-       CROWN_F_INITED   = 0x2000000000000000,
-       CROWN_EPOCH_MASK = 0x1fffffffffffffff);
 
 typedef struct {
     _Atomic hatrack_hash_t hv;
@@ -103,19 +79,3 @@ uint64_t        crown_len        (crown_t *);
 hatrack_view_t *crown_view       (crown_t *, uint64_t *, bool);
 hatrack_view_t *crown_view_fast  (crown_t *, uint64_t *, bool);
 hatrack_view_t *crown_view_slow  (crown_t *, uint64_t *, bool);
-
-/* These need to be non-static because tophat and hatrack_dict both
- * need them, so that they can call in without a second call to
- * MMM. But, they should be considered "friend" functions, and not
- * part of the public API.
- */
-crown_store_t    *crown_store_new    (uint64_t);
-void             *crown_store_get    (crown_store_t *, hatrack_hash_t, bool *);
-void             *crown_store_put    (crown_store_t *, crown_t *,
-				      hatrack_hash_t, void *, bool *, uint64_t);
-void             *crown_store_replace(crown_store_t *, crown_t *,
-				      hatrack_hash_t, void *, bool *, uint64_t);
-bool              crown_store_add    (crown_store_t *, crown_t *,
-				      hatrack_hash_t, void *, uint64_t);
-void             *crown_store_remove (crown_store_t *, crown_t *,
-				      hatrack_hash_t, bool *, uint64_t);

--- a/include/hatrack/debug.h
+++ b/include/hatrack/debug.h
@@ -52,14 +52,12 @@
  * go right up to the end of the array, make sure we get a zero,
  * whatever the semantics of the strncpy() implementation.
  */
-// clang-format off
 typedef struct {
-    char      msg[HATRACK_DEBUG_MSG_SIZE];
-    char      null;
-    uint64_t  sequence;
-    int64_t   thread;
+    char     msg[HATRACK_DEBUG_MSG_SIZE];
+    char     null;
+    uint64_t sequence;
+    int64_t  thread;
 } hatrack_debug_record_t;
-
 
 /*
  * __hatrack_debug_sequence is a monotoincally increasing counter for
@@ -75,6 +73,8 @@ typedef struct {
  * threads don't stomp on each other's insertions while a write is in
  * progress.
  */
+
+// clang-format off
 extern hatrack_debug_record_t __hatrack_debug[];
 extern _Atomic uint64_t       __hatrack_debug_sequence;
 extern const char             __hatrack_hex_conversion_table[];
@@ -95,7 +95,6 @@ void debug_thread       (void);
 void debug_other_thread (int64_t);
 void debug_grep         (char *);
 void debug_pgrep        (uintptr_t);
-
 // clang-format on
 
 /* hatrack_debug()

--- a/include/hatrack/dict.h
+++ b/include/hatrack/dict.h
@@ -73,34 +73,34 @@ struct hatrack_dict_t {
 };
 
 // clang-format off
-hatrack_dict_t *hatrack_dict_new    (uint32_t);
-void            hatrack_dict_init   (hatrack_dict_t *, uint32_t);
-void            hatrack_dict_cleanup(hatrack_dict_t *);
-void            hatrack_dict_delete (hatrack_dict_t *);
+HATRACK_EXTERN hatrack_dict_t *hatrack_dict_new    (uint32_t);
+HATRACK_EXTERN void            hatrack_dict_init   (hatrack_dict_t *, uint32_t);
+HATRACK_EXTERN void            hatrack_dict_cleanup(hatrack_dict_t *);
+HATRACK_EXTERN void            hatrack_dict_delete (hatrack_dict_t *);
 
-void hatrack_dict_set_hash_offset     (hatrack_dict_t *, int32_t);
-void hatrack_dict_set_cache_offset    (hatrack_dict_t *, int32_t);
-void hatrack_dict_set_custom_hash     (hatrack_dict_t *, hatrack_hash_func_t);
-void hatrack_dict_set_free_handler    (hatrack_dict_t *, hatrack_mem_hook_t);
-void hatrack_dict_set_key_return_hook (hatrack_dict_t *, hatrack_mem_hook_t);
-void hatrack_dict_set_val_return_hook (hatrack_dict_t *, hatrack_mem_hook_t);
-void hatrack_dict_set_consistent_views(hatrack_dict_t *, bool);
-void hatrack_dict_set_sorted_views    (hatrack_dict_t *, bool);
-bool hatrack_dict_get_consistent_views(hatrack_dict_t *);
-bool hatrack_dict_get_sorted_views    (hatrack_dict_t *);
+HATRACK_EXTERN void hatrack_dict_set_hash_offset     (hatrack_dict_t *, int32_t);
+HATRACK_EXTERN void hatrack_dict_set_cache_offset    (hatrack_dict_t *, int32_t);
+HATRACK_EXTERN void hatrack_dict_set_custom_hash     (hatrack_dict_t *, hatrack_hash_func_t);
+HATRACK_EXTERN void hatrack_dict_set_free_handler    (hatrack_dict_t *, hatrack_mem_hook_t);
+HATRACK_EXTERN void hatrack_dict_set_key_return_hook (hatrack_dict_t *, hatrack_mem_hook_t);
+HATRACK_EXTERN void hatrack_dict_set_val_return_hook (hatrack_dict_t *, hatrack_mem_hook_t);
+HATRACK_EXTERN void hatrack_dict_set_consistent_views(hatrack_dict_t *, bool);
+HATRACK_EXTERN void hatrack_dict_set_sorted_views    (hatrack_dict_t *, bool);
+HATRACK_EXTERN bool hatrack_dict_get_consistent_views(hatrack_dict_t *);
+HATRACK_EXTERN bool hatrack_dict_get_sorted_views    (hatrack_dict_t *);
 
-void *hatrack_dict_get    (hatrack_dict_t *, void *, bool *);
-void  hatrack_dict_put    (hatrack_dict_t *, void *, void *);
-bool  hatrack_dict_replace(hatrack_dict_t *, void *, void *);
-bool  hatrack_dict_add    (hatrack_dict_t *, void *, void *);
-bool  hatrack_dict_remove (hatrack_dict_t *, void *);
+HATRACK_EXTERN void *hatrack_dict_get    (hatrack_dict_t *, void *, bool *);
+HATRACK_EXTERN void  hatrack_dict_put    (hatrack_dict_t *, void *, void *);
+HATRACK_EXTERN bool  hatrack_dict_replace(hatrack_dict_t *, void *, void *);
+HATRACK_EXTERN bool  hatrack_dict_add    (hatrack_dict_t *, void *, void *);
+HATRACK_EXTERN bool  hatrack_dict_remove (hatrack_dict_t *, void *);
 
-hatrack_dict_key_t   *hatrack_dict_keys         (hatrack_dict_t *, uint64_t *);
-hatrack_dict_value_t *hatrack_dict_values       (hatrack_dict_t *, uint64_t *);
-hatrack_dict_item_t  *hatrack_dict_items        (hatrack_dict_t *, uint64_t *);
-hatrack_dict_key_t   *hatrack_dict_keys_sort    (hatrack_dict_t *, uint64_t *);
-hatrack_dict_value_t *hatrack_dict_values_sort  (hatrack_dict_t *, uint64_t *);
-hatrack_dict_item_t  *hatrack_dict_items_sort   (hatrack_dict_t *, uint64_t *);
-hatrack_dict_key_t   *hatrack_dict_keys_nosort  (hatrack_dict_t *, uint64_t *);
-hatrack_dict_value_t *hatrack_dict_values_nosort(hatrack_dict_t *, uint64_t *);
-hatrack_dict_item_t  *hatrack_dict_items_nosort (hatrack_dict_t *, uint64_t *);
+HATRACK_EXTERN hatrack_dict_key_t   *hatrack_dict_keys         (hatrack_dict_t *, uint64_t *);
+HATRACK_EXTERN hatrack_dict_value_t *hatrack_dict_values       (hatrack_dict_t *, uint64_t *);
+HATRACK_EXTERN hatrack_dict_item_t  *hatrack_dict_items        (hatrack_dict_t *, uint64_t *);
+HATRACK_EXTERN hatrack_dict_key_t   *hatrack_dict_keys_sort    (hatrack_dict_t *, uint64_t *);
+HATRACK_EXTERN hatrack_dict_value_t *hatrack_dict_values_sort  (hatrack_dict_t *, uint64_t *);
+HATRACK_EXTERN hatrack_dict_item_t  *hatrack_dict_items_sort   (hatrack_dict_t *, uint64_t *);
+HATRACK_EXTERN hatrack_dict_key_t   *hatrack_dict_keys_nosort  (hatrack_dict_t *, uint64_t *);
+HATRACK_EXTERN hatrack_dict_value_t *hatrack_dict_values_nosort(hatrack_dict_t *, uint64_t *);
+HATRACK_EXTERN hatrack_dict_item_t  *hatrack_dict_items_nosort (hatrack_dict_t *, uint64_t *);

--- a/include/hatrack/duncecap.h
+++ b/include/hatrack/duncecap.h
@@ -38,8 +38,6 @@
 #include "base.h"
 #include "hatrack_common.h"
 
-// clang-format off
-
 /* duncecap_record_t
  *
  * In this implementation, readers only use a mutex long enough to
@@ -77,8 +75,7 @@
  *          construct a consistent sort order.
  */
 typedef struct {
-    alignas(16)
-    void    *item;
+    alignas(16) void *item;
     uint64_t epoch;
 } duncecap_record_t;
 
@@ -149,13 +146,13 @@ typedef struct {
  *               so that we can avoid an extra indirection.
  */
 typedef struct {
-    _Atomic uint64_t    readers;
-    uint64_t            last_slot;
-    uint64_t            threshold;
-    uint64_t            used_count;
-    uint64_t            alloc_len;
-    uint64_t            pad;
-    duncecap_bucket_t   buckets[];
+    _Atomic uint64_t  readers;
+    uint64_t          last_slot;
+    uint64_t          threshold;
+    uint64_t          used_count;
+    uint64_t          alloc_len;
+    uint64_t          pad;
+    duncecap_bucket_t buckets[];
 } duncecap_store_t;
 
 /* duncecap_t
@@ -197,12 +194,11 @@ typedef struct {
  *                  operation, for the purposes of sort ordering.
  */
 typedef struct {
-    duncecap_store_t   *store_current;
-    uint64_t            item_count;
-    uint64_t            next_epoch;
-    pthread_mutex_t     mutex;
+    duncecap_store_t *store_current;
+    uint64_t          item_count;
+    uint64_t          next_epoch;
+    pthread_mutex_t   mutex;
 } duncecap_t;
-// clang-format on
 
 /* duncecap_reader_enter()
  *
@@ -224,31 +220,16 @@ typedef struct {
  * use mmm_alloc() for the stores (which we do in the duncecap2
  * implementation).
  */
-static inline duncecap_store_t *
-duncecap_reader_enter(duncecap_t *self)
-{
-    duncecap_store_t *ret;
-
-    pthread_mutex_lock(&self->mutex);
-    ret = self->store_current;
-    atomic_fetch_add(&ret->readers, 1);
-    pthread_mutex_unlock(&self->mutex);
-
-    return ret;
-}
+duncecap_store_t *
+duncecap_reader_enter(duncecap_t *self);
 
 /* duncecap_reader_exit()
  *
  * This simply needs to decrement the reader count associated with the
  * store, atomically.
  */
-static inline void
-duncecap_reader_exit(duncecap_store_t *store)
-{
-    atomic_fetch_sub(&store->readers, 1);
-
-    return;
-}
+void
+duncecap_reader_exit(duncecap_store_t *store);
 
 /* This API requires that you deal with hashing the key external to
  * the API.  You might want to cache hash values, use different
@@ -259,6 +240,7 @@ duncecap_reader_exit(duncecap_store_t *store)
  * choose a 3-universal keyed hash function, or if hash values need to
  * be consistent across runs, something fast and practical like XXH3.
  */
+
 // clang-format off
 duncecap_t     *duncecap_new      (void);
 duncecap_t     *duncecap_new_size (char);

--- a/include/hatrack/duncecap.h
+++ b/include/hatrack/duncecap.h
@@ -220,7 +220,7 @@ typedef struct {
  * use mmm_alloc() for the stores (which we do in the duncecap2
  * implementation).
  */
-duncecap_store_t *
+HATRACK_EXTERN duncecap_store_t *
 duncecap_reader_enter(duncecap_t *self);
 
 /* duncecap_reader_exit()
@@ -228,7 +228,7 @@ duncecap_reader_enter(duncecap_t *self);
  * This simply needs to decrement the reader count associated with the
  * store, atomically.
  */
-void
+HATRACK_EXTERN void
 duncecap_reader_exit(duncecap_store_t *store);
 
 /* This API requires that you deal with hashing the key external to
@@ -242,18 +242,17 @@ duncecap_reader_exit(duncecap_store_t *store);
  */
 
 // clang-format off
-duncecap_t     *duncecap_new      (void);
-duncecap_t     *duncecap_new_size (char);
-void            duncecap_init     (duncecap_t *);
-void            duncecap_init_size(duncecap_t *, char);
-void            duncecap_cleanup  (duncecap_t *);
-void            duncecap_delete   (duncecap_t *);
-void           *duncecap_get      (duncecap_t *, hatrack_hash_t, bool *);
-void           *duncecap_put      (duncecap_t *, hatrack_hash_t, void *,
-				   bool *);
-void           *duncecap_replace  (duncecap_t *, hatrack_hash_t, void *,
-				   bool *);
-bool            duncecap_add      (duncecap_t *, hatrack_hash_t, void *);
-void           *duncecap_remove   (duncecap_t *, hatrack_hash_t, bool *);
-uint64_t        duncecap_len      (duncecap_t *);
-hatrack_view_t *duncecap_view     (duncecap_t *, uint64_t *, bool);
+HATRACK_EXTERN duncecap_t     *duncecap_new      (void);
+HATRACK_EXTERN duncecap_t     *duncecap_new_size (char);
+HATRACK_EXTERN void            duncecap_init     (duncecap_t *);
+HATRACK_EXTERN void            duncecap_init_size(duncecap_t *, char);
+HATRACK_EXTERN void            duncecap_cleanup  (duncecap_t *);
+HATRACK_EXTERN void            duncecap_delete   (duncecap_t *);
+HATRACK_EXTERN void           *duncecap_get      (duncecap_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *duncecap_put      (duncecap_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *duncecap_replace  (duncecap_t *, hatrack_hash_t, void *,	bool *);
+HATRACK_EXTERN bool            duncecap_add      (duncecap_t *, hatrack_hash_t, void *);
+HATRACK_EXTERN void           *duncecap_remove   (duncecap_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN uint64_t        duncecap_len      (duncecap_t *);
+HATRACK_EXTERN hatrack_view_t *duncecap_view     (duncecap_t *, uint64_t *, bool);
+ 

--- a/include/hatrack/flexarray.h
+++ b/include/hatrack/flexarray.h
@@ -65,20 +65,20 @@ enum {
 };
 
 // clang-format off
-flexarray_t *flexarray_new                (uint64_t);
-void         flexarray_init               (flexarray_t *, uint64_t);
-void         flexarray_set_ret_callback   (flexarray_t *, flex_callback_t);
-void         flexarray_set_eject_callback (flexarray_t *, flex_callback_t);
-void         flexarray_cleanup            (flexarray_t *);
-void         flexarray_delete             (flexarray_t *);
-void        *flexarray_get                (flexarray_t *, uint64_t, int *);
-bool         flexarray_set                (flexarray_t *, uint64_t, void *);
-void         flexarray_grow               (flexarray_t *, uint64_t);
-void         flexarray_shrink             (flexarray_t *, uint64_t);
-uint64_t     flexarray_len                (flexarray_t *);
-flex_view_t *flexarray_view               (flexarray_t *);
-void        *flexarray_view_next          (flex_view_t *, int *);
-void         flexarray_view_delete        (flex_view_t *);
-void        *flexarray_view_get           (flex_view_t *, uint64_t, int *);
-uint64_t     flexarray_view_len           (flex_view_t *);
-flexarray_t *flexarray_add                (flexarray_t *, flexarray_t *);
+HATRACK_EXTERN flexarray_t *flexarray_new                (uint64_t);
+HATRACK_EXTERN void         flexarray_init               (flexarray_t *, uint64_t);
+HATRACK_EXTERN void         flexarray_set_ret_callback   (flexarray_t *, flex_callback_t);
+HATRACK_EXTERN void         flexarray_set_eject_callback (flexarray_t *, flex_callback_t);
+HATRACK_EXTERN void         flexarray_cleanup            (flexarray_t *);
+HATRACK_EXTERN void         flexarray_delete             (flexarray_t *);
+HATRACK_EXTERN void        *flexarray_get                (flexarray_t *, uint64_t, int *);
+HATRACK_EXTERN bool         flexarray_set                (flexarray_t *, uint64_t, void *);
+HATRACK_EXTERN void         flexarray_grow               (flexarray_t *, uint64_t);
+HATRACK_EXTERN void         flexarray_shrink             (flexarray_t *, uint64_t);
+HATRACK_EXTERN uint64_t     flexarray_len                (flexarray_t *);
+HATRACK_EXTERN flex_view_t *flexarray_view               (flexarray_t *);
+HATRACK_EXTERN void        *flexarray_view_next          (flex_view_t *, int *);
+HATRACK_EXTERN void         flexarray_view_delete        (flex_view_t *);
+HATRACK_EXTERN void        *flexarray_view_get           (flex_view_t *, uint64_t, int *);
+HATRACK_EXTERN uint64_t     flexarray_view_len           (flex_view_t *);
+HATRACK_EXTERN flexarray_t *flexarray_add                (flexarray_t *, flexarray_t *);

--- a/include/hatrack/flexarray.h
+++ b/include/hatrack/flexarray.h
@@ -27,14 +27,11 @@
 
 #include "base.h"
 
-#define FLEXARRAY_MIN_STORE_SZ_LOG 4
-
-// clang-format off
 typedef void (*flex_callback_t)(void *);
 
 typedef struct {
-    void     *item;
-    uint64_t  state;
+    void    *item;
+    uint64_t state;
 } flex_item_t;
 
 typedef _Atomic flex_item_t flex_cell_t;
@@ -50,17 +47,24 @@ typedef struct {
 struct flex_store_t {
     uint64_t                store_size;
     _Atomic uint64_t        array_size;
-    _Atomic (flex_store_t *)next;
+    _Atomic(flex_store_t *) next;
     _Atomic bool            claimed;
     flex_cell_t             cells[];
 };
 
 typedef struct flexarray_t {
-    flex_callback_t          ret_callback;
-    flex_callback_t          eject_callback;
-    _Atomic (flex_store_t  *)store;
+    flex_callback_t         ret_callback;
+    flex_callback_t         eject_callback;
+    _Atomic(flex_store_t *) store;
 } flexarray_t;
 
+enum {
+    FLEX_OK,
+    FLEX_OOB,
+    FLEX_UNINITIALIZED
+};
+
+// clang-format off
 flexarray_t *flexarray_new                (uint64_t);
 void         flexarray_init               (flexarray_t *, uint64_t);
 void         flexarray_set_ret_callback   (flexarray_t *, flex_callback_t);
@@ -78,16 +82,3 @@ void         flexarray_view_delete        (flex_view_t *);
 void        *flexarray_view_get           (flex_view_t *, uint64_t, int *);
 uint64_t     flexarray_view_len           (flex_view_t *);
 flexarray_t *flexarray_add                (flexarray_t *, flexarray_t *);
-
-enum64(flex_enum_t,
-       FLEX_ARRAY_SHRINK = 0x8000000000000000,
-       FLEX_ARRAY_MOVING = 0x4000000000000000,
-       FLEX_ARRAY_MOVED  = 0x2000000000000000,
-       FLEX_ARRAY_USED   = 0x1000000000000000
-       );
-
-enum {
-    FLEX_OK,
-    FLEX_OOB,
-    FLEX_UNINITIALIZED
-};

--- a/include/hatrack/hatring.h
+++ b/include/hatrack/hatring.h
@@ -68,14 +68,14 @@ typedef struct {
 } hatring_t;
 
 // clang-format off
-hatring_t      *hatring_new             (uint64_t);
-void            hatring_init            (hatring_t *, uint64_t);
-void            hatring_cleanup         (hatring_t *);
-void            hatring_delete          (hatring_t *);
-uint32_t        hatring_enqueue         (hatring_t *, void *);
-void           *hatring_dequeue         (hatring_t *, bool *);
-void           *hatring_dequeue_w_epoch (hatring_t *, bool *, uint32_t *);
-hatring_view_t *hatring_view            (hatring_t *);
-void           *hatring_view_next       (hatring_view_t *, bool *);
-void            hatring_view_delete     (hatring_view_t *);
-void            hatring_set_drop_handler(hatring_t *, hatring_drop_handler);
+HATRACK_EXTERN hatring_t      *hatring_new             (uint64_t);
+HATRACK_EXTERN void            hatring_init            (hatring_t *, uint64_t);
+HATRACK_EXTERN void            hatring_cleanup         (hatring_t *);
+HATRACK_EXTERN void            hatring_delete          (hatring_t *);
+HATRACK_EXTERN uint32_t        hatring_enqueue         (hatring_t *, void *);
+HATRACK_EXTERN void           *hatring_dequeue         (hatring_t *, bool *);
+HATRACK_EXTERN void           *hatring_dequeue_w_epoch (hatring_t *, bool *, uint32_t *);
+HATRACK_EXTERN hatring_view_t *hatring_view            (hatring_t *);
+HATRACK_EXTERN void           *hatring_view_next       (hatring_view_t *, bool *);
+HATRACK_EXTERN void            hatring_view_delete     (hatring_view_t *);
+HATRACK_EXTERN void            hatring_set_drop_handler(hatring_t *, hatring_drop_handler);

--- a/include/hatrack/hatring.h
+++ b/include/hatrack/hatring.h
@@ -67,66 +67,15 @@ typedef struct {
     hatring_cell_t       cells[];
 } hatring_t;
 
-enum {
-    HATRING_ENQUEUED = 0x8000000000000000,
-    HATRING_DEQUEUED = 0x4000000000000000,
-    HATRING_MASK     = 0xcfffffffffffffff
-};
-
-static inline bool
-hatring_is_lagging(uint32_t read_epoch, uint32_t write_epoch, uint64_t size)
-{
-    if (read_epoch + size < write_epoch) {
-        return true;
-    }
-
-    return false;
-}
-
-static inline uint32_t
-hatring_enqueue_epoch(uint64_t ptrs)
-{
-    return (uint32_t)(ptrs >> 32);
-}
-
-static inline uint32_t
-hatring_dequeue_epoch(uint64_t ptrs)
-{
-    return (uint32_t)(ptrs & 0x00000000ffffffff);
-}
-
-static inline uint32_t
-hatring_dequeue_ix(uint64_t epochs, uint32_t last_slot)
-{
-    return (uint32_t)(epochs & last_slot);
-}
-
-static inline uint32_t
-hatring_cell_epoch(uint64_t state)
-{
-    return (uint32_t)(state & 0x00000000ffffffff);
-}
-
-static inline bool
-hatring_is_enqueued(uint64_t state)
-{
-    return state & HATRING_ENQUEUED;
-}
-
-static inline uint64_t
-hatring_fixed_epoch(uint32_t write_epoch, uint64_t store_size)
-{
-    return (((uint64_t)write_epoch) << 32) | (write_epoch - store_size);
-}
-
-hatring_t      *hatring_new(uint64_t);
-void            hatring_init(hatring_t *, uint64_t);
-void            hatring_cleanup(hatring_t *);
-void            hatring_delete(hatring_t *);
-uint32_t        hatring_enqueue(hatring_t *, void *);
-void           *hatring_dequeue(hatring_t *, bool *);
-void           *hatring_dequeue_w_epoch(hatring_t *, bool *, uint32_t *);
-hatring_view_t *hatring_view(hatring_t *);
-void           *hatring_view_next(hatring_view_t *, bool *);
-void            hatring_view_delete(hatring_view_t *);
+// clang-format off
+hatring_t      *hatring_new             (uint64_t);
+void            hatring_init            (hatring_t *, uint64_t);
+void            hatring_cleanup         (hatring_t *);
+void            hatring_delete          (hatring_t *);
+uint32_t        hatring_enqueue         (hatring_t *, void *);
+void           *hatring_dequeue         (hatring_t *, bool *);
+void           *hatring_dequeue_w_epoch (hatring_t *, bool *, uint32_t *);
+hatring_view_t *hatring_view            (hatring_t *);
+void           *hatring_view_next       (hatring_view_t *, bool *);
+void            hatring_view_delete     (hatring_view_t *);
 void            hatring_set_drop_handler(hatring_t *, hatring_drop_handler);

--- a/include/hatrack/helpmanager.h
+++ b/include/hatrack/helpmanager.h
@@ -47,11 +47,6 @@ typedef struct {
 } help_cell_t;
 
 typedef struct {
-    uint64_t op;
-    int64_t  jobid;
-} help_op_t;
-
-typedef struct {
     uint64_t            op;
     void               *input;
     void               *aux;
@@ -59,11 +54,7 @@ typedef struct {
     _Atomic help_cell_t retval;
 } help_record_t;
 
-typedef _Atomic help_record_t help_record_atomic_t;
-
 typedef void (*helper_func)(void *, help_record_t *, uint64_t);
-
-static help_record_t thread_records[HATRACK_THREADS_MAX];
 
 typedef struct {
     void        *parent;
@@ -71,12 +62,6 @@ typedef struct {
     capq_t       capq;
 } help_manager_t;
 
-static inline void *
-hatrack_help_get_parent(help_manager_t *manager)
-{
-    return manager->parent;
-}
-
-void  hatrack_help_init(help_manager_t *, void *, helper_func *, bool);
-void *hatrack_perform_wf_op(help_manager_t *, uint64_t, void *, void *, bool *);
-void  hatrack_complete_help(help_manager_t *, help_record_t *, int64_t, void *, bool);
+HATRACK_EXTERN void  hatrack_help_init(help_manager_t *, void *, helper_func *, bool);
+HATRACK_EXTERN void *hatrack_perform_wf_op(help_manager_t *, uint64_t, void *, void *, bool *);
+HATRACK_EXTERN void  hatrack_complete_help(help_manager_t *, help_record_t *, int64_t, void *, bool);

--- a/include/hatrack/hihat.h
+++ b/include/hatrack/hihat.h
@@ -57,14 +57,6 @@ typedef struct {
     uint64_t info;
 } hihat_record_t;
 
-// The aforementioned flags, along with a bitmask that allows us to
-// extract the epoch in the info field, ignoring any migration flags.
-enum64(hihat_flag_t,
-       HIHAT_F_MOVING   = 0x8000000000000000,
-       HIHAT_F_MOVED    = 0x4000000000000000,
-       HIHAT_F_INITED   = 0x2000000000000000,
-       HIHAT_EPOCH_MASK = 0x1fffffffffffffff);
-
 /* hihat_bucket_t
  *
  * The representation of a bucket. The hash value and the record can
@@ -144,13 +136,12 @@ typedef struct hihat_store_st hihat_store_t;
  *               so that we can avoid an extra indirection.
  *
  */
-// clang-format off
 struct hihat_store_st {
-    uint64_t                   last_slot;
-    uint64_t                   threshold;
-    _Atomic uint64_t           used_count;
-    _Atomic(hihat_store_t *)   store_next;
-    hihat_bucket_t             buckets[];
+    uint64_t                 last_slot;
+    uint64_t                 threshold;
+    _Atomic uint64_t         used_count;
+    _Atomic(hihat_store_t *) store_next;
+    hihat_bucket_t           buckets[];
 };
 
 /* hihat_t
@@ -177,7 +168,6 @@ typedef struct {
     uint64_t                 next_epoch;
 } hihat_t;
 
-
 /* This API requires that you deal with hashing the key external to
  * the API.  You might want to cache hash values, use different
  * functions for different data objects, etc.
@@ -187,6 +177,8 @@ typedef struct {
  * choose a 3-universal keyed hash function, or if hash values need to
  * be consistent across runs, something fast and practical like XXH3.
  */
+
+// clang-format off
 hihat_t        *hihat_new      (void);
 hihat_t        *hihat_new_size (char);
 void            hihat_init     (hihat_t *);

--- a/include/hatrack/hihat.h
+++ b/include/hatrack/hihat.h
@@ -179,19 +179,19 @@ typedef struct {
  */
 
 // clang-format off
-hihat_t        *hihat_new      (void);
-hihat_t        *hihat_new_size (char);
-void            hihat_init     (hihat_t *);
-void            hihat_init_size(hihat_t *, char);
-void            hihat_cleanup  (hihat_t *);
-void            hihat_delete   (hihat_t *);
-void           *hihat_get      (hihat_t *, hatrack_hash_t, bool *);
-void           *hihat_put      (hihat_t *, hatrack_hash_t, void *, bool *);
-void           *hihat_replace  (hihat_t *, hatrack_hash_t, void *, bool *);
-bool            hihat_add      (hihat_t *, hatrack_hash_t, void *);
-void           *hihat_remove   (hihat_t *, hatrack_hash_t, bool *);
-uint64_t        hihat_len      (hihat_t *);
-hatrack_view_t *hihat_view     (hihat_t *, uint64_t *, bool);
+HATRACK_EXTERN hihat_t        *hihat_new      (void);
+HATRACK_EXTERN hihat_t        *hihat_new_size (char);
+HATRACK_EXTERN void            hihat_init     (hihat_t *);
+HATRACK_EXTERN void            hihat_init_size(hihat_t *, char);
+HATRACK_EXTERN void            hihat_cleanup  (hihat_t *);
+HATRACK_EXTERN void            hihat_delete   (hihat_t *);
+HATRACK_EXTERN void           *hihat_get      (hihat_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *hihat_put      (hihat_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *hihat_replace  (hihat_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN bool            hihat_add      (hihat_t *, hatrack_hash_t, void *);
+HATRACK_EXTERN void           *hihat_remove   (hihat_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN uint64_t        hihat_len      (hihat_t *);
+HATRACK_EXTERN hatrack_view_t *hihat_view     (hihat_t *, uint64_t *, bool);
 
 /*
  * Note that hihat_a is almost identical to hihat. It has the same
@@ -202,16 +202,16 @@ hatrack_view_t *hihat_view     (hihat_t *, uint64_t *, bool);
  * Instead of adding an extra indirection for that second migration
  * function, we just copy all the methods.
  */
-hihat_t        *hihat_a_new      (void);
-hihat_t        *hihat_a_new_size (char);
-void            hihat_a_init     (hihat_t *);
-void            hihat_a_init_size(hihat_t *, char);
-void            hihat_a_cleanup  (hihat_t *);
-void            hihat_a_delete   (hihat_t *);
-void           *hihat_a_get      (hihat_t *, hatrack_hash_t, bool *);
-void           *hihat_a_put      (hihat_t *, hatrack_hash_t, void *, bool *);
-void           *hihat_a_replace  (hihat_t *, hatrack_hash_t, void *, bool *);
-bool            hihat_a_add      (hihat_t *, hatrack_hash_t, void *);
-void           *hihat_a_remove   (hihat_t *, hatrack_hash_t, bool *);
-uint64_t        hihat_a_len      (hihat_t *);
-hatrack_view_t *hihat_a_view     (hihat_t *, uint64_t *, bool);
+HATRACK_EXTERN hihat_t        *hihat_a_new      (void);
+HATRACK_EXTERN hihat_t        *hihat_a_new_size (char);
+HATRACK_EXTERN void            hihat_a_init     (hihat_t *);
+HATRACK_EXTERN void            hihat_a_init_size(hihat_t *, char);
+HATRACK_EXTERN void            hihat_a_cleanup  (hihat_t *);
+HATRACK_EXTERN void            hihat_a_delete   (hihat_t *);
+HATRACK_EXTERN void           *hihat_a_get      (hihat_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *hihat_a_put      (hihat_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *hihat_a_replace  (hihat_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN bool            hihat_a_add      (hihat_t *, hatrack_hash_t, void *);
+HATRACK_EXTERN void           *hihat_a_remove   (hihat_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN uint64_t        hihat_a_len      (hihat_t *);
+HATRACK_EXTERN hatrack_view_t *hihat_a_view     (hihat_t *, uint64_t *, bool);

--- a/include/hatrack/hq.h
+++ b/include/hatrack/hq.h
@@ -66,15 +66,15 @@ typedef struct {
 } hq_t;
 
 // clang-format off
-hq_t      *hq_new        (void);
-hq_t      *hq_new_size   (uint64_t);
-void       hq_init       (hq_t *);
-void       hq_init_size  (hq_t *, uint64_t);
-void       hq_cleanup    (hq_t *);
-void       hq_delete     (hq_t *);
-void       hq_enqueue    (hq_t *, void *);
-void      *hq_dequeue    (hq_t *, bool *);
-int64_t    hq_len        (hq_t *);
-hq_view_t *hq_view       (hq_t *);
-void      *hq_view_next  (hq_view_t *, bool *);
-void       hq_view_delete(hq_view_t *);
+HATRACK_EXTERN hq_t      *hq_new        (void);
+HATRACK_EXTERN hq_t      *hq_new_size   (uint64_t);
+HATRACK_EXTERN void       hq_init       (hq_t *);
+HATRACK_EXTERN void       hq_init_size  (hq_t *, uint64_t);
+HATRACK_EXTERN void       hq_cleanup    (hq_t *);
+HATRACK_EXTERN void       hq_delete     (hq_t *);
+HATRACK_EXTERN void       hq_enqueue    (hq_t *, void *);
+HATRACK_EXTERN void      *hq_dequeue    (hq_t *, bool *);
+HATRACK_EXTERN int64_t    hq_len        (hq_t *);
+HATRACK_EXTERN hq_view_t *hq_view       (hq_t *);
+HATRACK_EXTERN void      *hq_view_next  (hq_view_t *, bool *);
+HATRACK_EXTERN void       hq_view_delete(hq_view_t *);

--- a/include/hatrack/llstack.h
+++ b/include/hatrack/llstack.h
@@ -37,9 +37,9 @@ typedef struct {
 } llstack_t;
 
 // clang-format off
-llstack_t *llstack_new    (void);
-void       llstack_init   (llstack_t *);
-void       llstack_cleanup(llstack_t *);
-void       llstack_delete (llstack_t *);
-void       llstack_push   (llstack_t *, void *);
-void      *llstack_pop    (llstack_t *, bool *);
+HATRACK_EXTERN llstack_t *llstack_new    (void);
+HATRACK_EXTERN void       llstack_init   (llstack_t *);
+HATRACK_EXTERN void       llstack_cleanup(llstack_t *);
+HATRACK_EXTERN void       llstack_delete (llstack_t *);
+HATRACK_EXTERN void       llstack_push   (llstack_t *, void *);
+HATRACK_EXTERN void      *llstack_pop    (llstack_t *, bool *);

--- a/include/hatrack/logring.h
+++ b/include/hatrack/logring.h
@@ -202,12 +202,12 @@ typedef struct {
 } logring_t;
 
 // clang-format off
-logring_t      *logring_new        (uint64_t, uint64_t);
-void            logring_init       (logring_t *, uint64_t, uint64_t);
-void            logring_cleanup    (logring_t *);
-void            logring_delete     (logring_t *);
-void            logring_enqueue    (logring_t *, void *, uint64_t);
-bool            logring_dequeue    (logring_t *, void *, uint64_t *);
-logring_view_t *logring_view       (logring_t *, bool);
-void           *logring_view_next  (logring_view_t *, uint64_t *);
-void            logring_view_delete(logring_view_t *);
+HATRACK_EXTERN logring_t      *logring_new        (uint64_t, uint64_t);
+HATRACK_EXTERN void            logring_init       (logring_t *, uint64_t, uint64_t);
+HATRACK_EXTERN void            logring_cleanup    (logring_t *);
+HATRACK_EXTERN void            logring_delete     (logring_t *);
+HATRACK_EXTERN void            logring_enqueue    (logring_t *, void *, uint64_t);
+HATRACK_EXTERN bool            logring_dequeue    (logring_t *, void *, uint64_t *);
+HATRACK_EXTERN logring_view_t *logring_view       (logring_t *, bool);
+HATRACK_EXTERN void           *logring_view_next  (logring_view_t *, uint64_t *);
+HATRACK_EXTERN void            logring_view_delete(logring_view_t *);

--- a/include/hatrack/logring.h
+++ b/include/hatrack/logring.h
@@ -152,8 +152,6 @@
 #include "base.h"
 #include "hatring.h"
 
-#define LOGRING_MIN_SIZE 64
-
 /* Information about the current entry.
  *
  */
@@ -188,14 +186,6 @@ typedef struct {
     char                         data[];
 } logring_entry_t;
 
-enum {
-    LOGRING_EMPTY           = 0x00,
-    LOGRING_RESERVED        = 0x01,
-    LOGRING_ENQUEUE_DONE    = 0x02,
-    LOGRING_DEQUEUE_RESERVE = 0x04,
-    LOGRING_VIEW_RESERVE    = 0x08
-};
-
 typedef struct {
     logring_view_t *view;
     uint64_t        last_viewid;
@@ -211,78 +201,13 @@ typedef struct {
     logring_entry_t    *entries;
 } logring_t;
 
-static inline bool
-logring_entry_is_being_used(logring_entry_info_t info)
-{
-    if (info.state & (LOGRING_RESERVED | LOGRING_VIEW_RESERVE | LOGRING_DEQUEUE_RESERVE)) {
-        return true;
-    }
-
-    return false;
-}
-
-static inline bool
-logring_current_entry_epoch(logring_entry_info_t info, uint32_t my_epoch)
-{
-    if (info.write_epoch == my_epoch) {
-        return true;
-    }
-
-    return false;
-}
-
-static inline bool
-logring_can_write_here(logring_entry_info_t info, uint32_t my_write_epoch)
-{
-    if (logring_entry_is_being_used(info)) {
-        return false;
-    }
-
-    if (info.write_epoch > my_write_epoch) {
-        return false;
-    }
-
-    return true;
-}
-
-static inline bool
-logring_can_dequeue_here(logring_entry_info_t info, uint32_t expected_epoch)
-{
-    if (info.write_epoch > expected_epoch) {
-        return false;
-    }
-
-    return true;
-}
-
-static inline hatring_cell_t *
-logring_get_ringcell(logring_t *self, uint32_t ix)
-{
-    return &self->ring->cells[ix & self->ring->last_slot];
-}
-
-static inline logring_entry_t *
-logring_get_entry(logring_t *self, uint64_t ix)
-{
-    uint64_t byte_ix;
-
-    byte_ix = ix * (sizeof(logring_entry_t) + self->entry_len);
-
-    return (logring_entry_t *)&(((char *)self->entries)[byte_ix]);
-}
-
-static inline uint64_t
-logring_set_dequeue_done(uint64_t state)
-{
-    return state & ~(LOGRING_DEQUEUE_RESERVE | LOGRING_ENQUEUE_DONE);
-}
-
-logring_t      *logring_new(uint64_t, uint64_t);
-void            logring_init(logring_t *, uint64_t, uint64_t);
-void            logring_cleanup(logring_t *);
-void            logring_delete(logring_t *);
-void            logring_enqueue(logring_t *, void *, uint64_t);
-bool            logring_dequeue(logring_t *, void *, uint64_t *);
-logring_view_t *logring_view(logring_t *, bool);
-void           *logring_view_next(logring_view_t *, uint64_t *);
+// clang-format off
+logring_t      *logring_new        (uint64_t, uint64_t);
+void            logring_init       (logring_t *, uint64_t, uint64_t);
+void            logring_cleanup    (logring_t *);
+void            logring_delete     (logring_t *);
+void            logring_enqueue    (logring_t *, void *, uint64_t);
+bool            logring_dequeue    (logring_t *, void *, uint64_t *);
+logring_view_t *logring_view       (logring_t *, bool);
+void           *logring_view_next  (logring_view_t *, uint64_t *);
 void            logring_view_delete(logring_view_t *);

--- a/include/hatrack/lohat-a.h
+++ b/include/hatrack/lohat-a.h
@@ -222,16 +222,16 @@ typedef struct {
 } lohat_a_t;
 
 // clang-format off
-lohat_a_t      *lohat_a_new      (void);
-lohat_a_t      *lohat_a_new_size (char);
-void            lohat_a_init     (lohat_a_t *);
-void            lohat_a_init_size(lohat_a_t *, char);
-void            lohat_a_cleanup  (lohat_a_t *);
-void            lohat_a_delete   (lohat_a_t *);
-void           *lohat_a_get      (lohat_a_t *, hatrack_hash_t, bool *);
-void           *lohat_a_put      (lohat_a_t *, hatrack_hash_t, void *, bool *);
-void           *lohat_a_replace  (lohat_a_t *, hatrack_hash_t, void *, bool *);
-bool            lohat_a_add      (lohat_a_t *, hatrack_hash_t, void *);
-void           *lohat_a_remove   (lohat_a_t *, hatrack_hash_t, bool *);
-uint64_t        lohat_a_len      (lohat_a_t *);
-hatrack_view_t *lohat_a_view     (lohat_a_t *, uint64_t *, bool);
+HATRACK_EXTERN lohat_a_t      *lohat_a_new      (void);
+HATRACK_EXTERN lohat_a_t      *lohat_a_new_size (char);
+HATRACK_EXTERN void            lohat_a_init     (lohat_a_t *);
+HATRACK_EXTERN void            lohat_a_init_size(lohat_a_t *, char);
+HATRACK_EXTERN void            lohat_a_cleanup  (lohat_a_t *);
+HATRACK_EXTERN void            lohat_a_delete   (lohat_a_t *);
+HATRACK_EXTERN void           *lohat_a_get      (lohat_a_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *lohat_a_put      (lohat_a_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *lohat_a_replace  (lohat_a_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN bool            lohat_a_add      (lohat_a_t *, hatrack_hash_t, void *);
+HATRACK_EXTERN void           *lohat_a_remove   (lohat_a_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN uint64_t        lohat_a_len      (lohat_a_t *);
+HATRACK_EXTERN hatrack_view_t *lohat_a_view     (lohat_a_t *, uint64_t *, bool);

--- a/include/hatrack/lohat-a.h
+++ b/include/hatrack/lohat-a.h
@@ -207,7 +207,6 @@ typedef struct {
  */
 typedef struct lohat_a_store_st lohat_a_store_t;
 
-// clang-format off
 struct lohat_a_store_st {
     uint64_t                     last_slot;
     lohat_a_history_t           *hist_end;
@@ -222,6 +221,7 @@ typedef struct {
     _Atomic(uint64_t)          item_count;
 } lohat_a_t;
 
+// clang-format off
 lohat_a_t      *lohat_a_new      (void);
 lohat_a_t      *lohat_a_new_size (char);
 void            lohat_a_init     (lohat_a_t *);

--- a/include/hatrack/lohat.h
+++ b/include/hatrack/lohat.h
@@ -560,16 +560,16 @@ typedef struct lohat_st {
  */
 
 // clang-format off
-lohat_t        *lohat_new      (void);
-lohat_t        *lohat_new_size (char);
-void            lohat_init     (lohat_t *);
-void            lohat_init_size(lohat_t *, char);
-void            lohat_cleanup  (lohat_t *);
-void            lohat_delete   (lohat_t *);
-void           *lohat_get      (lohat_t *, hatrack_hash_t, bool *);
-void           *lohat_put      (lohat_t *, hatrack_hash_t, void *, bool *);
-void           *lohat_replace  (lohat_t *, hatrack_hash_t, void *, bool *);
-bool            lohat_add      (lohat_t *, hatrack_hash_t, void *);
-void           *lohat_remove   (lohat_t *, hatrack_hash_t, bool *);
-uint64_t        lohat_len      (lohat_t *);
-hatrack_view_t *lohat_view     (lohat_t *, uint64_t *, bool);
+HATRACK_EXTERN lohat_t        *lohat_new      (void);
+HATRACK_EXTERN lohat_t        *lohat_new_size (char);
+HATRACK_EXTERN void            lohat_init     (lohat_t *);
+HATRACK_EXTERN void            lohat_init_size(lohat_t *, char);
+HATRACK_EXTERN void            lohat_cleanup  (lohat_t *);
+HATRACK_EXTERN void            lohat_delete   (lohat_t *);
+HATRACK_EXTERN void           *lohat_get      (lohat_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *lohat_put      (lohat_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *lohat_replace  (lohat_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN bool            lohat_add      (lohat_t *, hatrack_hash_t, void *);
+HATRACK_EXTERN void           *lohat_remove   (lohat_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN uint64_t        lohat_len      (lohat_t *);
+HATRACK_EXTERN hatrack_view_t *lohat_view     (lohat_t *, uint64_t *, bool);

--- a/include/hatrack/lohat.h
+++ b/include/hatrack/lohat.h
@@ -396,14 +396,11 @@
  * collection, etc. We expect this all to be application dependent,
  * and outside of the scope of this project.
  */
-// clang-format off
 
 typedef struct {
     _Atomic hatrack_hash_t    hv;
     _Atomic(lohat_record_t *) head;
 } lohat_history_t;
-
-// clang-format on
 
 typedef struct lohat_store_st lohat_store_t;
 
@@ -510,7 +507,6 @@ typedef struct lohat_store_st lohat_store_t;
  *               Only writers care about this variable, and only during
  *               migration.
  */
-// clang-format off
 
 struct lohat_store_st {
     uint64_t                 last_slot;
@@ -547,13 +543,11 @@ struct lohat_store_st {
  *                prematurely.
  *
  */
-// clang-format off
 
 typedef struct lohat_st {
     _Atomic(lohat_store_t *) store_current;
     _Atomic uint64_t         item_count;
 } lohat_t;
-
 
 /* This API requires that you deal with hashing the key external to
  * the API.  You might want to cache hash values, use different
@@ -579,5 +573,3 @@ bool            lohat_add      (lohat_t *, hatrack_hash_t, void *);
 void           *lohat_remove   (lohat_t *, hatrack_hash_t, bool *);
 uint64_t        lohat_len      (lohat_t *);
 hatrack_view_t *lohat_view     (lohat_t *, uint64_t *, bool);
-
-// clang-format on

--- a/include/hatrack/newshat.h
+++ b/include/hatrack/newshat.h
@@ -28,8 +28,6 @@
 #include "base.h"
 #include "hatrack_common.h"
 
-// clang-format off
-
 /* newshat_record_t
  *
  * Each newshat bucket is individually locked, so that only one thread
@@ -54,9 +52,8 @@
  */
 
 typedef struct {
-    alignas(16)
-    void                *item;
-    uint64_t             epoch;
+    alignas(16) void *item;
+    uint64_t epoch;
 } newshat_record_t;
 
 /* newshat_bucket_t
@@ -104,7 +101,6 @@ typedef struct {
  *             the atomic store approach, they would actually be
  *             wait-free.
  */
-// clang-format off
 typedef struct {
     _Atomic newshat_record_t record;
     hatrack_hash_t           hv;
@@ -145,10 +141,10 @@ typedef struct {
  *               so that we can avoid an extra indirection.
  */
 typedef struct {
-    uint64_t             last_slot;
-    uint64_t             threshold;
-    _Atomic uint64_t     used_count;
-    newshat_bucket_t     buckets[];
+    uint64_t         last_slot;
+    uint64_t         threshold;
+    _Atomic uint64_t used_count;
+    newshat_bucket_t buckets[];
 } newshat_store_t;
 
 /* newshat_t
@@ -181,10 +177,10 @@ typedef struct {
  *                  operation, for the purposes of sort ordering.
  */
 typedef struct {
-    newshat_store_t     *store_current;
-    _Atomic uint64_t     item_count;
-    _Atomic uint64_t     next_epoch;
-    pthread_mutex_t      migrate_mutex;
+    newshat_store_t *store_current;
+    _Atomic uint64_t item_count;
+    _Atomic uint64_t next_epoch;
+    pthread_mutex_t  migrate_mutex;
 } newshat_t;
 
 /* This API requires that you deal with hashing the key external to
@@ -196,6 +192,8 @@ typedef struct {
  * choose a 3-universal keyed hash function, or if hash values need to
  * be consistent across runs, something fast and practical like XXH3.
  */
+
+// clang-format off
 newshat_t      *newshat_new      (void);
 newshat_t      *newshat_new_size (char);
 void            newshat_init     (newshat_t *);

--- a/include/hatrack/newshat.h
+++ b/include/hatrack/newshat.h
@@ -194,16 +194,16 @@ typedef struct {
  */
 
 // clang-format off
-newshat_t      *newshat_new      (void);
-newshat_t      *newshat_new_size (char);
-void            newshat_init     (newshat_t *);
-void            newshat_init_size(newshat_t *, char);
-void            newshat_cleanup  (newshat_t *);
-void            newshat_delete   (newshat_t *);
-void           *newshat_get      (newshat_t *, hatrack_hash_t, bool *);
-void           *newshat_put      (newshat_t *, hatrack_hash_t, void *, bool *);
-void           *newshat_replace  (newshat_t *, hatrack_hash_t, void *, bool *);
-bool            newshat_add      (newshat_t *, hatrack_hash_t, void *);
-void           *newshat_remove   (newshat_t *, hatrack_hash_t, bool *);
-uint64_t        newshat_len      (newshat_t *);
-hatrack_view_t *newshat_view     (newshat_t *, uint64_t *, bool);
+HATRACK_EXTERN newshat_t      *newshat_new      (void);
+HATRACK_EXTERN newshat_t      *newshat_new_size (char);
+HATRACK_EXTERN void            newshat_init     (newshat_t *);
+HATRACK_EXTERN void            newshat_init_size(newshat_t *, char);
+HATRACK_EXTERN void            newshat_cleanup  (newshat_t *);
+HATRACK_EXTERN void            newshat_delete   (newshat_t *);
+HATRACK_EXTERN void           *newshat_get      (newshat_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *newshat_put      (newshat_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *newshat_replace  (newshat_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN bool            newshat_add      (newshat_t *, hatrack_hash_t, void *);
+HATRACK_EXTERN void           *newshat_remove   (newshat_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN uint64_t        newshat_len      (newshat_t *);
+HATRACK_EXTERN hatrack_view_t *newshat_view     (newshat_t *, uint64_t *, bool);

--- a/include/hatrack/oldhat.h
+++ b/include/hatrack/oldhat.h
@@ -180,16 +180,16 @@ typedef struct {
  */
 
 // clang-format off
-oldhat_t       *oldhat_new      (void);
-oldhat_t       *oldhat_new_size (char);
-void            oldhat_init     (oldhat_t *);
-void            oldhat_init_size(oldhat_t *, char);
-void            oldhat_cleanup  (oldhat_t *);
-void            oldhat_delete   (oldhat_t *);
-void           *oldhat_get      (oldhat_t *, hatrack_hash_t, bool *);
-void           *oldhat_put      (oldhat_t *, hatrack_hash_t, void *, bool *);
-void           *oldhat_replace  (oldhat_t *, hatrack_hash_t, void *, bool *);
-bool            oldhat_add      (oldhat_t *, hatrack_hash_t, void *);
-void           *oldhat_remove   (oldhat_t *, hatrack_hash_t, bool *);
-uint64_t        oldhat_len      (oldhat_t *);
-hatrack_view_t *oldhat_view     (oldhat_t *, uint64_t *, bool);
+HATRACK_EXTERN oldhat_t       *oldhat_new      (void);
+HATRACK_EXTERN oldhat_t       *oldhat_new_size (char);
+HATRACK_EXTERN void            oldhat_init     (oldhat_t *);
+HATRACK_EXTERN void            oldhat_init_size(oldhat_t *, char);
+HATRACK_EXTERN void            oldhat_cleanup  (oldhat_t *);
+HATRACK_EXTERN void            oldhat_delete   (oldhat_t *);
+HATRACK_EXTERN void           *oldhat_get      (oldhat_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *oldhat_put      (oldhat_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *oldhat_replace  (oldhat_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN bool            oldhat_add      (oldhat_t *, hatrack_hash_t, void *);
+HATRACK_EXTERN void           *oldhat_remove   (oldhat_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN uint64_t        oldhat_len      (oldhat_t *);
+HATRACK_EXTERN hatrack_view_t *oldhat_view     (oldhat_t *, uint64_t *, bool);

--- a/include/hatrack/oldhat.h
+++ b/include/hatrack/oldhat.h
@@ -79,7 +79,6 @@
  * used     -- We set this to true when there is a value present.
  *
  */
-// clang-format off
 typedef struct {
     hatrack_hash_t hv;
     void          *item;
@@ -89,7 +88,6 @@ typedef struct {
 } oldhat_record_t;
 
 typedef struct oldhat_store_st oldhat_store_t;
-
 
 /* oldhat_store_t
  *
@@ -143,7 +141,6 @@ typedef struct oldhat_store_st oldhat_store_t;
  *               dynamically allocate the store to the correct size,
  *               so that we can avoid an extra indirection.
  */
-// clang-format off
 struct oldhat_store_st {
     uint64_t                   last_slot;
     uint64_t                   threshold;
@@ -167,7 +164,6 @@ struct oldhat_store_st {
  *                  This value isn't used in anything critical, just
  *                  to return a result when querying the length.
  */
-// clang-format off
 typedef struct {
     _Atomic(oldhat_store_t *) store_current;
     _Atomic uint64_t          item_count;
@@ -182,6 +178,8 @@ typedef struct {
  * choose a 3-universal keyed hash function, or if hash values need to
  * be consistent across runs, something fast and practical like XXH3.
  */
+
+// clang-format off
 oldhat_t       *oldhat_new      (void);
 oldhat_t       *oldhat_new_size (char);
 void            oldhat_init     (oldhat_t *);

--- a/include/hatrack/q64.h
+++ b/include/hatrack/q64.h
@@ -34,12 +34,8 @@
 #pragma once
 
 #include "base.h"
-#include "hatomic.h"
 
-#define QUEUE_HELP_VALUE 1 << QUEUE_HELP_STEPS
-
-// clang-format off
-typedef uint64_t q64_item_t;
+typedef uint64_t           q64_item_t;
 typedef _Atomic q64_item_t q64_cell_t;
 
 typedef struct q64_segment_st q64_segment_t;
@@ -53,7 +49,7 @@ typedef struct q64_segment_st q64_segment_t;
  */
 
 struct q64_segment_st {
-    _Atomic (q64_segment_t *)next;
+    _Atomic(q64_segment_t *) next;
     uint64_t                 size;
     _Atomic uint64_t         enqueue_index;
     _Atomic uint64_t         dequeue_index;
@@ -61,8 +57,7 @@ struct q64_segment_st {
 };
 
 typedef struct {
-    alignas(16)
-    q64_segment_t *enqueue_segment;
+    alignas(16) q64_segment_t *enqueue_segment;
     q64_segment_t *dequeue_segment;
 } q64_seg_ptrs_t;
 
@@ -73,22 +68,13 @@ typedef struct {
     _Atomic uint64_t       len;
 } q64_t;
 
-enum64(q64_cell_state_t,
-       Q64_EMPTY   = 0x00,
-       Q64_TOOSLOW = 0x01,
-       Q64_USED    = 0x02);
-
-static inline uint64_t
-q64_len(q64_t *self)
-{
-    return atomic_read(&self->len);
-}
-
+// clang-format off
 q64_t   *q64_new      (void);
 q64_t   *q64_new_size (char);
 void     q64_init     (q64_t *);
 void     q64_init_size(q64_t *, char);
 void     q64_cleanup  (q64_t *);
 void     q64_delete   (q64_t *);
+uint64_t q64_len      (q64_t *);
 void     q64_enqueue  (q64_t *, void *);
 void    *q64_dequeue  (q64_t *, bool *);

--- a/include/hatrack/q64.h
+++ b/include/hatrack/q64.h
@@ -69,12 +69,12 @@ typedef struct {
 } q64_t;
 
 // clang-format off
-q64_t   *q64_new      (void);
-q64_t   *q64_new_size (char);
-void     q64_init     (q64_t *);
-void     q64_init_size(q64_t *, char);
-void     q64_cleanup  (q64_t *);
-void     q64_delete   (q64_t *);
-uint64_t q64_len      (q64_t *);
-void     q64_enqueue  (q64_t *, void *);
-void    *q64_dequeue  (q64_t *, bool *);
+HATRACK_EXTERN q64_t   *q64_new      (void);
+HATRACK_EXTERN q64_t   *q64_new_size (char);
+HATRACK_EXTERN void     q64_init     (q64_t *);
+HATRACK_EXTERN void     q64_init_size(q64_t *, char);
+HATRACK_EXTERN void     q64_cleanup  (q64_t *);
+HATRACK_EXTERN void     q64_delete   (q64_t *);
+HATRACK_EXTERN uint64_t q64_len      (q64_t *);
+HATRACK_EXTERN void     q64_enqueue  (q64_t *, void *);
+HATRACK_EXTERN void    *q64_dequeue  (q64_t *, bool *);

--- a/include/hatrack/queue.h
+++ b/include/hatrack/queue.h
@@ -77,11 +77,7 @@
 #pragma once
 
 #include "base.h"
-#include "hatomic.h"
 
-#define QUEUE_HELP_VALUE 1 << QUEUE_HELP_STEPS
-
-// clang-format off
 typedef struct {
     void    *item;
     uint64_t state;
@@ -100,7 +96,7 @@ typedef struct queue_segment_st queue_segment_t;
  */
 
 struct queue_segment_st {
-    _Atomic (queue_segment_t *)next;
+    _Atomic(queue_segment_t *) next;
     uint64_t                   size;
     _Atomic uint64_t           enqueue_index;
     _Atomic uint64_t           dequeue_index;
@@ -109,7 +105,7 @@ struct queue_segment_st {
 
 typedef struct {
     alignas(16)
-    queue_segment_t *enqueue_segment;
+        queue_segment_t *enqueue_segment;
     queue_segment_t *dequeue_segment;
 } queue_seg_ptrs_t;
 
@@ -120,22 +116,13 @@ typedef struct hatrack_queue_t {
     _Atomic uint64_t         len;
 } queue_t;
 
-enum64(queue_cell_state_t,
-       QUEUE_EMPTY   = 0x00,
-       QUEUE_TOOSLOW = 0x01,
-       QUEUE_USED    = 0x02);
-
-static inline uint64_t
-queue_len(queue_t *self)
-{
-    return atomic_read(&self->len);
-}
-
+// clang-format off
 queue_t *queue_new      (void);
 queue_t *queue_new_size (char);
 void     queue_init     (queue_t *);
 void     queue_init_size(queue_t *, char);
 void     queue_cleanup  (queue_t *);
 void     queue_delete   (queue_t *);
+uint64_t queue_len      (queue_t *);
 void     queue_enqueue  (queue_t *, void *);
 void    *queue_dequeue  (queue_t *, bool *);

--- a/include/hatrack/queue.h
+++ b/include/hatrack/queue.h
@@ -117,12 +117,12 @@ typedef struct hatrack_queue_t {
 } queue_t;
 
 // clang-format off
-queue_t *queue_new      (void);
-queue_t *queue_new_size (char);
-void     queue_init     (queue_t *);
-void     queue_init_size(queue_t *, char);
-void     queue_cleanup  (queue_t *);
-void     queue_delete   (queue_t *);
-uint64_t queue_len      (queue_t *);
-void     queue_enqueue  (queue_t *, void *);
-void    *queue_dequeue  (queue_t *, bool *);
+HATRACK_EXTERN queue_t *queue_new      (void);
+HATRACK_EXTERN queue_t *queue_new_size (char);
+HATRACK_EXTERN void     queue_init     (queue_t *);
+HATRACK_EXTERN void     queue_init_size(queue_t *, char);
+HATRACK_EXTERN void     queue_cleanup  (queue_t *);
+HATRACK_EXTERN void     queue_delete   (queue_t *);
+HATRACK_EXTERN uint64_t queue_len      (queue_t *);
+HATRACK_EXTERN void     queue_enqueue  (queue_t *, void *);
+HATRACK_EXTERN void    *queue_dequeue  (queue_t *, bool *);

--- a/include/hatrack/refhat.h
+++ b/include/hatrack/refhat.h
@@ -24,8 +24,6 @@
 #include "base.h"
 #include "hatrack_common.h"
 
-// clang-format off
-
 /* refhat_bucket_t
  *
  * For consistency with our other (parallel) implementations, our
@@ -58,9 +56,9 @@
  *            the bucket.
  */
 typedef struct {
-    hatrack_hash_t    hv;
-    void             *item;
-    uint64_t          epoch;
+    hatrack_hash_t hv;
+    void          *item;
+    uint64_t       epoch;
 } refhat_bucket_t;
 
 /* refhat_t
@@ -99,16 +97,14 @@ typedef struct {
  *               operation, for the purposes of sort ordering.
  */
 typedef struct {
-    uint64_t          last_slot;
-    uint64_t          threshold;
-    uint64_t          used_count;
-    uint64_t          item_count;
-    refhat_bucket_t  *buckets;
-    uint64_t          buckets_size;
-    uint64_t          next_epoch;
+    uint64_t         last_slot;
+    uint64_t         threshold;
+    uint64_t         used_count;
+    uint64_t         item_count;
+    refhat_bucket_t *buckets;
+    uint64_t         buckets_size;
+    uint64_t         next_epoch;
 } refhat_t;
-
-
 
 /* This API requires that you deal with hashing the key external to
  * the API.  You might want to cache hash values, use different
@@ -119,6 +115,8 @@ typedef struct {
  * choose a 3-universal keyed hash function, or if hash values need to
  * be consistent across runs, something fast and practical like XXH3.
  */
+
+// clang-format off
 refhat_t       *refhat_new      (void);
 refhat_t       *refhat_new_size (char);
 void            refhat_init     (refhat_t *);
@@ -132,5 +130,3 @@ bool            refhat_add      (refhat_t *, hatrack_hash_t, void *);
 void           *refhat_remove   (refhat_t *, hatrack_hash_t, bool *);
 uint64_t        refhat_len      (refhat_t *);
 hatrack_view_t *refhat_view     (refhat_t *, uint64_t *, bool);
-
-//clang-format on

--- a/include/hatrack/refhat.h
+++ b/include/hatrack/refhat.h
@@ -117,16 +117,16 @@ typedef struct {
  */
 
 // clang-format off
-refhat_t       *refhat_new      (void);
-refhat_t       *refhat_new_size (char);
-void            refhat_init     (refhat_t *);
-void            refhat_init_size(refhat_t *, char);
-void            refhat_cleanup  (refhat_t *);
-void            refhat_delete   (refhat_t *);
-void           *refhat_get      (refhat_t *, hatrack_hash_t, bool *);
-void           *refhat_put      (refhat_t *, hatrack_hash_t, void *, bool *);
-void           *refhat_replace  (refhat_t *, hatrack_hash_t, void *, bool *);
-bool            refhat_add      (refhat_t *, hatrack_hash_t, void *);
-void           *refhat_remove   (refhat_t *, hatrack_hash_t, bool *);
-uint64_t        refhat_len      (refhat_t *);
-hatrack_view_t *refhat_view     (refhat_t *, uint64_t *, bool);
+HATRACK_EXTERN refhat_t       *refhat_new      (void);
+HATRACK_EXTERN refhat_t       *refhat_new_size (char);
+HATRACK_EXTERN void            refhat_init     (refhat_t *);
+HATRACK_EXTERN void            refhat_init_size(refhat_t *, char);
+HATRACK_EXTERN void            refhat_cleanup  (refhat_t *);
+HATRACK_EXTERN void            refhat_delete   (refhat_t *);
+HATRACK_EXTERN void           *refhat_get      (refhat_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *refhat_put      (refhat_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *refhat_replace  (refhat_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN bool            refhat_add      (refhat_t *, hatrack_hash_t, void *);
+HATRACK_EXTERN void           *refhat_remove   (refhat_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN uint64_t        refhat_len      (refhat_t *);
+HATRACK_EXTERN hatrack_view_t *refhat_view     (refhat_t *, uint64_t *, bool);

--- a/include/hatrack/set.h
+++ b/include/hatrack/set.h
@@ -37,32 +37,27 @@ struct hatrack_set_st {
 };
 
 // clang-format off
-hatrack_set_t  *hatrack_set_new             (uint32_t);
-void            hatrack_set_init            (hatrack_set_t *, uint32_t);
-void            hatrack_set_cleanup         (hatrack_set_t *);
-void            hatrack_set_delete          (hatrack_set_t *);
-void            hatrack_set_set_hash_offset (hatrack_set_t *, int32_t);
-void            hatrack_set_set_cache_offset(hatrack_set_t *, int32_t);
-void            hatrack_set_set_custom_hash (hatrack_set_t *,
-					     hatrack_hash_func_t);
-void            hatrack_set_set_free_handler(hatrack_set_t *,
-					     hatrack_mem_hook_t);
-void            hatrack_set_set_return_hook (hatrack_set_t *,
-					     hatrack_mem_hook_t);
-bool            hatrack_set_contains        (hatrack_set_t *, void *);
-bool            hatrack_set_put             (hatrack_set_t *, void *);
-bool            hatrack_set_add             (hatrack_set_t *, void *);
-bool            hatrack_set_remove          (hatrack_set_t *, void *);
-void           *hatrack_set_items           (hatrack_set_t *, uint64_t *);
-void           *hatrack_set_items_sort      (hatrack_set_t *, uint64_t *);
-void           *hatrack_set_any_item        (hatrack_set_t *, bool *);
-bool            hatrack_set_is_eq           (hatrack_set_t *, hatrack_set_t *);
-bool            hatrack_set_is_superset     (hatrack_set_t *, hatrack_set_t *,
-					     bool);
-bool            hatrack_set_is_subset       (hatrack_set_t *, hatrack_set_t *,
-					     bool);
-bool            hatrack_set_is_disjoint     (hatrack_set_t *, hatrack_set_t *);
-hatrack_set_t  *hatrack_set_difference      (hatrack_set_t *, hatrack_set_t *);
-hatrack_set_t  *hatrack_set_union           (hatrack_set_t *, hatrack_set_t *);
-hatrack_set_t  *hatrack_set_intersection    (hatrack_set_t *, hatrack_set_t *);
-hatrack_set_t  *hatrack_set_disjunction     (hatrack_set_t *, hatrack_set_t *);
+HATRACK_EXTERN hatrack_set_t  *hatrack_set_new             (uint32_t);
+HATRACK_EXTERN void            hatrack_set_init            (hatrack_set_t *, uint32_t);
+HATRACK_EXTERN void            hatrack_set_cleanup         (hatrack_set_t *);
+HATRACK_EXTERN void            hatrack_set_delete          (hatrack_set_t *);
+HATRACK_EXTERN void            hatrack_set_set_hash_offset (hatrack_set_t *, int32_t);
+HATRACK_EXTERN void            hatrack_set_set_cache_offset(hatrack_set_t *, int32_t);
+HATRACK_EXTERN void            hatrack_set_set_custom_hash (hatrack_set_t *, hatrack_hash_func_t);
+HATRACK_EXTERN void            hatrack_set_set_free_handler(hatrack_set_t *, hatrack_mem_hook_t);
+HATRACK_EXTERN void            hatrack_set_set_return_hook (hatrack_set_t *, hatrack_mem_hook_t);
+HATRACK_EXTERN bool            hatrack_set_contains        (hatrack_set_t *, void *);
+HATRACK_EXTERN bool            hatrack_set_put             (hatrack_set_t *, void *);
+HATRACK_EXTERN bool            hatrack_set_add             (hatrack_set_t *, void *);
+HATRACK_EXTERN bool            hatrack_set_remove          (hatrack_set_t *, void *);
+HATRACK_EXTERN void           *hatrack_set_items           (hatrack_set_t *, uint64_t *);
+HATRACK_EXTERN void           *hatrack_set_items_sort      (hatrack_set_t *, uint64_t *);
+HATRACK_EXTERN void           *hatrack_set_any_item        (hatrack_set_t *, bool *);
+HATRACK_EXTERN bool            hatrack_set_is_eq           (hatrack_set_t *, hatrack_set_t *);
+HATRACK_EXTERN bool            hatrack_set_is_superset     (hatrack_set_t *, hatrack_set_t *, bool);
+HATRACK_EXTERN bool            hatrack_set_is_subset       (hatrack_set_t *, hatrack_set_t *, bool);
+HATRACK_EXTERN bool            hatrack_set_is_disjoint     (hatrack_set_t *, hatrack_set_t *);
+HATRACK_EXTERN hatrack_set_t  *hatrack_set_difference      (hatrack_set_t *, hatrack_set_t *);
+HATRACK_EXTERN hatrack_set_t  *hatrack_set_union           (hatrack_set_t *, hatrack_set_t *);
+HATRACK_EXTERN hatrack_set_t  *hatrack_set_intersection    (hatrack_set_t *, hatrack_set_t *);
+HATRACK_EXTERN hatrack_set_t  *hatrack_set_disjunction     (hatrack_set_t *, hatrack_set_t *);

--- a/include/hatrack/stack.h
+++ b/include/hatrack/stack.h
@@ -74,12 +74,12 @@ typedef struct {
 } hatstack_t;
 
 // clang-format off
-hatstack_t   *hatstack_new        (uint64_t);
-void          hatstack_init       (hatstack_t *, uint64_t);
-void          hatstack_cleanup    (hatstack_t *);
-void          hatstack_delete     (hatstack_t *);
-void          hatstack_push       (hatstack_t *, void *);
-void         *hatstack_pop        (hatstack_t *, bool *);
-stack_view_t *hatstack_view       (hatstack_t *);
-void         *hatstack_view_next  (stack_view_t *, bool *);
-void          hatstack_view_delete(stack_view_t *);
+HATRACK_EXTERN hatstack_t   *hatstack_new        (uint64_t);
+HATRACK_EXTERN void          hatstack_init       (hatstack_t *, uint64_t);
+HATRACK_EXTERN void          hatstack_cleanup    (hatstack_t *);
+HATRACK_EXTERN void          hatstack_delete     (hatstack_t *);
+HATRACK_EXTERN void          hatstack_push       (hatstack_t *, void *);
+HATRACK_EXTERN void         *hatstack_pop        (hatstack_t *, bool *);
+HATRACK_EXTERN stack_view_t *hatstack_view       (hatstack_t *);
+HATRACK_EXTERN void         *hatstack_view_next  (stack_view_t *, bool *);
+HATRACK_EXTERN void          hatstack_view_delete(stack_view_t *);

--- a/include/hatrack/stack.h
+++ b/include/hatrack/stack.h
@@ -68,105 +68,18 @@ struct stack_store_t {
 typedef struct {
     _Atomic(stack_store_t *) store;
     uint64_t                 compress_threshold;
-
 #ifdef HATSTACK_WAIT_FREE
     _Atomic int64_t push_help_shift;
 #endif
-
 } hatstack_t;
 
-hatstack_t   *hatstack_new(uint64_t);
-void          hatstack_init(hatstack_t *, uint64_t);
-void          hatstack_cleanup(hatstack_t *);
-void          hatstack_delete(hatstack_t *);
-void          hatstack_push(hatstack_t *, void *);
-void         *hatstack_pop(hatstack_t *, bool *);
-stack_view_t *hatstack_view(hatstack_t *);
-void         *hatstack_view_next(stack_view_t *, bool *);
+// clang-format off
+hatstack_t   *hatstack_new        (uint64_t);
+void          hatstack_init       (hatstack_t *, uint64_t);
+void          hatstack_cleanup    (hatstack_t *);
+void          hatstack_delete     (hatstack_t *);
+void          hatstack_push       (hatstack_t *, void *);
+void         *hatstack_pop        (hatstack_t *, bool *);
+stack_view_t *hatstack_view       (hatstack_t *);
+void         *hatstack_view_next  (stack_view_t *, bool *);
 void          hatstack_view_delete(stack_view_t *);
-
-enum {
-    HATSTACK_HEAD_MOVE_MASK    = 0x80000000ffffffff,
-    HATSTACK_HEAD_EPOCH_BUMP   = 0x0000000100000000,
-    HATSTACK_HEAD_INDEX_MASK   = 0x00000000ffffffff,
-    HATSTACK_HEAD_EPOCH_MASK   = 0x7fffffff00000000,
-    HATSTACK_HEAD_INITIALIZING = 0xffffffffffffffff,
-};
-
-static inline bool
-head_is_moving(uint64_t n, uint64_t store_size)
-{
-    return (n & HATSTACK_HEAD_INDEX_MASK) >= store_size;
-}
-
-static inline uint32_t
-head_get_epoch(uint64_t n)
-{
-    return (n >> 32);
-}
-
-static inline uint32_t
-head_get_index(uint64_t n)
-{
-    return n & HATSTACK_HEAD_INDEX_MASK;
-}
-
-static inline uint64_t
-head_candidate_new_epoch(uint64_t n, uint32_t ix)
-{
-    return ((n & HATSTACK_HEAD_EPOCH_MASK) | ix) + HATSTACK_HEAD_EPOCH_BUMP;
-}
-
-// These flags / constants are used in stack_item_t's state.
-enum {
-    HATSTACK_PUSHED = 0x00000001, // Cell is full.
-    HATSTACK_POPPED = 0x00000002, // Cell was full, is empty.
-    HATSTACK_MOVING = 0x00000004,
-    HATSTACK_MOVED  = 0x00000008
-};
-
-static inline uint32_t
-state_add_moved(uint32_t old)
-{
-    return old | HATSTACK_MOVING | HATSTACK_MOVED;
-}
-
-static inline uint32_t
-state_add_moving(uint32_t old)
-{
-    return old | HATSTACK_MOVING;
-}
-
-static inline bool
-state_is_pushed(uint32_t state)
-{
-    return (bool)(state & HATSTACK_PUSHED);
-}
-
-static inline bool
-state_is_popped(uint32_t state)
-{
-    return (bool)(state & HATSTACK_POPPED);
-}
-
-static inline bool
-state_is_moving(uint32_t state)
-{
-    return (bool)(state & HATSTACK_MOVING);
-}
-
-static inline bool
-state_is_moved(uint32_t state)
-{
-    return (bool)(state & HATSTACK_MOVED);
-}
-
-static inline bool
-cell_can_push(stack_item_t item, uint32_t epoch)
-{
-    if (item.valid_after >= epoch) {
-        return false;
-    }
-
-    return true;
-}

--- a/include/hatrack/swimcap.h
+++ b/include/hatrack/swimcap.h
@@ -213,16 +213,16 @@ typedef struct {
  */
 
 // clang-format off
-swimcap_t      *swimcap_new      (void);
-swimcap_t      *swimcap_new_size (char);
-void            swimcap_init     (swimcap_t *);
-void            swimcap_init_size(swimcap_t *, char);
-void            swimcap_cleanup  (swimcap_t *);
-void            swimcap_delete   (swimcap_t *);
-void           *swimcap_get      (swimcap_t *, hatrack_hash_t, bool *);
-void           *swimcap_put      (swimcap_t *, hatrack_hash_t, void *, bool *);
-void           *swimcap_replace  (swimcap_t *, hatrack_hash_t, void *, bool *);
-bool            swimcap_add      (swimcap_t *, hatrack_hash_t, void *);
-void           *swimcap_remove   (swimcap_t *, hatrack_hash_t, bool *);
-uint64_t        swimcap_len      (swimcap_t *);
-hatrack_view_t *swimcap_view     (swimcap_t *, uint64_t *, bool);
+HATRACK_EXTERN swimcap_t      *swimcap_new      (void);
+HATRACK_EXTERN swimcap_t      *swimcap_new_size (char);
+HATRACK_EXTERN void            swimcap_init     (swimcap_t *);
+HATRACK_EXTERN void            swimcap_init_size(swimcap_t *, char);
+HATRACK_EXTERN void            swimcap_cleanup  (swimcap_t *);
+HATRACK_EXTERN void            swimcap_delete   (swimcap_t *);
+HATRACK_EXTERN void           *swimcap_get      (swimcap_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *swimcap_put      (swimcap_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *swimcap_replace  (swimcap_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN bool            swimcap_add      (swimcap_t *, hatrack_hash_t, void *);
+HATRACK_EXTERN void           *swimcap_remove   (swimcap_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN uint64_t        swimcap_len      (swimcap_t *);
+HATRACK_EXTERN hatrack_view_t *swimcap_view     (swimcap_t *, uint64_t *, bool);

--- a/include/hatrack/swimcap.h
+++ b/include/hatrack/swimcap.h
@@ -37,8 +37,6 @@
 #include "base.h"
 #include "hatrack_common.h"
 
-// clang-format off
-
 /* swimcap_record_t
  *
  * This is unchanged from duncecap_record_t.
@@ -79,8 +77,7 @@
  *          point on which to construct a consistent sort order.
  */
 typedef struct {
-    alignas(16)
-    void    *item;
+    alignas(16) void *item;
     uint64_t epoch;
 } swimcap_record_t;
 
@@ -199,10 +196,10 @@ typedef struct {
  *                  operation, for the purposes of sort ordering.
  */
 typedef struct {
-    swimcap_store_t   *store_current;
-    uint64_t           item_count;
-    uint64_t           next_epoch;
-    pthread_mutex_t    write_mutex;
+    swimcap_store_t *store_current;
+    uint64_t         item_count;
+    uint64_t         next_epoch;
+    pthread_mutex_t  write_mutex;
 } swimcap_t;
 
 /* This API requires that you deal with hashing the key external to
@@ -214,6 +211,8 @@ typedef struct {
  * choose a 3-universal keyed hash function, or if hash values need to
  * be consistent across runs, something fast and practical like XXH3.
  */
+
+// clang-format off
 swimcap_t      *swimcap_new      (void);
 swimcap_t      *swimcap_new_size (char);
 void            swimcap_init     (swimcap_t *);

--- a/include/hatrack/tiara.h
+++ b/include/hatrack/tiara.h
@@ -55,12 +55,6 @@
 #include "base.h"
 #include "hatrack_common.h"
 
-enum64(tiara_flag_t,
-       TIARA_F_MOVING = 0x0000000000000001,
-       TIARA_F_MOVED  = 0x0000000000000002,
-       TIARA_F_USED   = 0x0000000000000004,
-       TIARA_F_ALL    = TIARA_F_MOVING | TIARA_F_MOVED | TIARA_F_USED);
-
 typedef struct {
     uint64_t hv;
     void    *item;
@@ -83,16 +77,17 @@ typedef struct {
     _Atomic uint64_t         item_count;
 } tiara_t;
 
-tiara_t        *tiara_new(void);
-tiara_t        *tiara_new_size(char);
-void            tiara_init(tiara_t *);
+// clang-format off
+tiara_t        *tiara_new      (void);
+tiara_t        *tiara_new_size (char);
+void            tiara_init     (tiara_t *);
 void            tiara_init_size(tiara_t *, char);
-void            tiara_cleanup(tiara_t *);
-void            tiara_delete(tiara_t *);
-void           *tiara_get(tiara_t *, uint64_t);
-void           *tiara_put(tiara_t *, uint64_t, void *);
-void           *tiara_replace(tiara_t *, uint64_t, void *);
-bool            tiara_add(tiara_t *, uint64_t, void *);
-void           *tiara_remove(tiara_t *, uint64_t);
-uint64_t        tiara_len(tiara_t *);
-hatrack_view_t *tiara_view(tiara_t *, uint64_t *, bool);
+void            tiara_cleanup  (tiara_t *);
+void            tiara_delete   (tiara_t *);
+void           *tiara_get      (tiara_t *, uint64_t);
+void           *tiara_put      (tiara_t *, uint64_t, void *);
+void           *tiara_replace  (tiara_t *, uint64_t, void *);
+bool            tiara_add      (tiara_t *, uint64_t, void *);
+void           *tiara_remove   (tiara_t *, uint64_t);
+uint64_t        tiara_len      (tiara_t *);
+hatrack_view_t *tiara_view     (tiara_t *, uint64_t *, bool);

--- a/include/hatrack/tiara.h
+++ b/include/hatrack/tiara.h
@@ -78,16 +78,16 @@ typedef struct {
 } tiara_t;
 
 // clang-format off
-tiara_t        *tiara_new      (void);
-tiara_t        *tiara_new_size (char);
-void            tiara_init     (tiara_t *);
-void            tiara_init_size(tiara_t *, char);
-void            tiara_cleanup  (tiara_t *);
-void            tiara_delete   (tiara_t *);
-void           *tiara_get      (tiara_t *, uint64_t);
-void           *tiara_put      (tiara_t *, uint64_t, void *);
-void           *tiara_replace  (tiara_t *, uint64_t, void *);
-bool            tiara_add      (tiara_t *, uint64_t, void *);
-void           *tiara_remove   (tiara_t *, uint64_t);
-uint64_t        tiara_len      (tiara_t *);
-hatrack_view_t *tiara_view     (tiara_t *, uint64_t *, bool);
+HATRACK_EXTERN tiara_t        *tiara_new      (void);
+HATRACK_EXTERN tiara_t        *tiara_new_size (char);
+HATRACK_EXTERN void            tiara_init     (tiara_t *);
+HATRACK_EXTERN void            tiara_init_size(tiara_t *, char);
+HATRACK_EXTERN void            tiara_cleanup  (tiara_t *);
+HATRACK_EXTERN void            tiara_delete   (tiara_t *);
+HATRACK_EXTERN void           *tiara_get      (tiara_t *, uint64_t);
+HATRACK_EXTERN void           *tiara_put      (tiara_t *, uint64_t, void *);
+HATRACK_EXTERN void           *tiara_replace  (tiara_t *, uint64_t, void *);
+HATRACK_EXTERN bool            tiara_add      (tiara_t *, uint64_t, void *);
+HATRACK_EXTERN void           *tiara_remove   (tiara_t *, uint64_t);
+HATRACK_EXTERN uint64_t        tiara_len      (tiara_t *);
+HATRACK_EXTERN hatrack_view_t *tiara_view     (tiara_t *, uint64_t *, bool);

--- a/include/hatrack/tophat.h
+++ b/include/hatrack/tophat.h
@@ -140,14 +140,13 @@ typedef enum {
 /* tophat_st_record_t and tophat_st_bucket_t are straightforward,
  * and together constitute the single-threaded bucket layout.
  */
-// clang-format off
 typedef struct {
-    void     *item;
-    uint64_t  epoch;
+    void    *item;
+    uint64_t epoch;
 } tophat_st_record_t;
 
 typedef struct {
-            hatrack_hash_t     hv;
+    hatrack_hash_t             hv;
     _Atomic tophat_st_record_t record;
 } tophat_st_bucket_t;
 
@@ -198,10 +197,9 @@ typedef struct {
     tophat_st_ctx_t   *st_table;
     pthread_mutex_t    mutex;
     tophat_migration_t dst_type;
-    _Atomic (void *)   mt_table;
+    _Atomic(void *)    mt_table;
     hatrack_vtable_t   mt_vtable;
 } tophat_t;
-
 
 /* Here, we see that we have four different initialization functions,
  * each of which selects which multi-threaded implementation we want
@@ -215,6 +213,8 @@ typedef struct {
  * _mx   = Mutex variant
  * _wf   = Wait-Free variant
  */
+
+// clang-format off
 tophat_t       *tophat_new_fast_mx      (void);
 tophat_t       *tophat_new_fast_wf      (void);
 tophat_t       *tophat_new_cst_mx       (void);

--- a/include/hatrack/tophat.h
+++ b/include/hatrack/tophat.h
@@ -215,29 +215,29 @@ typedef struct {
  */
 
 // clang-format off
-tophat_t       *tophat_new_fast_mx      (void);
-tophat_t       *tophat_new_fast_wf      (void);
-tophat_t       *tophat_new_cst_mx       (void);
-tophat_t       *tophat_new_cst_wf       (void);
-tophat_t       *tophat_new_fast_mx_size (char);
-tophat_t       *tophat_new_fast_wf_size (char);
-tophat_t       *tophat_new_cst_mx_size  (char);
-tophat_t       *tophat_new_cst_wf_size  (char);
-void            tophat_init_fast_mx     (tophat_t *);
-void            tophat_init_fast_wf     (tophat_t *);
-void            tophat_init_cst_mx      (tophat_t *);
-void            tophat_init_cst_wf      (tophat_t *);
-void            tophat_init_fast_mx_size(tophat_t *, char);
-void            tophat_init_fast_wf_size(tophat_t *, char);
-void            tophat_init_cst_mx_size (tophat_t *, char);
-void            tophat_init_cst_wf_size (tophat_t *, char);
+HATRACK_EXTERN tophat_t       *tophat_new_fast_mx      (void);
+HATRACK_EXTERN tophat_t       *tophat_new_fast_wf      (void);
+HATRACK_EXTERN tophat_t       *tophat_new_cst_mx       (void);
+HATRACK_EXTERN tophat_t       *tophat_new_cst_wf       (void);
+HATRACK_EXTERN tophat_t       *tophat_new_fast_mx_size (char);
+HATRACK_EXTERN tophat_t       *tophat_new_fast_wf_size (char);
+HATRACK_EXTERN tophat_t       *tophat_new_cst_mx_size  (char);
+HATRACK_EXTERN tophat_t       *tophat_new_cst_wf_size  (char);
+HATRACK_EXTERN void            tophat_init_fast_mx     (tophat_t *);
+HATRACK_EXTERN void            tophat_init_fast_wf     (tophat_t *);
+HATRACK_EXTERN void            tophat_init_cst_mx      (tophat_t *);
+HATRACK_EXTERN void            tophat_init_cst_wf      (tophat_t *);
+HATRACK_EXTERN void            tophat_init_fast_mx_size(tophat_t *, char);
+HATRACK_EXTERN void            tophat_init_fast_wf_size(tophat_t *, char);
+HATRACK_EXTERN void            tophat_init_cst_mx_size (tophat_t *, char);
+HATRACK_EXTERN void            tophat_init_cst_wf_size (tophat_t *, char);
 
-void            tophat_cleanup     (tophat_t *);
-void            tophat_delete      (tophat_t *);
-void           *tophat_get         (tophat_t *, hatrack_hash_t, bool *);
-void           *tophat_put         (tophat_t *, hatrack_hash_t, void *, bool *);
-void           *tophat_replace     (tophat_t *, hatrack_hash_t, void *, bool *);
-bool            tophat_add         (tophat_t *, hatrack_hash_t, void *);
-void           *tophat_remove      (tophat_t *, hatrack_hash_t, bool *);
-uint64_t        tophat_len         (tophat_t *);
-hatrack_view_t *tophat_view        (tophat_t *, uint64_t *, bool);
+HATRACK_EXTERN void            tophat_cleanup     (tophat_t *);
+HATRACK_EXTERN void            tophat_delete      (tophat_t *);
+HATRACK_EXTERN void           *tophat_get         (tophat_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *tophat_put         (tophat_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *tophat_replace     (tophat_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN bool            tophat_add         (tophat_t *, hatrack_hash_t, void *);
+HATRACK_EXTERN void           *tophat_remove      (tophat_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN uint64_t        tophat_len         (tophat_t *);
+HATRACK_EXTERN hatrack_view_t *tophat_view        (tophat_t *, uint64_t *, bool);

--- a/include/hatrack/vector.h
+++ b/include/hatrack/vector.h
@@ -63,20 +63,20 @@ typedef struct {
 } vector_t;
 
 // clang-format off
-vector_t      *vector_new               (int64_t);
-void           vector_init              (vector_t *, int64_t, bool);
-void           vector_set_ret_callback  (vector_t *, vector_callback_t);
-void           vector_set_eject_callback(vector_t *, vector_callback_t);
-void           vector_cleanup           (vector_t *);
-void           vector_delete            (vector_t *);
-void          *vector_get               (vector_t *, int64_t, int *);
-bool           vector_set               (vector_t *, int64_t, void *);
-void           vector_grow              (vector_t *, int64_t);
-void           vector_shrink            (vector_t *, int64_t);
-uint32_t       vector_len               (vector_t *);
-void           vector_push              (vector_t *, void *);
-void          *vector_pop               (vector_t *, bool *);
-void          *vector_peek              (vector_t *, bool *);
-vector_view_t *vector_view              (vector_t *);
-void          *vector_view_next         (vector_view_t *, bool *);
-void           vector_view_delete       (vector_view_t *);
+HATRACK_EXTERN vector_t      *vector_new               (int64_t);
+HATRACK_EXTERN void           vector_init              (vector_t *, int64_t, bool);
+HATRACK_EXTERN void           vector_set_ret_callback  (vector_t *, vector_callback_t);
+HATRACK_EXTERN void           vector_set_eject_callback(vector_t *, vector_callback_t);
+HATRACK_EXTERN void           vector_cleanup           (vector_t *);
+HATRACK_EXTERN void           vector_delete            (vector_t *);
+HATRACK_EXTERN void          *vector_get               (vector_t *, int64_t, int *);
+HATRACK_EXTERN bool           vector_set               (vector_t *, int64_t, void *);
+HATRACK_EXTERN void           vector_grow              (vector_t *, int64_t);
+HATRACK_EXTERN void           vector_shrink            (vector_t *, int64_t);
+HATRACK_EXTERN uint32_t       vector_len               (vector_t *);
+HATRACK_EXTERN void           vector_push              (vector_t *, void *);
+HATRACK_EXTERN void          *vector_pop               (vector_t *, bool *);
+HATRACK_EXTERN void          *vector_peek              (vector_t *, bool *);
+HATRACK_EXTERN vector_view_t *vector_view              (vector_t *);
+HATRACK_EXTERN void          *vector_view_next         (vector_view_t *, bool *);
+HATRACK_EXTERN void           vector_view_delete       (vector_view_t *);

--- a/include/hatrack/vector.h
+++ b/include/hatrack/vector.h
@@ -24,14 +24,11 @@
 #include "base.h"
 #include "helpmanager.h"
 
-#define VECTOR_MIN_STORE_SZ_LOG 4
-
-// clang-format off
 typedef void (*vector_callback_t)(void *);
 
 typedef struct {
-    void     *item;
-    int64_t   state;
+    void   *item;
+    int64_t state;
 } vector_item_t;
 
 typedef _Atomic vector_item_t vector_cell_t;
@@ -39,32 +36,33 @@ typedef _Atomic vector_item_t vector_cell_t;
 typedef struct vector_store_t vector_store_t;
 
 typedef struct {
-    int64_t             next_ix;
-    int64_t             size;
-    vector_store_t     *contents;
-    vector_callback_t   eject_callback;
+    int64_t           next_ix;
+    int64_t           size;
+    vector_store_t   *contents;
+    vector_callback_t eject_callback;
 } vector_view_t;
 
 typedef struct {
     int64_t array_size;
-    int64_t  job_id;
+    int64_t job_id;
 } vec_size_info_t;
 
 struct vector_store_t {
     int64_t                   store_size;
     _Atomic vec_size_info_t   array_size_info;
-    _Atomic (vector_store_t *)next;
+    _Atomic(vector_store_t *) next;
     _Atomic bool              claimed;
     vector_cell_t             cells[];
 };
 
 typedef struct {
-    vector_callback_t          ret_callback;
-    vector_callback_t          eject_callback;
-    _Atomic (vector_store_t  *)store;
-    help_manager_t             help_manager;
+    vector_callback_t         ret_callback;
+    vector_callback_t         eject_callback;
+    _Atomic(vector_store_t *) store;
+    help_manager_t            help_manager;
 } vector_t;
 
+// clang-format off
 vector_t      *vector_new               (int64_t);
 void           vector_init              (vector_t *, int64_t, bool);
 void           vector_set_ret_callback  (vector_t *, vector_callback_t);
@@ -82,28 +80,3 @@ void          *vector_peek              (vector_t *, bool *);
 vector_view_t *vector_view              (vector_t *);
 void          *vector_view_next         (vector_view_t *, bool *);
 void           vector_view_delete       (vector_view_t *);
-
-enum {
-       VECTOR_POPPED   = 0x8000000000000000,
-       VECTOR_USED     = 0x4000000000000000,
-       VECTOR_MOVING   = 0x2000000000000000,
-       VECTOR_MOVED    = 0x1000000000000000,
-       VECTOR_JOB_MASK = 0x0fffffffffffffff
-};
-
-
-enum {
-    VECTOR_OK,
-    VECTOR_OOB,
-    VECTOR_UNINITIALIZED
-};
-
-enum {
-    VECTOR_OP_PUSH = 0,
-    VECTOR_OP_POP,
-    VECTOR_OP_PEEK,
-    VECTOR_OP_GROW,
-    VECTOR_OP_SHRINK,
-    VECTOR_OP_SLOW_SET,
-    VECTOR_OP_VIEW
-};

--- a/include/hatrack/witchhat.h
+++ b/include/hatrack/witchhat.h
@@ -65,19 +65,17 @@ typedef struct {
 } witchhat_t;
 
 // clang-format off
-witchhat_t     *witchhat_new        (void);
-witchhat_t     *witchhat_new_size   (char);
-void            witchhat_init       (witchhat_t *);
-void            witchhat_init_size  (witchhat_t *, char);
-void            witchhat_cleanup    (witchhat_t *);
-void            witchhat_delete     (witchhat_t *);
-void           *witchhat_get        (witchhat_t *, hatrack_hash_t, bool *);
-void           *witchhat_put        (witchhat_t *, hatrack_hash_t, void *,
-				     bool *);
-void           *witchhat_replace    (witchhat_t *, hatrack_hash_t, void *,
-				     bool *);
-bool            witchhat_add        (witchhat_t *, hatrack_hash_t, void *);
-void           *witchhat_remove     (witchhat_t *, hatrack_hash_t, bool *);
-uint64_t        witchhat_len        (witchhat_t *);
-hatrack_view_t *witchhat_view       (witchhat_t *, uint64_t *, bool);
-hatrack_view_t *witchhat_view_no_mmm(witchhat_t *, uint64_t *, bool);
+HATRACK_EXTERN witchhat_t     *witchhat_new        (void);
+HATRACK_EXTERN witchhat_t     *witchhat_new_size   (char);
+HATRACK_EXTERN void            witchhat_init       (witchhat_t *);
+HATRACK_EXTERN void            witchhat_init_size  (witchhat_t *, char);
+HATRACK_EXTERN void            witchhat_cleanup    (witchhat_t *);
+HATRACK_EXTERN void            witchhat_delete     (witchhat_t *);
+HATRACK_EXTERN void           *witchhat_get        (witchhat_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *witchhat_put        (witchhat_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *witchhat_replace    (witchhat_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN bool            witchhat_add        (witchhat_t *, hatrack_hash_t, void *);
+HATRACK_EXTERN void           *witchhat_remove     (witchhat_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN uint64_t        witchhat_len        (witchhat_t *);
+HATRACK_EXTERN hatrack_view_t *witchhat_view       (witchhat_t *, uint64_t *, bool);
+HATRACK_EXTERN hatrack_view_t *witchhat_view_no_mmm(witchhat_t *, uint64_t *, bool);

--- a/include/hatrack/witchhat.h
+++ b/include/hatrack/witchhat.h
@@ -42,12 +42,6 @@ typedef struct {
     uint64_t info;
 } witchhat_record_t;
 
-enum64(witchhat_flag_t,
-       WITCHHAT_F_MOVING   = 0x8000000000000000,
-       WITCHHAT_F_MOVED    = 040000000000000000,
-       WITCHHAT_F_INITED   = 0x2000000000000000,
-       WITCHHAT_EPOCH_MASK = 0x1fffffffffffffff);
-
 typedef struct {
     _Atomic hatrack_hash_t    hv;
     _Atomic witchhat_record_t record;
@@ -55,7 +49,6 @@ typedef struct {
 
 typedef struct witchhat_store_st witchhat_store_t;
 
-// clang-format off
 struct witchhat_store_st {
     uint64_t                    last_slot;
     uint64_t                    threshold;
@@ -68,11 +61,10 @@ typedef struct {
     _Atomic(witchhat_store_t *) store_current;
     _Atomic uint64_t            item_count;
     _Atomic uint64_t            help_needed;
-            uint64_t            next_epoch;
-
+    uint64_t                    next_epoch;
 } witchhat_t;
 
-
+// clang-format off
 witchhat_t     *witchhat_new        (void);
 witchhat_t     *witchhat_new_size   (char);
 void            witchhat_init       (witchhat_t *);
@@ -89,26 +81,3 @@ void           *witchhat_remove     (witchhat_t *, hatrack_hash_t, bool *);
 uint64_t        witchhat_len        (witchhat_t *);
 hatrack_view_t *witchhat_view       (witchhat_t *, uint64_t *, bool);
 hatrack_view_t *witchhat_view_no_mmm(witchhat_t *, uint64_t *, bool);
-
-/* These need to be non-static because tophat and hatrack_dict both
- * need them, so that they can call in without a second call to
- * MMM. But, they should be considered "friend" functions, and not
- * part of the public API.
- *
- * Actually, hatrack_dict no longer uses Witchhat, it uses Crown, but
- * I'm going to explicitly leave these here, instead of going back to
- * making them static.
- */
-witchhat_store_t *witchhat_store_new    (uint64_t);
-void             *witchhat_store_get    (witchhat_store_t *, hatrack_hash_t,
-					 bool *);
-void             *witchhat_store_put    (witchhat_store_t *, witchhat_t *,
-					 hatrack_hash_t, void *, bool *,
-					 uint64_t);
-void             *witchhat_store_replace(witchhat_store_t *, witchhat_t *,
-					 hatrack_hash_t, void *, bool *,
-					 uint64_t);
-bool              witchhat_store_add    (witchhat_store_t *, witchhat_t *,
-					 hatrack_hash_t, void *, uint64_t);
-void             *witchhat_store_remove (witchhat_store_t *, witchhat_t *,
-					 hatrack_hash_t, bool *, uint64_t);

--- a/include/hatrack/woolhat.h
+++ b/include/hatrack/woolhat.h
@@ -74,23 +74,21 @@ typedef struct {
 } hatrack_set_view_t;
 
 // clang-format off
-woolhat_t      *woolhat_new             (void);
-woolhat_t      *woolhat_new_size        (char);
-void            woolhat_init            (woolhat_t *);
-void            woolhat_init_size       (woolhat_t *, char);
-void            woolhat_cleanup         (woolhat_t *);
-void            woolhat_delete          (woolhat_t *);
-void            woolhat_set_cleanup_func(woolhat_t *, mmm_cleanup_func, void *);
-void           *woolhat_get             (woolhat_t *, hatrack_hash_t, bool *);
-void           *woolhat_put             (woolhat_t *, hatrack_hash_t, void *,
-					 bool *);
-void           *woolhat_replace         (woolhat_t *, hatrack_hash_t, void *,
-					 bool *);
-bool            woolhat_add             (woolhat_t *, hatrack_hash_t, void *);
-void           *woolhat_remove          (woolhat_t *, hatrack_hash_t, bool *);
-uint64_t        woolhat_len             (woolhat_t *);
+HATRACK_EXTERN woolhat_t      *woolhat_new             (void);
+HATRACK_EXTERN woolhat_t      *woolhat_new_size        (char);
+HATRACK_EXTERN void            woolhat_init            (woolhat_t *);
+HATRACK_EXTERN void            woolhat_init_size       (woolhat_t *, char);
+HATRACK_EXTERN void            woolhat_cleanup         (woolhat_t *);
+HATRACK_EXTERN void            woolhat_delete          (woolhat_t *);
+HATRACK_EXTERN void            woolhat_set_cleanup_func(woolhat_t *, mmm_cleanup_func, void *);
+HATRACK_EXTERN void           *woolhat_get             (woolhat_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *woolhat_put             (woolhat_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *woolhat_replace         (woolhat_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN bool            woolhat_add             (woolhat_t *, hatrack_hash_t, void *);
+HATRACK_EXTERN void           *woolhat_remove          (woolhat_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN uint64_t        woolhat_len             (woolhat_t *);
 
-hatrack_view_t     *woolhat_view        (woolhat_t *, uint64_t *, bool);
-hatrack_set_view_t *woolhat_view_epoch  (woolhat_t *, uint64_t *, uint64_t);
+HATRACK_EXTERN hatrack_view_t     *woolhat_view        (woolhat_t *, uint64_t *, bool);
+HATRACK_EXTERN hatrack_set_view_t *woolhat_view_epoch  (woolhat_t *, uint64_t *, uint64_t);
 
-void hatrack_set_view_delete(hatrack_set_view_t *view, uint64_t num);
+HATRACK_EXTERN void hatrack_set_view_delete(hatrack_set_view_t *view, uint64_t num);

--- a/include/hatrack/woolhat.h
+++ b/include/hatrack/woolhat.h
@@ -25,6 +25,7 @@
 
 #include "base.h"
 #include "hatrack_common.h"
+#include "mmm.h"
 
 typedef struct woolhat_record_st woolhat_record_t;
 

--- a/include/hatrack/woolhat.h
+++ b/include/hatrack/woolhat.h
@@ -24,7 +24,6 @@
 #pragma once
 
 #include "base.h"
-#include "malloc.h"
 #include "hatrack_common.h"
 
 typedef struct woolhat_record_st woolhat_record_t;
@@ -35,17 +34,9 @@ struct woolhat_record_st {
     bool              deleted;
 };
 
-enum {
-    WOOLHAT_F_MOVING      = 0x0000000000000001,
-    WOOLHAT_F_MOVED       = 0x0000000000000002,
-    WOOLHAT_F_DELETE_HELP = 0x0000000000000004
-};
-
-// clang-format off
-
 typedef struct {
-    woolhat_record_t  *head;
-    uint64_t           flags;
+    woolhat_record_t *head;
+    uint64_t          flags;
 } woolhat_state_t;
 
 typedef struct {
@@ -71,7 +62,6 @@ typedef struct woolhat_st {
     void                      *cleanup_aux;
 } woolhat_t;
 
-
 /* This is a special type of view result that includes the hash
  * value, intended for set operations. Currently, it is only in use
  * by woolhat (and by hatrack_set, which is built on woolhat).
@@ -83,12 +73,7 @@ typedef struct {
     int64_t        sort_epoch;
 } hatrack_set_view_t;
 
-static inline void
-hatrack_set_view_delete(hatrack_set_view_t *view, uint64_t num)
-{
-    hatrack_free(view, sizeof(hatrack_set_view_t) * num);
-}
-
+// clang-format off
 woolhat_t      *woolhat_new             (void);
 woolhat_t      *woolhat_new_size        (char);
 void            woolhat_init            (woolhat_t *);
@@ -107,3 +92,5 @@ uint64_t        woolhat_len             (woolhat_t *);
 
 hatrack_view_t     *woolhat_view        (woolhat_t *, uint64_t *, bool);
 hatrack_set_view_t *woolhat_view_epoch  (woolhat_t *, uint64_t *, uint64_t);
+
+void hatrack_set_view_delete(hatrack_set_view_t *view, uint64_t num);

--- a/include/test/testhat.h
+++ b/include/test/testhat.h
@@ -29,6 +29,9 @@
 #ifndef __TESTHAT_H__
 #define __TESTHAT_H__
 
+#include "hatrack/malloc.h"
+#include "hatrack/counters.h"
+
 // Pull in the various implementations.
 #include "hatrack/refhat.h"
 #include "hatrack/duncecap.h"

--- a/src/hatrack/array/arr64.c
+++ b/src/hatrack/array/arr64.c
@@ -34,6 +34,19 @@
 #include "hatrack/mmm.h"
 #include "hatrack/hatrack_common.h"
 
+#define ARR64_MIN_STORE_SZ_LOG 4
+
+enum64(arr64_enum_t,
+       ARR64_USED   = 0x00000000000000001,
+       ARR64_MOVED  = 0x00000000000000002,
+       ARR64_MOVING = 0x00000000000000004);
+
+enum {
+    ARR64_OK,
+    ARR64_OOB,
+    ARR64_UNINITIALIZED
+};
+
 static arr64_store_t *arr64_new_store(uint64_t, uint64_t);
 static void           arr64_migrate(arr64_store_t *, arr64_t *);
 

--- a/src/hatrack/array/arr64.c
+++ b/src/hatrack/array/arr64.c
@@ -29,7 +29,10 @@
  *  Author:         John Viega, john@zork.org
  */
 
-#include "hatrack.h"
+#include "hatrack/arr64.h"
+#include "hatrack/malloc.h"
+#include "hatrack/mmm.h"
+#include "hatrack/hatrack_common.h"
 
 static arr64_store_t *arr64_new_store(uint64_t, uint64_t);
 static void           arr64_migrate(arr64_store_t *, arr64_t *);

--- a/src/hatrack/array/arr64.c
+++ b/src/hatrack/array/arr64.c
@@ -32,6 +32,7 @@
 #include "hatrack/arr64.h"
 #include "hatrack/malloc.h"
 #include "hatrack/mmm.h"
+#include "hatrack/hatomic.h"
 #include "hatrack/hatrack_common.h"
 
 #define ARR64_MIN_STORE_SZ_LOG 4

--- a/src/hatrack/array/flexarray.c
+++ b/src/hatrack/array/flexarray.c
@@ -23,7 +23,10 @@
  *  Author:         John Viega, john@zork.org
  */
 
-#include "hatrack.h"
+#include "hatrack/flexarray.h"
+#include "hatrack/malloc.h"
+#include "hatrack/mmm.h"
+#include "hatrack/hatrack_common.h"
 
 static flex_store_t *flexarray_new_store(uint64_t, uint64_t);
 static void          flexarray_migrate(flex_store_t *, flexarray_t *);

--- a/src/hatrack/array/flexarray.c
+++ b/src/hatrack/array/flexarray.c
@@ -27,6 +27,7 @@
 #include "hatrack/malloc.h"
 #include "hatrack/mmm.h"
 #include "hatrack/hatrack_common.h"
+#include "../hatrack-internal.h"
 
 #define FLEXARRAY_MIN_STORE_SZ_LOG 4
 

--- a/src/hatrack/array/flexarray.c
+++ b/src/hatrack/array/flexarray.c
@@ -28,6 +28,14 @@
 #include "hatrack/mmm.h"
 #include "hatrack/hatrack_common.h"
 
+#define FLEXARRAY_MIN_STORE_SZ_LOG 4
+
+enum64(flex_enum_t,
+       FLEX_ARRAY_SHRINK = 0x8000000000000000,
+       FLEX_ARRAY_MOVING = 0x4000000000000000,
+       FLEX_ARRAY_MOVED  = 0x2000000000000000,
+       FLEX_ARRAY_USED   = 0x1000000000000000);
+
 static flex_store_t *flexarray_new_store(uint64_t, uint64_t);
 static void          flexarray_migrate(flex_store_t *, flexarray_t *);
 

--- a/src/hatrack/array/flexarray.c
+++ b/src/hatrack/array/flexarray.c
@@ -26,6 +26,7 @@
 #include "hatrack/flexarray.h"
 #include "hatrack/malloc.h"
 #include "hatrack/mmm.h"
+#include "hatrack/hatomic.h"
 #include "hatrack/hatrack_common.h"
 #include "../hatrack-internal.h"
 

--- a/src/hatrack/array/vector.c
+++ b/src/hatrack/array/vector.c
@@ -24,7 +24,32 @@
 #include "hatrack/malloc.h"
 #include "hatrack/mmm.h"
 #include "hatrack/hatrack_common.h"
-// #include "hatrack/flexarray.h"
+
+#define VECTOR_MIN_STORE_SZ_LOG 4
+
+enum {
+    VECTOR_POPPED   = 0x8000000000000000,
+    VECTOR_USED     = 0x4000000000000000,
+    VECTOR_MOVING   = 0x2000000000000000,
+    VECTOR_MOVED    = 0x1000000000000000,
+    VECTOR_JOB_MASK = 0x0fffffffffffffff
+};
+
+enum {
+    VECTOR_OK,
+    VECTOR_OOB,
+    VECTOR_UNINITIALIZED
+};
+
+enum {
+    VECTOR_OP_PUSH = 0,
+    VECTOR_OP_POP,
+    VECTOR_OP_PEEK,
+    VECTOR_OP_GROW,
+    VECTOR_OP_SHRINK,
+    VECTOR_OP_SLOW_SET,
+    VECTOR_OP_VIEW
+};
 
 static vector_store_t *vector_new_store(int64_t, int64_t);
 static void            vector_migrate(vector_store_t *, vector_t *);

--- a/src/hatrack/array/vector.c
+++ b/src/hatrack/array/vector.c
@@ -23,6 +23,7 @@
 #include "hatrack/debug.h"
 #include "hatrack/malloc.h"
 #include "hatrack/mmm.h"
+#include "hatrack/hatomic.h"
 #include "hatrack/hatrack_common.h"
 
 #define VECTOR_MIN_STORE_SZ_LOG 4

--- a/src/hatrack/array/vector.c
+++ b/src/hatrack/array/vector.c
@@ -19,7 +19,12 @@
  *  Author:         John Viega, john@zork.org
  */
 
-#include "hatrack.h"
+#include "hatrack/vector.h"
+#include "hatrack/debug.h"
+#include "hatrack/malloc.h"
+#include "hatrack/mmm.h"
+#include "hatrack/hatrack_common.h"
+// #include "hatrack/flexarray.h"
 
 static vector_store_t *vector_new_store(int64_t, int64_t);
 static void            vector_migrate(vector_store_t *, vector_t *);
@@ -376,7 +381,7 @@ vector_view(vector_t *self)
     if (self->ret_callback) {
         for (i = 0; i < si.array_size; i++) {
             item = atomic_load(&store->cells[i]);
-            if (item.state & FLEX_ARRAY_USED) {
+            if (item.state & VECTOR_USED) {
                 (*self->ret_callback)(item.item);
             }
         }

--- a/src/hatrack/hash/ballcap.c
+++ b/src/hatrack/hash/ballcap.c
@@ -47,6 +47,8 @@
  */
 
 #include "hatrack/ballcap.h"
+#include "hatrack/malloc.h"
+#include "hatrack/hatomic.h"
 #include "../hatrack-internal.h"
 
 #include <stdlib.h>

--- a/src/hatrack/hash/ballcap.c
+++ b/src/hatrack/hash/ballcap.c
@@ -46,7 +46,9 @@
  *  Author:         John Viega, john@zork.org
  */
 
-#include "hatrack.h"
+#include "hatrack/ballcap.h"
+
+#include <stdlib.h>
 
 // clang-format off
 

--- a/src/hatrack/hash/ballcap.c
+++ b/src/hatrack/hash/ballcap.c
@@ -47,6 +47,7 @@
  */
 
 #include "hatrack/ballcap.h"
+#include "../hatrack-internal.h"
 
 #include <stdlib.h>
 

--- a/src/hatrack/hash/crown-internal.h
+++ b/src/hatrack/hash/crown-internal.h
@@ -1,0 +1,43 @@
+#include "hatrack/crown.h"
+
+#ifdef HATRACK_32_BIT_HOP_TABLE
+
+#define CROWN_HOME_BIT 0x80000000
+
+typedef uint32_t hop_t;
+
+#define CLZ(n) __builtin_clzl(n)
+
+#else
+
+#define CROWN_HOME_BIT 0x8000000000000000
+
+typedef uint64_t hop_t;
+
+#define CLZ(n) __builtin_clzll(n)
+
+#endif
+
+enum64(crown_flag_t,
+       CROWN_F_MOVING   = 0x8000000000000000,
+       CROWN_F_MOVED    = 0x4000000000000000,
+       CROWN_F_INITED   = 0x2000000000000000,
+       CROWN_EPOCH_MASK = 0x1fffffffffffffff);
+
+/* These need to be non-static because tophat and hatrack_dict both
+ * need them, so that they can call in without a second call to
+ * MMM. But, they should be considered "friend" functions, and not
+ * part of the public API.
+ */
+
+// clang-format off
+crown_store_t    *crown_store_new    (uint64_t);
+void             *crown_store_get    (crown_store_t *, hatrack_hash_t, bool *);
+void             *crown_store_put    (crown_store_t *, crown_t *,
+				      hatrack_hash_t, void *, bool *, uint64_t);
+void             *crown_store_replace(crown_store_t *, crown_t *,
+				      hatrack_hash_t, void *, bool *, uint64_t);
+bool              crown_store_add    (crown_store_t *, crown_t *,
+				      hatrack_hash_t, void *, uint64_t);
+void             *crown_store_remove (crown_store_t *, crown_t *,
+				      hatrack_hash_t, bool *, uint64_t);

--- a/src/hatrack/hash/crown.c
+++ b/src/hatrack/hash/crown.c
@@ -161,6 +161,8 @@
  */
 
 #include "crown-internal.h"
+#include "hatrack/malloc.h"
+#include "hatrack/hatomic.h"
 #include "../hatrack-internal.h"
 
 #include <stdlib.h>

--- a/src/hatrack/hash/crown.c
+++ b/src/hatrack/hash/crown.c
@@ -160,7 +160,7 @@
  *
  */
 
-#include "hatrack/crown.h"
+#include "crown-internal.h"
 
 #include <stdlib.h>
 

--- a/src/hatrack/hash/crown.c
+++ b/src/hatrack/hash/crown.c
@@ -161,6 +161,7 @@
  */
 
 #include "crown-internal.h"
+#include "../hatrack-internal.h"
 
 #include <stdlib.h>
 

--- a/src/hatrack/hash/crown.c
+++ b/src/hatrack/hash/crown.c
@@ -160,8 +160,9 @@
  *
  */
 
-#define HATRACK_INTERNAL_API
-#include "hatrack.h"
+#include "hatrack/crown.h"
+
+#include <stdlib.h>
 
 // clang-format off
 

--- a/src/hatrack/hash/dict.c
+++ b/src/hatrack/hash/dict.c
@@ -22,6 +22,7 @@
 #include "hatrack/dict.h"
 #include "hatrack/hash.h"
 #include "crown-internal.h"
+#include "../hatrack-internal.h"
 
 // clang-format off
 static hatrack_hash_t hatrack_dict_get_hash_value(hatrack_dict_t *, void *);

--- a/src/hatrack/hash/dict.c
+++ b/src/hatrack/hash/dict.c
@@ -19,8 +19,8 @@
  *  Author:         John Viega, john@zork.org
  */
 
-#define HATRACK_INTERNAL_API
-#include "hatrack.h"
+#include "hatrack/dict.h"
+#include "hatrack/hash.h"
 
 // clang-format off
 static hatrack_hash_t hatrack_dict_get_hash_value(hatrack_dict_t *, void *);

--- a/src/hatrack/hash/dict.c
+++ b/src/hatrack/hash/dict.c
@@ -21,6 +21,7 @@
 
 #include "hatrack/dict.h"
 #include "hatrack/hash.h"
+#include "hatrack/hatomic.h"
 #include "crown-internal.h"
 #include "../hatrack-internal.h"
 

--- a/src/hatrack/hash/dict.c
+++ b/src/hatrack/hash/dict.c
@@ -21,6 +21,7 @@
 
 #include "hatrack/dict.h"
 #include "hatrack/hash.h"
+#include "crown-internal.h"
 
 // clang-format off
 static hatrack_hash_t hatrack_dict_get_hash_value(hatrack_dict_t *, void *);

--- a/src/hatrack/hash/duncecap.c
+++ b/src/hatrack/hash/duncecap.c
@@ -30,6 +30,7 @@
  */
 
 #include "hatrack/duncecap.h"
+#include "../hatrack-internal.h"
 
 #include <stdlib.h>
 

--- a/src/hatrack/hash/duncecap.c
+++ b/src/hatrack/hash/duncecap.c
@@ -51,6 +51,27 @@ static void             *duncecap_store_remove (duncecap_store_t *,
 static void             duncecap_migrate       (duncecap_t *);
 // clang-format on
 
+duncecap_store_t *
+duncecap_reader_enter(duncecap_t *self)
+{
+    duncecap_store_t *ret;
+
+    pthread_mutex_lock(&self->mutex);
+    ret = self->store_current;
+    atomic_fetch_add(&ret->readers, 1);
+    pthread_mutex_unlock(&self->mutex);
+
+    return ret;
+}
+
+void
+duncecap_reader_exit(duncecap_store_t *store)
+{
+    atomic_fetch_sub(&store->readers, 1);
+
+    return;
+}
+
 /* These macros clean up duncecap_view() to make it more readable.  With
  * duncecap, we allow compile-time configuration to determine whether
  * views are consistent or not (this is set in stone for all our other

--- a/src/hatrack/hash/duncecap.c
+++ b/src/hatrack/hash/duncecap.c
@@ -30,6 +30,8 @@
  */
 
 #include "hatrack/duncecap.h"
+#include "hatrack/malloc.h"
+#include "hatrack/hatomic.h"
 #include "../hatrack-internal.h"
 
 #include <stdlib.h>

--- a/src/hatrack/hash/duncecap.c
+++ b/src/hatrack/hash/duncecap.c
@@ -29,7 +29,9 @@
  *
  */
 
-#include "hatrack.h"
+#include "hatrack/duncecap.h"
+
+#include <stdlib.h>
 
 // clang-format off
 static duncecap_store_t *duncecap_store_new    (uint64_t);

--- a/src/hatrack/hash/hihat-a.c
+++ b/src/hatrack/hash/hihat-a.c
@@ -37,6 +37,7 @@
  */
 
 #include "hihat-internal.h"
+#include "../hatrack-internal.h"
 
 #include <stdlib.h>
 

--- a/src/hatrack/hash/hihat-a.c
+++ b/src/hatrack/hash/hihat-a.c
@@ -36,7 +36,9 @@
  *
  */
 
-#include "hatrack.h"
+#include "hatrack/hihat.h"
+
+#include <stdlib.h>
 
 // clang-format off
 static hihat_store_t *hihat_a_store_new    (uint64_t);

--- a/src/hatrack/hash/hihat-a.c
+++ b/src/hatrack/hash/hihat-a.c
@@ -37,6 +37,8 @@
  */
 
 #include "hihat-internal.h"
+#include "hatrack/malloc.h"
+#include "hatrack/hatomic.h"
 #include "../hatrack-internal.h"
 
 #include <stdlib.h>

--- a/src/hatrack/hash/hihat-a.c
+++ b/src/hatrack/hash/hihat-a.c
@@ -36,7 +36,7 @@
  *
  */
 
-#include "hatrack/hihat.h"
+#include "hihat-internal.h"
 
 #include <stdlib.h>
 

--- a/src/hatrack/hash/hihat-internal.h
+++ b/src/hatrack/hash/hihat-internal.h
@@ -1,0 +1,9 @@
+#include "hatrack/hihat.h"
+
+// The aforementioned flags, along with a bitmask that allows us to
+// extract the epoch in the info field, ignoring any migration flags.
+enum64(hihat_flag_t,
+       HIHAT_F_MOVING   = 0x8000000000000000,
+       HIHAT_F_MOVED    = 0x4000000000000000,
+       HIHAT_F_INITED   = 0x2000000000000000,
+       HIHAT_EPOCH_MASK = 0x1fffffffffffffff);

--- a/src/hatrack/hash/hihat.c
+++ b/src/hatrack/hash/hihat.c
@@ -25,6 +25,8 @@
  */
 
 #include "hihat-internal.h"
+#include "hatrack/malloc.h"
+#include "hatrack/hatomic.h"
 #include "../hatrack-internal.h"
 
 #include <stdlib.h>

--- a/src/hatrack/hash/hihat.c
+++ b/src/hatrack/hash/hihat.c
@@ -24,7 +24,9 @@
  *
  */
 
-#include "hatrack.h"
+#include "hatrack/hihat.h"
+
+#include <stdlib.h>
 
 // clang-format off
 static hihat_store_t *hihat_store_new    (uint64_t);

--- a/src/hatrack/hash/hihat.c
+++ b/src/hatrack/hash/hihat.c
@@ -25,6 +25,7 @@
  */
 
 #include "hihat-internal.h"
+#include "../hatrack-internal.h"
 
 #include <stdlib.h>
 

--- a/src/hatrack/hash/hihat.c
+++ b/src/hatrack/hash/hihat.c
@@ -24,7 +24,7 @@
  *
  */
 
-#include "hatrack/hihat.h"
+#include "hihat-internal.h"
 
 #include <stdlib.h>
 

--- a/src/hatrack/hash/lohat-a.c
+++ b/src/hatrack/hash/lohat-a.c
@@ -24,7 +24,9 @@
  *
  */
 
-#include "hatrack.h"
+#include "hatrack/lohat-a.h"
+
+#include <stdlib.h>
 
 #ifdef SANE_FETCH_ADD_PTR_SEMANTICS
 #define fa_ptr_incr(t) (1)

--- a/src/hatrack/hash/lohat-a.c
+++ b/src/hatrack/hash/lohat-a.c
@@ -25,6 +25,7 @@
  */
 
 #include "hatrack/lohat-a.h"
+#include "../hatrack-internal.h"
 
 #include <stdlib.h>
 

--- a/src/hatrack/hash/lohat-a.c
+++ b/src/hatrack/hash/lohat-a.c
@@ -25,6 +25,8 @@
  */
 
 #include "hatrack/lohat-a.h"
+#include "hatrack/malloc.h"
+#include "hatrack/hatomic.h"
 #include "../hatrack-internal.h"
 
 #include <stdlib.h>

--- a/src/hatrack/hash/lohat.c
+++ b/src/hatrack/hash/lohat.c
@@ -26,6 +26,7 @@
  */
 
 #include "hatrack/lohat.h"
+#include "../hatrack-internal.h"
 
 #include <stdlib.h>
 

--- a/src/hatrack/hash/lohat.c
+++ b/src/hatrack/hash/lohat.c
@@ -25,8 +25,9 @@
  *
  */
 
-#include "hatrack.h"
-#include <stdint.h>
+#include "hatrack/lohat.h"
+
+#include <stdlib.h>
 
 // clang-format off
 

--- a/src/hatrack/hash/lohat.c
+++ b/src/hatrack/hash/lohat.c
@@ -26,6 +26,8 @@
  */
 
 #include "hatrack/lohat.h"
+#include "hatrack/malloc.h"
+#include "hatrack/hatomic.h"
 #include "../hatrack-internal.h"
 
 #include <stdlib.h>

--- a/src/hatrack/hash/newshat.c
+++ b/src/hatrack/hash/newshat.c
@@ -25,6 +25,7 @@
  */
 
 #include "hatrack/newshat.h"
+#include "../hatrack-internal.h"
 
 #include <stdlib.h>
 

--- a/src/hatrack/hash/newshat.c
+++ b/src/hatrack/hash/newshat.c
@@ -25,6 +25,8 @@
  */
 
 #include "hatrack/newshat.h"
+#include "hatrack/malloc.h"
+#include "hatrack/hatomic.h"
 #include "../hatrack-internal.h"
 
 #include <stdlib.h>

--- a/src/hatrack/hash/newshat.c
+++ b/src/hatrack/hash/newshat.c
@@ -24,7 +24,9 @@
  *
  */
 
-#include "hatrack.h"
+#include "hatrack/newshat.h"
+
+#include <stdlib.h>
 
 // clang-format off
 

--- a/src/hatrack/hash/oldhat.c
+++ b/src/hatrack/hash/oldhat.c
@@ -65,6 +65,8 @@
  */
 
 #include "hatrack/oldhat.h"
+#include "hatrack/malloc.h"
+#include "hatrack/hatomic.h"
 #include "../hatrack-internal.h"
 
 #include <stdlib.h>

--- a/src/hatrack/hash/oldhat.c
+++ b/src/hatrack/hash/oldhat.c
@@ -65,6 +65,7 @@
  */
 
 #include "hatrack/oldhat.h"
+#include "../hatrack-internal.h"
 
 #include <stdlib.h>
 

--- a/src/hatrack/hash/oldhat.c
+++ b/src/hatrack/hash/oldhat.c
@@ -64,7 +64,9 @@
  *  Author:         John Viega, john@zork.org
  */
 
-#include "hatrack.h"
+#include "hatrack/oldhat.h"
+
+#include <stdlib.h>
 
 // clang-format off
 static oldhat_store_t  *oldhat_store_new    (uint64_t);

--- a/src/hatrack/hash/refhat.c
+++ b/src/hatrack/hash/refhat.c
@@ -20,7 +20,9 @@
  *
  */
 
-#include "hatrack.h"
+#include "hatrack/refhat.h"
+
+#include <stdlib.h>
 
 static void refhat_migrate(refhat_t *);
 

--- a/src/hatrack/hash/refhat.c
+++ b/src/hatrack/hash/refhat.c
@@ -21,6 +21,8 @@
  */
 
 #include "hatrack/refhat.h"
+#include "hatrack/malloc.h"
+#include "hatrack/hatomic.h"
 #include "../hatrack-internal.h"
 
 #include <stdlib.h>

--- a/src/hatrack/hash/refhat.c
+++ b/src/hatrack/hash/refhat.c
@@ -21,6 +21,7 @@
  */
 
 #include "hatrack/refhat.h"
+#include "../hatrack-internal.h"
 
 #include <stdlib.h>
 

--- a/src/hatrack/hash/set.c
+++ b/src/hatrack/hash/set.c
@@ -21,6 +21,7 @@
 
 #include "hatrack/set.h"
 #include "hatrack/hash.h"
+#include "hatrack/hatomic.h"
 #include "../hatrack-internal.h"
 
 #include <stdlib.h>

--- a/src/hatrack/hash/set.c
+++ b/src/hatrack/hash/set.c
@@ -21,6 +21,7 @@
 
 #include "hatrack/set.h"
 #include "hatrack/hash.h"
+#include "../hatrack-internal.h"
 
 #include <stdlib.h>
 

--- a/src/hatrack/hash/set.c
+++ b/src/hatrack/hash/set.c
@@ -19,7 +19,10 @@
  *  Author:         John Viega, john@zork.org
  */
 
-#include "hatrack.h"
+#include "hatrack/set.h"
+#include "hatrack/hash.h"
+
+#include <stdlib.h>
 
 static hatrack_hash_t hatrack_set_get_hash_value(hatrack_set_t *, void *);
 static void           hatrack_set_record_eject(woolhat_record_t *, hatrack_set_t *);

--- a/src/hatrack/hash/swimcap.c
+++ b/src/hatrack/hash/swimcap.c
@@ -34,6 +34,7 @@
  */
 
 #include "hatrack/swimcap.h"
+#include "../hatrack-internal.h"
 
 #include <stdlib.h>
 

--- a/src/hatrack/hash/swimcap.c
+++ b/src/hatrack/hash/swimcap.c
@@ -34,6 +34,8 @@
  */
 
 #include "hatrack/swimcap.h"
+#include "hatrack/malloc.h"
+#include "hatrack/hatomic.h"
 #include "../hatrack-internal.h"
 
 #include <stdlib.h>

--- a/src/hatrack/hash/swimcap.c
+++ b/src/hatrack/hash/swimcap.c
@@ -33,7 +33,9 @@
  *
  */
 
-#include "hatrack.h"
+#include "hatrack/swimcap.h"
+
+#include <stdlib.h>
 
 // clang-format off
 static swimcap_store_t *swimcap_store_new    (uint64_t);

--- a/src/hatrack/hash/tiara.c
+++ b/src/hatrack/hash/tiara.c
@@ -37,6 +37,7 @@
  */
 
 #include "hatrack/tiara.h"
+#include "../hatrack-internal.h"
 
 #include <stdlib.h>
 

--- a/src/hatrack/hash/tiara.c
+++ b/src/hatrack/hash/tiara.c
@@ -36,7 +36,9 @@
  *
  */
 
-#include "hatrack.h"
+#include "hatrack/tiara.h"
+
+#include <stdlib.h>
 
 // clang-format off
 static tiara_store_t *tiara_store_new    (uint64_t);

--- a/src/hatrack/hash/tiara.c
+++ b/src/hatrack/hash/tiara.c
@@ -52,6 +52,12 @@ static bool           tiara_store_add    (tiara_store_t *, tiara_t *, uint64_t,
 static void          *tiara_store_remove (tiara_store_t *, tiara_t *, uint64_t);
 static tiara_store_t *tiara_store_migrate(tiara_store_t *, tiara_t *);
 
+enum64(tiara_flag_t,
+       TIARA_F_MOVING = 0x0000000000000001,
+       TIARA_F_MOVED  = 0x0000000000000002,
+       TIARA_F_USED   = 0x0000000000000004,
+       TIARA_F_ALL    = TIARA_F_MOVING | TIARA_F_MOVED | TIARA_F_USED);
+
 tiara_t *
 tiara_new(void)
 {

--- a/src/hatrack/hash/tiara.c
+++ b/src/hatrack/hash/tiara.c
@@ -37,6 +37,8 @@
  */
 
 #include "hatrack/tiara.h"
+#include "hatrack/malloc.h"
+#include "hatrack/hatomic.h"
 #include "../hatrack-internal.h"
 
 #include <stdlib.h>

--- a/src/hatrack/hash/tophat.c
+++ b/src/hatrack/hash/tophat.c
@@ -26,7 +26,13 @@
  *
  */
 
-#include "hatrack.h"
+#include "hatrack/tophat.h"
+#include "hatrack/ballcap.h"
+#include "hatrack/newshat.h"
+#include "hatrack/witchhat.h"
+#include "hatrack/woolhat.h"
+
+#include <stdlib.h>
 
 // clang-format off
 static void             tophat_init_base     (tophat_t *, char);

--- a/src/hatrack/hash/tophat.c
+++ b/src/hatrack/hash/tophat.c
@@ -32,6 +32,7 @@
 #include "hatrack/woolhat.h"
 
 #include "witchhat-internal.h"
+#include "../hatrack-internal.h"
 
 #include <stdlib.h>
 

--- a/src/hatrack/hash/tophat.c
+++ b/src/hatrack/hash/tophat.c
@@ -29,8 +29,9 @@
 #include "hatrack/tophat.h"
 #include "hatrack/ballcap.h"
 #include "hatrack/newshat.h"
-#include "hatrack/witchhat.h"
 #include "hatrack/woolhat.h"
+
+#include "witchhat-internal.h"
 
 #include <stdlib.h>
 

--- a/src/hatrack/hash/tophat.c
+++ b/src/hatrack/hash/tophat.c
@@ -30,6 +30,8 @@
 #include "hatrack/ballcap.h"
 #include "hatrack/newshat.h"
 #include "hatrack/woolhat.h"
+#include "hatrack/malloc.h"
+#include "hatrack/hatomic.h"
 
 #include "witchhat-internal.h"
 #include "../hatrack-internal.h"

--- a/src/hatrack/hash/witchhat-internal.h
+++ b/src/hatrack/hash/witchhat-internal.h
@@ -1,0 +1,23 @@
+#include "hatrack/witchhat.h"
+
+enum64(witchhat_flag_t,
+       WITCHHAT_F_MOVING   = 0x8000000000000000,
+       WITCHHAT_F_MOVED    = 040000000000000000,
+       WITCHHAT_F_INITED   = 0x2000000000000000,
+       WITCHHAT_EPOCH_MASK = 0x1fffffffffffffff);
+
+/* These need to be non-static because tophat and hatrack_dict both
+ * need them, so that they can call in without a second call to
+ * MMM. But, they should be considered "friend" functions, and not
+ * part of the public API.
+ *
+ * Actually, hatrack_dict no longer uses Witchhat, it uses Crown, but
+ * I'm going to explicitly leave these here, instead of going back to
+ * making them static.
+ */
+witchhat_store_t *witchhat_store_new(uint64_t);
+void             *witchhat_store_get(witchhat_store_t *, hatrack_hash_t, bool *);
+void             *witchhat_store_put(witchhat_store_t *, witchhat_t *, hatrack_hash_t, void *, bool *, uint64_t);
+void             *witchhat_store_replace(witchhat_store_t *, witchhat_t *, hatrack_hash_t, void *, bool *, uint64_t);
+bool              witchhat_store_add(witchhat_store_t *, witchhat_t *, hatrack_hash_t, void *, uint64_t);
+void             *witchhat_store_remove(witchhat_store_t *, witchhat_t *, hatrack_hash_t, bool *, uint64_t);

--- a/src/hatrack/hash/witchhat.c
+++ b/src/hatrack/hash/witchhat.c
@@ -32,7 +32,9 @@
  *  Author:         John Viega, john@zork.org
  */
 
-#include "hatrack.h"
+#include "hatrack/witchhat.h"
+
+#include <stdlib.h>
 
 // clang-format off
 // Most of the store functions are needed by other modules, for better

--- a/src/hatrack/hash/witchhat.c
+++ b/src/hatrack/hash/witchhat.c
@@ -32,7 +32,7 @@
  *  Author:         John Viega, john@zork.org
  */
 
-#include "hatrack/witchhat.h"
+#include "witchhat-internal.h"
 
 #include <stdlib.h>
 

--- a/src/hatrack/hash/witchhat.c
+++ b/src/hatrack/hash/witchhat.c
@@ -33,6 +33,7 @@
  */
 
 #include "witchhat-internal.h"
+#include "../hatrack-internal.h"
 
 #include <stdlib.h>
 

--- a/src/hatrack/hash/witchhat.c
+++ b/src/hatrack/hash/witchhat.c
@@ -33,6 +33,8 @@
  */
 
 #include "witchhat-internal.h"
+#include "hatrack/malloc.h"
+#include "hatrack/hatomic.h"
 #include "../hatrack-internal.h"
 
 #include <stdlib.h>

--- a/src/hatrack/hash/woolhat.c
+++ b/src/hatrack/hash/woolhat.c
@@ -26,7 +26,9 @@
  *  Author:         John Viega, john@zork.org
  */
 
-#include "hatrack.h"
+#include "hatrack/woolhat.h"
+
+#include <stdlib.h>
 
 // clang-format off
 

--- a/src/hatrack/hash/woolhat.c
+++ b/src/hatrack/hash/woolhat.c
@@ -27,6 +27,7 @@
  */
 
 #include "hatrack/woolhat.h"
+#include "../hatrack-internal.h"
 
 #include <stdlib.h>
 

--- a/src/hatrack/hash/woolhat.c
+++ b/src/hatrack/hash/woolhat.c
@@ -30,6 +30,12 @@
 
 #include <stdlib.h>
 
+enum {
+    WOOLHAT_F_MOVING      = 0x0000000000000001,
+    WOOLHAT_F_MOVED       = 0x0000000000000002,
+    WOOLHAT_F_DELETE_HELP = 0x0000000000000004
+};
+
 // clang-format off
 
 // Needs to be non-static because tophat needs it; nonetheless, do not
@@ -54,6 +60,14 @@ static inline bool      woolhat_help_required(uint64_t);
 static inline bool      woolhat_need_to_help (woolhat_t *);
 static uint64_t         woolhat_set_ordering (woolhat_record_t *, bool);
 static inline void      woolhat_new_insertion(woolhat_record_t *);
+
+
+void
+hatrack_set_view_delete(hatrack_set_view_t *view, uint64_t num)
+{
+    hatrack_free(view, sizeof(hatrack_set_view_t) * num);
+}
+
 
 static uint64_t
 woolhat_set_ordering(woolhat_record_t *record, bool deleted_below)

--- a/src/hatrack/hash/woolhat.c
+++ b/src/hatrack/hash/woolhat.c
@@ -27,6 +27,8 @@
  */
 
 #include "hatrack/woolhat.h"
+#include "hatrack/malloc.h"
+#include "hatrack/hatomic.h"
 #include "../hatrack-internal.h"
 
 #include <stdlib.h>
@@ -62,13 +64,13 @@ static inline bool      woolhat_need_to_help (woolhat_t *);
 static uint64_t         woolhat_set_ordering (woolhat_record_t *, bool);
 static inline void      woolhat_new_insertion(woolhat_record_t *);
 
+// clang-format on
 
 void
 hatrack_set_view_delete(hatrack_set_view_t *view, uint64_t num)
 {
     hatrack_free(view, sizeof(hatrack_set_view_t) * num);
 }
-
 
 static uint64_t
 woolhat_set_ordering(woolhat_record_t *record, bool deleted_below)
@@ -78,12 +80,12 @@ woolhat_set_ordering(woolhat_record_t *record, bool deleted_below)
     mmm_hdr = mmm_get_header(record);
 
     if (mmm_hdr->create_epoch) {
-	return mmm_hdr->create_epoch;
+        return mmm_hdr->create_epoch;
     }
 
     if ((!record->next) || deleted_below) {
-	mmm_hdr->create_epoch = mmm_hdr->write_epoch;
-	return mmm_hdr->create_epoch;
+        mmm_hdr->create_epoch = mmm_hdr->write_epoch;
+        return mmm_hdr->create_epoch;
     }
 
     mmm_hdr->create_epoch = woolhat_set_ordering(record->next, false);
@@ -102,8 +104,6 @@ woolhat_new_insertion(woolhat_record_t *record)
 
     return;
 }
-
-// clang-format on
 
 woolhat_t *
 woolhat_new(void)

--- a/src/hatrack/hash/xxhash.c
+++ b/src/hatrack/hash/xxhash.c
@@ -39,4 +39,4 @@
 
 #define XXH_STATIC_LINKING_ONLY /* access advanced declarations */
 #define XXH_IMPLEMENTATION      /* access definitions */
-#include "hatrack.h"
+#include "hatrack/xxhash.h"

--- a/src/hatrack/hatrack-internal.h
+++ b/src/hatrack/hatrack-internal.h
@@ -1,0 +1,250 @@
+#include "hatrack/hatrack_common.h"
+#include "hatrack/counters.h"
+#include "hatrack/mmm.h"
+
+/* These inline functions are used across all the hatrack
+ * implementations.
+ */
+
+static inline uint64_t
+hatrack_compute_table_threshold(uint64_t size)
+{
+    /* size - (size >> 2) calculates 75% of size (100% - 25%).
+     *
+     * When code checks to see if the current store has hit its
+     * threshold,, implementations generally are adding to the used
+     * count, and do atomic_fetch_add(), which returns the original
+     * value.
+     *
+     * So, when checking if used_count >= 75%, the -1 gets us to 75%,
+     * otherwise we're resizing at one item more full than 75%.
+     *
+     * That in itself is not a big deal, of course. And if there's
+     * anywhere that we check to resize where we're not also reserving
+     * a bucket, we would resize an item too early, but again, so what
+     * and who cares.
+     *
+     * Frankly, if I didn't want to be able to just say "75%" without
+     * an asterisk, I'd just drop the -1.
+     */
+    return size - (size >> 2) - 1;
+}
+
+/*
+ * We always perform a migration when the number of buckets used is
+ * 75% of the total number of buckets in the current store. But, we
+ * reserve buckets in a store, even if those items are deleted, so the
+ * number of actual items in a table could be small when the store is
+ * getting full (never changing the hash in a store's bucket makes our
+ * lives MUCH easier given parallel work being one in the table).
+ *
+ * This function figures out, when it's time to migrate, what the new
+ * size of the table should be. Our metric here is:
+ *
+ *  1) If the CURRENT table was at least 50% full, we double the new
+ *     table size.
+ *
+ *  2) If the CURRENT table was up to 25% full, we HALF the new table
+ *     size.
+ *
+ *  3) Otherwise, we leave the table size the same.
+ *
+ *  Also, we never let the table shrink TOO far... which we base on
+ *  the preprocessor variable HATRACK_MIN_SIZE.
+ */
+static inline uint64_t
+hatrack_new_size(uint64_t last_bucket, uint64_t size)
+{
+    uint64_t table_size = last_bucket + 1;
+
+    if (size >= table_size >> 1) {
+        return table_size << 1;
+    }
+    // We will never bother to size back down to the smallest few
+    // table sizes.
+    if (size <= (HATRACK_MIN_SIZE << 2)) {
+        HATRACK_CTR(HATRACK_CTR_STORE_SHRINK);
+        return HATRACK_MIN_SIZE << 3;
+    }
+    if (size <= (table_size >> 2)) {
+        HATRACK_CTR(HATRACK_CTR_STORE_SHRINK);
+        return table_size >> 1;
+    }
+
+    return table_size;
+}
+
+/* Since we use 128-bit hash values, we can safely use the null hash
+ * value to mean "unreserved" (and even "empty" in our locking
+ * tables).
+ */
+
+#ifndef NO___INT128_T
+
+static inline bool
+hatrack_bucket_unreserved(hatrack_hash_t hv)
+{
+    return !hv;
+}
+
+#else
+static inline bool
+hatrack_bucket_unreserved(hatrack_hash_t hv)
+{
+    return !hv.w1 && !hv.w2;
+}
+
+#endif
+
+/*
+ * Calculates the starting bucket that a hash value maps to, given the
+ * table size.  This is exactly the hash value modulo the table size.
+ *
+ * Since our table sizes are a power of two, "x % y" gives the same
+ * result as "x & (y-1)", but the later is appreciably faster on most
+ * architectures (probably on all architectures, since the processor
+ * basically gets to skip an expensive division). And it gets run
+ * enough that it could matter a bit.
+ *
+ * Also, since our table sizes will never get to 2^64 (and since we
+ * can use the bitwise AND due to the power of two table size), when
+ * we don't have a native 128-bit type, we only need to look at one of
+ * the two 64-bit chunks in the hash (conceptually the one we look at
+ * we consider the most significant chunk).
+ */
+
+#ifndef NO___INT128_T
+
+static inline uint64_t
+hatrack_bucket_index(hatrack_hash_t hv, uint64_t last_slot)
+{
+    return hv & last_slot;
+}
+
+#else
+
+static inline uint64_t
+hatrack_bucket_index(hatrack_hash_t hv, uint64_t last_slot)
+{
+    return hv.w1 & last_slot;
+}
+
+#endif
+
+#ifndef NO___INT128_T
+
+static inline void
+hatrack_bucket_initialize(hatrack_hash_t *hv)
+{
+    *hv = 0;
+}
+
+#else
+
+static inline void
+hatrack_bucket_initialize(hatrack_hash_t *hv)
+{
+    hv->w1 = 0;
+    hv->w2 = 0;
+}
+#endif
+
+/* These are just basic bitwise operations, but performing them on
+ * pointers requires some messy casting.  These inline functions just
+ * hide the casting for us, improving code readability.
+ */
+static inline int64_t
+hatrack_pflag_test(void *ptr, uint64_t flags)
+{
+    return ((int64_t)ptr) & flags;
+}
+
+static inline void *
+hatrack_pflag_set(void *ptr, uint64_t flags)
+{
+    return (void *)(((uint64_t)ptr) | flags);
+}
+
+static inline void *
+hatrack_pflag_clear(void *ptr, uint64_t flags)
+{
+    return (void *)(((uint64_t)ptr) & ~flags);
+}
+
+static inline void *
+hatrack_found(bool *found, void *ret)
+{
+    if (found) {
+        *found = true;
+    }
+
+    return ret;
+}
+
+static inline void *
+hatrack_not_found(bool *found)
+{
+    if (found) {
+        *found = false;
+    }
+
+    return NULL;
+}
+
+static inline void *
+hatrack_found_w_mmm(bool *found, void *ret)
+{
+    mmm_end_op();
+    return hatrack_found(found, ret);
+}
+
+static inline void *
+hatrack_not_found_w_mmm(bool *found)
+{
+    mmm_end_op();
+    return hatrack_not_found(found);
+}
+
+typedef struct
+{
+    uint64_t h;
+    uint64_t l;
+} generic_2x64_t;
+
+typedef union {
+    generic_2x64_t      st;
+    _Atomic __uint128_t atomic_num;
+    __uint128_t         num;
+} generic_2x64_u;
+
+static inline generic_2x64_u
+hatrack_or2x64(generic_2x64_u *s1, generic_2x64_u s2)
+{
+    return (generic_2x64_u)atomic_fetch_or(&s1->atomic_num, s2.num);
+}
+
+static inline generic_2x64_u
+hatrack_or2x64l(generic_2x64_u *s1, uint64_t l)
+{
+    generic_2x64_u n = {.st = {.h = 0, .l = l}};
+
+    return (generic_2x64_u)atomic_fetch_or(&s1->atomic_num, n.num);
+}
+
+static inline generic_2x64_u
+hatrack_or2x64h(generic_2x64_u *s1, uint64_t h)
+{
+    generic_2x64_u n = {.st = {.h = h, .l = 0}};
+
+    return (generic_2x64_u)atomic_fetch_or(&s1->atomic_num, n.num);
+}
+
+#define OR2X64(s1, s2)  hatrack_or2x64((generic_2x64_u *)(s1), s2)
+#define OR2X64L(s1, s2) hatrack_or2x64l((generic_2x64_u *)(s1), s2)
+#define OR2X64H(s1, s2) hatrack_or2x64h((generic_2x64_u *)(s1), s2)
+#define ORPTR(s1, s2)   atomic_fetch_or((_Atomic uint64_t *)(s1), s2)
+
+#define hatrack_cell_alloc(container_type, cell_type, n) \
+    (container_type *)hatrack_zalloc(sizeof(container_type) + sizeof(cell_type) * n)
+
+int hatrack_quicksort_cmp(const void *, const void *);

--- a/src/hatrack/queue/capq.c
+++ b/src/hatrack/queue/capq.c
@@ -45,7 +45,10 @@
  *  Author:         John Viega, john@zork.org
  */
 
-#include "hatrack.h"
+#include "hatrack/capq.h"
+#include "hatrack/malloc.h"
+#include "hatrack/mmm.h"
+#include "hatrack/hatrack_common.h"
 
 static const capq_item_t empty_cell = {NULL, CAPQ_EMPTY};
 

--- a/src/hatrack/queue/capq.c
+++ b/src/hatrack/queue/capq.c
@@ -48,6 +48,7 @@
 #include "hatrack/capq.h"
 #include "hatrack/malloc.h"
 #include "hatrack/mmm.h"
+#include "hatrack/hatomic.h"
 #include "hatrack/hatrack_common.h"
 #include "../hatrack-internal.h"
 

--- a/src/hatrack/queue/capq.c
+++ b/src/hatrack/queue/capq.c
@@ -49,6 +49,7 @@
 #include "hatrack/malloc.h"
 #include "hatrack/mmm.h"
 #include "hatrack/hatrack_common.h"
+#include "../hatrack-internal.h"
 
 enum {
     CAPQ_EMPTY              = 0x0000000000000000,

--- a/src/hatrack/queue/debug.c
+++ b/src/hatrack/queue/debug.c
@@ -20,11 +20,12 @@
  *  Author:         John Viega, john@zork.org
  */
 
-#include "hatrack.h"
+#include "hatrack/debug.h"
 
 #ifdef HATRACK_DEBUG
 
 #include <stdio.h>
+#include <string.h>
 
 hatrack_debug_record_t __hatrack_debug[HATRACK_DEBUG_RING_SIZE] = {};
 

--- a/src/hatrack/queue/hatring-internal.h
+++ b/src/hatrack/queue/hatring-internal.h
@@ -1,0 +1,53 @@
+#include "hatrack/hatring.h"
+
+enum {
+    HATRING_ENQUEUED = 0x8000000000000000,
+    HATRING_DEQUEUED = 0x4000000000000000,
+    HATRING_MASK     = 0xcfffffffffffffff
+};
+
+static inline bool
+hatring_is_lagging(uint32_t read_epoch, uint32_t write_epoch, uint64_t size)
+{
+    if (read_epoch + size < write_epoch) {
+        return true;
+    }
+
+    return false;
+}
+
+static inline uint32_t
+hatring_enqueue_epoch(uint64_t ptrs)
+{
+    return (uint32_t)(ptrs >> 32);
+}
+
+static inline uint32_t
+hatring_dequeue_epoch(uint64_t ptrs)
+{
+    return (uint32_t)(ptrs & 0x00000000ffffffff);
+}
+
+static inline uint32_t
+hatring_dequeue_ix(uint64_t epochs, uint32_t last_slot)
+{
+    return (uint32_t)(epochs & last_slot);
+}
+
+static inline uint32_t
+hatring_cell_epoch(uint64_t state)
+{
+    return (uint32_t)(state & 0x00000000ffffffff);
+}
+
+static inline bool
+hatring_is_enqueued(uint64_t state)
+{
+    return state & HATRING_ENQUEUED;
+}
+
+static inline uint64_t
+hatring_fixed_epoch(uint32_t write_epoch, uint64_t store_size)
+{
+    return (((uint64_t)write_epoch) << 32) | (write_epoch - store_size);
+}

--- a/src/hatrack/queue/hatring.c
+++ b/src/hatrack/queue/hatring.c
@@ -23,6 +23,7 @@
 #include "hatrack/hatring.h"
 #include "hatrack/malloc.h"
 #include "hatrack/mmm.h"
+#include "hatrack/hatomic.h"
 #include "hatrack/hatrack_common.h"
 
 #include <string.h>

--- a/src/hatrack/queue/hatring.c
+++ b/src/hatrack/queue/hatring.c
@@ -27,6 +27,8 @@
 
 #include <string.h>
 
+#include "hatring-internal.h"
+
 #define HATRING_MINIMUM_SIZE 16
 
 /* The overhead for a call to nanosleep should be probably a couple

--- a/src/hatrack/queue/hatring.c
+++ b/src/hatrack/queue/hatring.c
@@ -28,6 +28,7 @@
 #include <string.h>
 
 #include "hatring-internal.h"
+#include "../hatrack-internal.h"
 
 #define HATRING_MINIMUM_SIZE 16
 

--- a/src/hatrack/queue/hatring.c
+++ b/src/hatrack/queue/hatring.c
@@ -20,7 +20,12 @@
  *  Author:         John Viega, john@zork.org
  */
 
-#include "hatrack.h"
+#include "hatrack/hatring.h"
+#include "hatrack/malloc.h"
+#include "hatrack/mmm.h"
+#include "hatrack/hatrack_common.h"
+
+#include <string.h>
 
 #define HATRING_MINIMUM_SIZE 16
 
@@ -71,7 +76,7 @@ hatring_init(hatring_t *self, uint64_t num_buckets)
         num_buckets = HATRING_MINIMUM_SIZE;
     }
 
-    bzero(self, sizeof(hatring_t) + sizeof(hatring_cell_t) * num_buckets);
+    memset(self, 0, sizeof(hatring_t) + sizeof(hatring_cell_t) * num_buckets);
 
     self->last_slot = num_buckets - 1;
 

--- a/src/hatrack/queue/hq.c
+++ b/src/hatrack/queue/hq.c
@@ -116,6 +116,7 @@
 #include "hatrack/hq.h"
 #include "hatrack/malloc.h"
 #include "hatrack/mmm.h"
+#include "hatrack/hatomic.h"
 #include "hatrack/hatrack_common.h"
 #include "../hatrack-internal.h"
 

--- a/src/hatrack/queue/hq.c
+++ b/src/hatrack/queue/hq.c
@@ -118,6 +118,78 @@
 #include "hatrack/mmm.h"
 #include "hatrack/hatrack_common.h"
 
+enum {
+    HQ_EMPTY              = 0x0000000000000000,
+    HQ_TOOSLOW            = 0x1000000000000000,
+    HQ_USED               = 0x2000000000000000,
+    HQ_MOVED              = 0x4000000000000000,
+    HQ_MOVING             = 0x8000000000000000,
+    HQ_FLAG_MASK          = 0xf000000000000000,
+    HQ_STORE_INITIALIZING = 0xffffffffffffffff
+};
+
+static inline bool
+hq_cell_too_slow(hq_item_t item)
+{
+    return (bool)(item.state & HQ_TOOSLOW);
+}
+
+static inline uint64_t
+hq_set_used(uint64_t ix)
+{
+    return HQ_USED | ix;
+}
+
+static inline bool
+hq_is_moving(uint64_t state)
+{
+    return state & HQ_MOVING;
+}
+
+static inline bool
+hq_is_moved(uint64_t state)
+{
+    return state & HQ_MOVED;
+}
+
+static inline bool
+hq_is_queued(uint64_t state)
+{
+    return state & HQ_USED;
+}
+
+#if 0 // UNUSED
+static inline uint64_t
+hq_add_moving(uint64_t state)
+{
+    return state | HQ_MOVING;
+}
+
+static inline uint64_t
+hq_add_moved(uint64_t state)
+{
+    return state | HQ_MOVED | HQ_MOVING;
+}
+
+static inline bool
+hq_can_enqueue(uint64_t state)
+{
+    return !(state & HQ_FLAG_MASK);
+}
+#endif
+
+static inline uint64_t
+hq_extract_epoch(uint64_t state)
+{
+    return state & ~(HQ_FLAG_MASK);
+}
+
+static inline uint64_t
+hq_ix(uint64_t seq, uint64_t sz)
+{
+    return seq & (sz - 1);
+}
+
 static const hq_item_t empty_cell = {NULL, HQ_EMPTY};
 
 static const union {
@@ -193,6 +265,12 @@ hq_delete(hq_t *self)
     hatrack_free(self, sizeof(hq_t));
 
     return;
+}
+
+int64_t
+hq_len(hq_t *self)
+{
+    return atomic_read(&self->len);
 }
 
 /* hq_enqueue is pretty simple in the average case. It only gets

--- a/src/hatrack/queue/hq.c
+++ b/src/hatrack/queue/hq.c
@@ -113,7 +113,10 @@
  *  Author:         John Viega, john@zork.org
  */
 
-#include "hatrack.h"
+#include "hatrack/hq.h"
+#include "hatrack/malloc.h"
+#include "hatrack/mmm.h"
+#include "hatrack/hatrack_common.h"
 
 static const hq_item_t empty_cell = {NULL, HQ_EMPTY};
 
@@ -187,7 +190,7 @@ void
 hq_delete(hq_t *self)
 {
     hq_cleanup(self);
-    hatrack_free(self, sozeof(hq_t));
+    hatrack_free(self, sizeof(hq_t));
 
     return;
 }

--- a/src/hatrack/queue/hq.c
+++ b/src/hatrack/queue/hq.c
@@ -117,6 +117,7 @@
 #include "hatrack/malloc.h"
 #include "hatrack/mmm.h"
 #include "hatrack/hatrack_common.h"
+#include "../hatrack-internal.h"
 
 enum {
     HQ_EMPTY              = 0x0000000000000000,

--- a/src/hatrack/queue/llstack.c
+++ b/src/hatrack/queue/llstack.c
@@ -27,6 +27,7 @@
 #include "hatrack/llstack.h"
 #include "hatrack/malloc.h"
 #include "hatrack/mmm.h"
+#include "hatrack/hatomic.h"
 
 llstack_t *
 llstack_new(void)

--- a/src/hatrack/queue/llstack.c
+++ b/src/hatrack/queue/llstack.c
@@ -24,7 +24,9 @@
  *  Author:         John Viega, john@zork.org
  */
 
-#include "hatrack.h"
+#include "hatrack/llstack.h"
+#include "hatrack/malloc.h"
+#include "hatrack/mmm.h"
 
 llstack_t *
 llstack_new(void)

--- a/src/hatrack/queue/logring.c
+++ b/src/hatrack/queue/logring.c
@@ -21,7 +21,12 @@
  *
  */
 
-#include "hatrack.h"
+#include "hatrack/logring.h"
+#include "hatrack/malloc.h"
+#include "hatrack/mmm.h"
+#include "hatrack/hatrack_common.h"
+
+#include <string.h>
 
 static void logring_view_help_if_needed(logring_t *);
 

--- a/src/hatrack/queue/logring.c
+++ b/src/hatrack/queue/logring.c
@@ -24,6 +24,7 @@
 #include "hatrack/logring.h"
 #include "hatrack/malloc.h"
 #include "hatrack/mmm.h"
+#include "hatrack/hatomic.h"
 #include "hatrack/hatrack_common.h"
 
 #include <string.h>

--- a/src/hatrack/queue/q64.c
+++ b/src/hatrack/queue/q64.c
@@ -23,6 +23,7 @@
 #include "hatrack/q64.h"
 #include "hatrack/malloc.h"
 #include "hatrack/mmm.h"
+#include "hatrack/hatomic.h"
 #include "hatrack/hatrack_common.h"
 #include "../hatrack-internal.h"
 

--- a/src/hatrack/queue/q64.c
+++ b/src/hatrack/queue/q64.c
@@ -20,7 +20,12 @@
  *  Author:         John Viega, john@zork.org
  */
 
-#include "hatrack.h"
+#include "hatrack/q64.h"
+#include "hatrack/malloc.h"
+#include "hatrack/mmm.h"
+#include "hatrack/hatrack_common.h"
+
+#include <stdlib.h>
 
 static const q64_item_t empty_cell      = Q64_EMPTY;
 static const q64_item_t too_slow_marker = Q64_TOOSLOW;
@@ -121,7 +126,7 @@ void
 q64_delete(q64_t *self)
 {
     q64_cleanup(self);
-    hatrack_free(self, siozeof(q64_t));
+    hatrack_free(self, sizeof(q64_t));
 
     return;
 }

--- a/src/hatrack/queue/q64.c
+++ b/src/hatrack/queue/q64.c
@@ -24,6 +24,7 @@
 #include "hatrack/malloc.h"
 #include "hatrack/mmm.h"
 #include "hatrack/hatrack_common.h"
+#include "../hatrack-internal.h"
 
 #include <stdlib.h>
 

--- a/src/hatrack/queue/q64.c
+++ b/src/hatrack/queue/q64.c
@@ -27,6 +27,13 @@
 
 #include <stdlib.h>
 
+#define QUEUE_HELP_VALUE 1 << QUEUE_HELP_STEPS
+
+enum64(q64_cell_state_t,
+       Q64_EMPTY   = 0x00,
+       Q64_TOOSLOW = 0x01,
+       Q64_USED    = 0x02);
+
 static const q64_item_t empty_cell      = Q64_EMPTY;
 static const q64_item_t too_slow_marker = Q64_TOOSLOW;
 static const q64_item_t value_mask      = ~(Q64_TOOSLOW | Q64_USED);
@@ -129,6 +136,12 @@ q64_delete(q64_t *self)
     hatrack_free(self, sizeof(q64_t));
 
     return;
+}
+
+uint64_t
+q64_len(q64_t *self)
+{
+    return atomic_read(&self->len);
 }
 
 /* q64_enqueue is pretty simple in the average case. It only gets

--- a/src/hatrack/queue/queue.c
+++ b/src/hatrack/queue/queue.c
@@ -19,7 +19,12 @@
  *  Author:         John Viega, john@zork.org
  */
 
-#include "hatrack.h"
+#include "hatrack/queue.h"
+#include "hatrack/malloc.h"
+#include "hatrack/mmm.h"
+#include "hatrack/hatrack_common.h"
+
+#include <stdlib.h>
 
 static const queue_item_t empty_cell      = {NULL, QUEUE_EMPTY};
 static const queue_item_t too_slow_marker = {NULL, QUEUE_TOOSLOW};

--- a/src/hatrack/queue/queue.c
+++ b/src/hatrack/queue/queue.c
@@ -22,6 +22,7 @@
 #include "hatrack/queue.h"
 #include "hatrack/malloc.h"
 #include "hatrack/mmm.h"
+#include "hatrack/hatomic.h"
 #include "hatrack/hatrack_common.h"
 #include "../hatrack-internal.h"
 

--- a/src/hatrack/queue/queue.c
+++ b/src/hatrack/queue/queue.c
@@ -23,6 +23,7 @@
 #include "hatrack/malloc.h"
 #include "hatrack/mmm.h"
 #include "hatrack/hatrack_common.h"
+#include "../hatrack-internal.h"
 
 #include <stdlib.h>
 

--- a/src/hatrack/queue/queue.c
+++ b/src/hatrack/queue/queue.c
@@ -26,6 +26,13 @@
 
 #include <stdlib.h>
 
+#define QUEUE_HELP_VALUE 1 << QUEUE_HELP_STEPS
+
+enum64(queue_cell_state_t,
+       QUEUE_EMPTY   = 0x00,
+       QUEUE_TOOSLOW = 0x01,
+       QUEUE_USED    = 0x02);
+
 static const queue_item_t empty_cell      = {NULL, QUEUE_EMPTY};
 static const queue_item_t too_slow_marker = {NULL, QUEUE_TOOSLOW};
 
@@ -127,6 +134,12 @@ queue_delete(queue_t *self)
     hatrack_free(self, sizeof(queue_t));
 
     return;
+}
+
+uint64_t
+queue_len(queue_t *self)
+{
+    return atomic_read(&self->len);
 }
 
 /* queue_enqueue is pretty simple in the average case. It only gets

--- a/src/hatrack/queue/stack.c
+++ b/src/hatrack/queue/stack.c
@@ -89,6 +89,94 @@
 
 #include <stdlib.h>
 
+enum {
+    HATSTACK_HEAD_MOVE_MASK    = 0x80000000ffffffff,
+    HATSTACK_HEAD_EPOCH_BUMP   = 0x0000000100000000,
+    HATSTACK_HEAD_INDEX_MASK   = 0x00000000ffffffff,
+    HATSTACK_HEAD_EPOCH_MASK   = 0x7fffffff00000000,
+    HATSTACK_HEAD_INITIALIZING = 0xffffffffffffffff,
+};
+
+static inline bool
+head_is_moving(uint64_t n, uint64_t store_size)
+{
+    return (n & HATSTACK_HEAD_INDEX_MASK) >= store_size;
+}
+
+static inline uint32_t
+head_get_epoch(uint64_t n)
+{
+    return (n >> 32);
+}
+
+static inline uint32_t
+head_get_index(uint64_t n)
+{
+    return n & HATSTACK_HEAD_INDEX_MASK;
+}
+
+static inline uint64_t
+head_candidate_new_epoch(uint64_t n, uint32_t ix)
+{
+    return ((n & HATSTACK_HEAD_EPOCH_MASK) | ix) + HATSTACK_HEAD_EPOCH_BUMP;
+}
+
+// These flags / constants are used in stack_item_t's state.
+enum {
+    HATSTACK_PUSHED = 0x00000001, // Cell is full.
+    HATSTACK_POPPED = 0x00000002, // Cell was full, is empty.
+    HATSTACK_MOVING = 0x00000004,
+    HATSTACK_MOVED  = 0x00000008
+};
+
+static inline uint32_t
+state_add_moved(uint32_t old)
+{
+    return old | HATSTACK_MOVING | HATSTACK_MOVED;
+}
+
+static inline uint32_t
+state_add_moving(uint32_t old)
+{
+    return old | HATSTACK_MOVING;
+}
+
+static inline bool
+state_is_pushed(uint32_t state)
+{
+    return (bool)(state & HATSTACK_PUSHED);
+}
+
+#if 0 // UNUSED
+static inline bool
+state_is_popped(uint32_t state)
+{
+    return (bool)(state & HATSTACK_POPPED);
+}
+#endif
+
+static inline bool
+state_is_moving(uint32_t state)
+{
+    return (bool)(state & HATSTACK_MOVING);
+}
+
+static inline bool
+state_is_moved(uint32_t state)
+{
+    return (bool)(state & HATSTACK_MOVED);
+}
+
+static inline bool
+cell_can_push(stack_item_t item, uint32_t epoch)
+{
+    if (item.valid_after >= epoch) {
+        return false;
+    }
+
+    return true;
+}
+
 static const stack_item_t proto_item_empty = {
     .item        = NULL,
     .state       = 0,

--- a/src/hatrack/queue/stack.c
+++ b/src/hatrack/queue/stack.c
@@ -85,6 +85,7 @@
 #include "hatrack/stack.h"
 #include "hatrack/malloc.h"
 #include "hatrack/mmm.h"
+#include "hatrack/hatomic.h"
 #include "hatrack/hatrack_common.h"
 #include "../hatrack-internal.h"
 

--- a/src/hatrack/queue/stack.c
+++ b/src/hatrack/queue/stack.c
@@ -86,6 +86,7 @@
 #include "hatrack/malloc.h"
 #include "hatrack/mmm.h"
 #include "hatrack/hatrack_common.h"
+#include "../hatrack-internal.h"
 
 #include <stdlib.h>
 

--- a/src/hatrack/queue/stack.c
+++ b/src/hatrack/queue/stack.c
@@ -82,7 +82,12 @@
  *  Author:         John Viega, john@zork.org
  */
 
-#include "hatrack.h"
+#include "hatrack/stack.h"
+#include "hatrack/malloc.h"
+#include "hatrack/mmm.h"
+#include "hatrack/hatrack_common.h"
+
+#include <stdlib.h>
 
 static const stack_item_t proto_item_empty = {
     .item        = NULL,

--- a/src/hatrack/support/counters.c
+++ b/src/hatrack/support/counters.c
@@ -20,12 +20,11 @@
  *  Author:         John Viega, john@zork.org
  */
 
-#include "hatrack.h"
+#include "hatrack/counters.h"
 
 #ifdef HATRACK_COUNTERS
 
 #include <stdio.h>
-#include <stdbool.h>
 
 // clang-format off
 _Atomic uint64_t hatrack_counters[HATRACK_COUNTERS_NUM]            = {};

--- a/src/hatrack/support/hatrack_common.c
+++ b/src/hatrack/support/hatrack_common.c
@@ -22,6 +22,13 @@
  */
 
 #include "hatrack/hatrack_common.h"
+#include "hatrack/malloc.h"
+
+void
+hatrack_view_delete(hatrack_view_t *view, uint64_t num)
+{
+    hatrack_free(view, sizeof(hatrack_view_t) * num);
+}
 
 /* Used when using quicksort to sort the contents of a hash table
  * 'view' by insertion time (the sort_epoch field).

--- a/src/hatrack/support/hatrack_common.c
+++ b/src/hatrack/support/hatrack_common.c
@@ -21,7 +21,7 @@
  *  Author:         John Viega, john@zork.org
  */
 
-#include "hatrack.h"
+#include "hatrack/hatrack_common.h"
 
 /* Used when using quicksort to sort the contents of a hash table
  * 'view' by insertion time (the sort_epoch field).

--- a/src/hatrack/support/helpmanager.c
+++ b/src/hatrack/support/helpmanager.c
@@ -27,6 +27,8 @@
 
 #include <string.h>
 
+static help_record_t thread_records[HATRACK_THREADS_MAX];
+
 void
 hatrack_help_init(help_manager_t *manager,
                   void           *parent,

--- a/src/hatrack/support/helpmanager.c
+++ b/src/hatrack/support/helpmanager.c
@@ -22,7 +22,10 @@
  *
  */
 
-#include "hatrack.h"
+#include "hatrack/helpmanager.h"
+#include "hatrack/mmm.h"
+
+#include <string.h>
 
 void
 hatrack_help_init(help_manager_t *manager,
@@ -31,7 +34,7 @@ hatrack_help_init(help_manager_t *manager,
                   bool            zero)
 {
     if (zero) {
-        bzero(manager, sizeof(help_manager_t));
+        memset(manager, 0, sizeof(help_manager_t));
     }
 
     manager->parent = parent;

--- a/src/hatrack/support/helpmanager.c
+++ b/src/hatrack/support/helpmanager.c
@@ -24,6 +24,7 @@
 
 #include "hatrack/helpmanager.h"
 #include "hatrack/mmm.h"
+#include "hatrack/hatomic.h"
 
 #include <string.h>
 

--- a/src/hatrack/support/mmm.c
+++ b/src/hatrack/support/mmm.c
@@ -21,7 +21,9 @@
  *
  */
 
-#include "hatrack.h"
+#include "hatrack/mmm.h"
+
+#include <stdlib.h>
 
 // clang-format off
 __thread mmm_header_t  *mmm_retire_list  = NULL;


### PR DESCRIPTION
This looks like a lot, but it's mostly just moving stuff around. Mainly it's a separation of public and private definitions into what should only be public definitions in the public header files. A couple of new header files placed alongside sources have been added for shared internal declarations and definitions (e.g., `crown-internal.h`). There should be no functional changes here.

I think most of what should be public and what should be private is pretty clear. There's some ambiguous stuff that I generally erred on the side of private with -- if it wasn't used outside of hatrack and it seemed not obviously public, I made it private. The rationale for this was that it's easier to add to the public API than it is to remove from it.

Most all internal struct definitions remain public, which I am personally not a fan of, particularly in something that's intended to be low-level and general purpose like this, but it seems this was intentional given the `_init` APIs and their use in con4m. I generally prefer to make public only what needs to be public as it eases the maintenance burden and makes intrusive changes that really shouldn't impact public use easier. There are ways to make it all work without exposing the data structures, but I haven't done that here and currently have no intention to do so.

There's some churn here with header files and also some formatting churn. There's a lot of `clang-format off` and `clang-format on` to preserve tabular formatting of function prototypes and the like. There were typos in some places that failed to re-enable formatting and sometimes re-enabling was just forgotten or whatever. Some of this kind of thing still remains in .c files, but I've cleaned it all up in the .h files.

The header file churn is largely due to the internal code not using the `hatrack.h` umbrella include, but in some cases also because of changes mainly to `mmm.h` that removed common includes like `malloc.h` and `hatomic.h`. This is a move closer to being IWYU (include what you use) clean. I didn't do a check with the tool to see what issues remain for this PR, but I will at some point soon to clean up the rest.

I've added `HATRACK_EXTERN` for function prototypes. It defaults to just `extern`, which of course isn't strictly necessary and wasn't used previously, at least for the most part. The intent is more for the future for other projects that embed. They can define `HATRACK_EXTERN` themselves if they want to. Mostly it's because I will want to when I embed this elsewhere to adjust symbol visibility. This should only be used for public functions. Don't use it for private functions shared between translation units.

A lot of static inline functions have been moved from being in headers, partly because mostly these are private functions, but also in a lot of cases because there's no justification for them being inline, particularly in `mmm.h`. The compiler won't actually inline all of them, many of them are doing heavy lifting that inlining won't help, and moving them to C translation units makes it easier to make changes, both planned and in a more general sense. If users of this library are dynamically linking it, having a lot of static inline functions for more than the simplest of things is not ideal.

Notably I've left `debug.h` and `gate.h` mostly untouched for now. I've taken them out of `hatrack.h`, though, at least for now. They both are not well name-spaced and have very specific use cases. The names in `debug.h` in particular are likely to clash with other code. Other than the gate code being used in the testing code, which already explicitly includes it, taking these two out of `hatrack.h` broke nothing. We can add them back into `hatrack.h` later if we really want to after they've been fixed, but fixing them was more than I wanted to take on here.