### PR TITLE
Move away from using __thread for thread-local storage in Hatrack

### DIFF
--- a/include/hatrack/arr64.h
+++ b/include/hatrack/arr64.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include "base.h"
+#include "mmm.h"
 
 typedef void (*arr64_callback_t)(void *);
 
@@ -62,9 +63,12 @@ HATRACK_EXTERN void          arr64_cleanup           (arr64_t *);
 HATRACK_EXTERN void          arr64_delete            (arr64_t *);
 HATRACK_EXTERN void         *arr64_get               (arr64_t *, uint64_t, int *);
 HATRACK_EXTERN bool          arr64_set               (arr64_t *, uint64_t, void *);
+HATRACK_EXTERN void          arr64_grow_mmm          (arr64_t *, mmm_thread_t *, uint64_t);
 HATRACK_EXTERN void          arr64_grow              (arr64_t *, uint64_t);
 HATRACK_EXTERN void          arr64_shrink            (arr64_t *, uint64_t);
 HATRACK_EXTERN uint32_t      arr64_len               (arr64_t *);
+HATRACK_EXTERN arr64_view_t *arr64_view_mmm          (arr64_t *, mmm_thread_t *);
 HATRACK_EXTERN arr64_view_t *arr64_view              (arr64_t *);
 HATRACK_EXTERN void         *arr64_view_next         (arr64_view_t *, bool *);
+HATRACK_EXTERN void          arr64_view_delete_mmm   (arr64_view_t *, mmm_thread_t *);
 HATRACK_EXTERN void          arr64_view_delete       (arr64_view_t *);

--- a/include/hatrack/ballcap.h
+++ b/include/hatrack/ballcap.h
@@ -57,7 +57,10 @@
 #include "base.h"
 #include "hatrack_common.h"
 
-// clang-format off
+#ifndef HATRACK_NO_PTHREAD
+
+#include <pthread.h>
+
 typedef struct ballcap_record_st ballcap_record_t;
 
 /*
@@ -79,31 +82,32 @@ typedef struct ballcap_record_st ballcap_record_t;
  */
 
 struct ballcap_record_st {
-    bool                 deleted;
-    void                *item;
-    ballcap_record_t    *next;
+    bool              deleted;
+    void             *item;
+    ballcap_record_t *next;
 };
 
 typedef struct {
-    hatrack_hash_t       hv;
-    ballcap_record_t    *record;
-    bool                 migrated;
-    pthread_mutex_t      mutex;
+    hatrack_hash_t    hv;
+    ballcap_record_t *record;
+    bool              migrated;
+    pthread_mutex_t   mutex;
 } ballcap_bucket_t;
 
 typedef struct {
-    uint64_t             last_slot;
-    uint64_t             threshold;
-    _Atomic uint64_t     used_count;
-    ballcap_bucket_t     buckets[];
+    uint64_t         last_slot;
+    uint64_t         threshold;
+    _Atomic uint64_t used_count;
+    ballcap_bucket_t buckets[];
 } ballcap_store_t;
 
 typedef struct {
-    _Atomic uint64_t     item_count;
-    ballcap_store_t     *store_current;
-    pthread_mutex_t      migrate_mutex;
+    _Atomic uint64_t item_count;
+    ballcap_store_t *store_current;
+    pthread_mutex_t  migrate_mutex;
 } ballcap_t;
 
+// clang-format off
 ballcap_t      *ballcap_new      (void);
 ballcap_t      *ballcap_new_size (char);
 void            ballcap_init     (ballcap_t *);
@@ -117,3 +121,6 @@ bool            ballcap_add      (ballcap_t *, hatrack_hash_t, void *);
 void           *ballcap_remove   (ballcap_t *, hatrack_hash_t, bool *);
 uint64_t        ballcap_len      (ballcap_t *);
 hatrack_view_t *ballcap_view     (ballcap_t *, uint64_t *, bool);
+// clang-format on
+
+#endif

--- a/include/hatrack/ballcap.h
+++ b/include/hatrack/ballcap.h
@@ -56,6 +56,7 @@
 
 #include "base.h"
 #include "hatrack_common.h"
+#include "mmm.h"
 
 #ifndef HATRACK_NO_PTHREAD
 
@@ -108,19 +109,26 @@ typedef struct {
 } ballcap_t;
 
 // clang-format off
-ballcap_t      *ballcap_new      (void);
-ballcap_t      *ballcap_new_size (char);
-void            ballcap_init     (ballcap_t *);
-void            ballcap_init_size(ballcap_t *, char);
-void            ballcap_cleanup  (ballcap_t *);
-void            ballcap_delete   (ballcap_t *);
-void           *ballcap_get      (ballcap_t *, hatrack_hash_t, bool *);
-void           *ballcap_put      (ballcap_t *, hatrack_hash_t, void *, bool *);
-void           *ballcap_replace  (ballcap_t *, hatrack_hash_t, void *, bool *);
-bool            ballcap_add      (ballcap_t *, hatrack_hash_t, void *);
-void           *ballcap_remove   (ballcap_t *, hatrack_hash_t, bool *);
-uint64_t        ballcap_len      (ballcap_t *);
-hatrack_view_t *ballcap_view     (ballcap_t *, uint64_t *, bool);
+ballcap_t      *ballcap_new        (void);
+ballcap_t      *ballcap_new_size   (char);
+void            ballcap_init       (ballcap_t *);
+void            ballcap_init_size  (ballcap_t *, char);
+void            ballcap_cleanup    (ballcap_t *);
+void            ballcap_delete     (ballcap_t *);
+void           *ballcap_get_mmm    (ballcap_t *, mmm_thread_t *, hatrack_hash_t, bool *);
+void           *ballcap_get        (ballcap_t *, hatrack_hash_t, bool *);
+void           *ballcap_put_mmm    (ballcap_t *, mmm_thread_t *, hatrack_hash_t, void *, bool *);
+void           *ballcap_put        (ballcap_t *, hatrack_hash_t, void *, bool *);
+void           *ballcap_replace_mmm(ballcap_t *, mmm_thread_t *, hatrack_hash_t, void *, bool *);
+void           *ballcap_replace    (ballcap_t *, hatrack_hash_t, void *, bool *);
+bool            ballcap_add_mmm    (ballcap_t *, mmm_thread_t *, hatrack_hash_t, void *);
+bool            ballcap_add        (ballcap_t *, hatrack_hash_t, void *);
+void           *ballcap_remove_mmm (ballcap_t *, mmm_thread_t *, hatrack_hash_t, bool *);
+void           *ballcap_remove     (ballcap_t *, hatrack_hash_t, bool *);
+uint64_t        ballcap_len_mmm    (ballcap_t *, mmm_thread_t *);
+uint64_t        ballcap_len        (ballcap_t *);
+hatrack_view_t *ballcap_view_mmm   (ballcap_t *, mmm_thread_t *, uint64_t *, bool);
+hatrack_view_t *ballcap_view       (ballcap_t *, uint64_t *, bool);
 // clang-format on
 
 #endif

--- a/include/hatrack/base.h
+++ b/include/hatrack/base.h
@@ -29,8 +29,6 @@
 #include <stdalign.h>
 #include <stdatomic.h>
 
-#include <pthread.h>
-
 #ifndef HATRACK_EXTERN
 #define HATRACK_EXTERN extern
 #endif

--- a/include/hatrack/capq.h
+++ b/include/hatrack/capq.h
@@ -48,6 +48,7 @@
 #pragma once
 
 #include "base.h"
+#include "mmm.h"
 
 typedef struct {
     void    *item;
@@ -80,8 +81,13 @@ HATRACK_EXTERN void       capq_init       (capq_t *);
 HATRACK_EXTERN void       capq_init_size  (capq_t *, uint64_t);
 HATRACK_EXTERN void       capq_cleanup    (capq_t *);
 HATRACK_EXTERN void       capq_delete     (capq_t *);
+HATRACK_EXTERN uint64_t   capq_enqueue_mmm(capq_t *, mmm_thread_t *, void *);
 HATRACK_EXTERN uint64_t   capq_enqueue    (capq_t *, void *);
+HATRACK_EXTERN capq_top_t capq_top_mmm    (capq_t *, mmm_thread_t *, bool *);
 HATRACK_EXTERN capq_top_t capq_top        (capq_t *, bool *);
+HATRACK_EXTERN bool       capq_cap_mmm    (capq_t *, mmm_thread_t *, uint64_t);
 HATRACK_EXTERN bool       capq_cap        (capq_t *, uint64_t);
+HATRACK_EXTERN void      *capq_dequeue_mmm(capq_t *, mmm_thread_t *, bool *);
 HATRACK_EXTERN void      *capq_dequeue    (capq_t *, bool *);
+HATRACK_EXTERN uint64_t   capq_len_mmm    (capq_t *, mmm_thread_t *);
 HATRACK_EXTERN uint64_t   capq_len        (capq_t *);

--- a/include/hatrack/crown.h
+++ b/include/hatrack/crown.h
@@ -28,6 +28,7 @@
 
 #include "base.h"
 #include "hatrack_common.h"
+#include "mmm.h"
 
 typedef struct {
     void    *item;
@@ -64,18 +65,27 @@ typedef struct {
 } crown_t;
 
 // clang-format off
-HATRACK_EXTERN crown_t        *crown_new        (void);
-HATRACK_EXTERN crown_t        *crown_new_size   (char);
-HATRACK_EXTERN void            crown_init       (crown_t *);
-HATRACK_EXTERN void            crown_init_size  (crown_t *, char);
-HATRACK_EXTERN void            crown_cleanup    (crown_t *);
-HATRACK_EXTERN void            crown_delete     (crown_t *);
-HATRACK_EXTERN void           *crown_get        (crown_t *, hatrack_hash_t, bool *);
-HATRACK_EXTERN void           *crown_put        (crown_t *, hatrack_hash_t, void *, bool *);
-HATRACK_EXTERN void           *crown_replace    (crown_t *, hatrack_hash_t, void *, bool *);
-HATRACK_EXTERN bool            crown_add        (crown_t *, hatrack_hash_t, void *);
-HATRACK_EXTERN void           *crown_remove     (crown_t *, hatrack_hash_t, bool *);
-HATRACK_EXTERN uint64_t        crown_len        (crown_t *);
-HATRACK_EXTERN hatrack_view_t *crown_view       (crown_t *, uint64_t *, bool);
-HATRACK_EXTERN hatrack_view_t *crown_view_fast  (crown_t *, uint64_t *, bool);
-HATRACK_EXTERN hatrack_view_t *crown_view_slow  (crown_t *, uint64_t *, bool);
+HATRACK_EXTERN crown_t        *crown_new          (void);
+HATRACK_EXTERN crown_t        *crown_new_size     (char);
+HATRACK_EXTERN void            crown_init         (crown_t *);
+HATRACK_EXTERN void            crown_init_size    (crown_t *, char);
+HATRACK_EXTERN void            crown_cleanup      (crown_t *);
+HATRACK_EXTERN void            crown_delete       (crown_t *);
+HATRACK_EXTERN void           *crown_get_mmm      (crown_t *, mmm_thread_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *crown_get          (crown_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *crown_put_mmm      (crown_t *, mmm_thread_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *crown_put          (crown_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *crown_replace_mmm  (crown_t *, mmm_thread_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *crown_replace      (crown_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN bool            crown_add_mmm      (crown_t *, mmm_thread_t *, hatrack_hash_t, void *);
+HATRACK_EXTERN bool            crown_add          (crown_t *, hatrack_hash_t, void *);
+HATRACK_EXTERN void           *crown_remove_mmm   (crown_t *, mmm_thread_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *crown_remove       (crown_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN uint64_t        crown_len_mmm      (crown_t *, mmm_thread_t *);
+HATRACK_EXTERN uint64_t        crown_len          (crown_t *);
+HATRACK_EXTERN hatrack_view_t *crown_view_mmm     (crown_t *, mmm_thread_t *, uint64_t *, bool);
+HATRACK_EXTERN hatrack_view_t *crown_view         (crown_t *, uint64_t *, bool);
+HATRACK_EXTERN hatrack_view_t *crown_view_fast_mmm(crown_t *, mmm_thread_t *, uint64_t *, bool);
+HATRACK_EXTERN hatrack_view_t *crown_view_fast    (crown_t *, uint64_t *, bool);
+HATRACK_EXTERN hatrack_view_t *crown_view_slow_mmm(crown_t *, mmm_thread_t *, uint64_t *, bool);
+HATRACK_EXTERN hatrack_view_t *crown_view_slow    (crown_t *, uint64_t *, bool);

--- a/include/hatrack/debug.h
+++ b/include/hatrack/debug.h
@@ -43,6 +43,11 @@
 
 #ifdef HATRACK_DEBUG
 
+#include "mmm.h"
+
+#include <stdio.h>
+#include <string.h>
+
 /* hatrack_debug_record_t
  *
  * The type for records in our ring buffer.
@@ -78,7 +83,6 @@ typedef struct {
 extern hatrack_debug_record_t __hatrack_debug[];
 extern _Atomic uint64_t       __hatrack_debug_sequence;
 extern const char             __hatrack_hex_conversion_table[];
-extern __thread int64_t       mmm_mytid;
 
 /* The below functions are all defined in debug.c. Again, they're only
  * compiled in if HATRACK_DEBUG is on. They are meant for providing
@@ -112,7 +116,7 @@ hatrack_debug(char *msg)
     index                = mysequence & HATRACK_DEBUG_RING_LAST_SLOT;
     record_ptr           = &__hatrack_debug[index];
     record_ptr->sequence = mysequence;
-    record_ptr->thread   = mmm_mytid;
+    record_ptr->thread   = mmm_thread->tid;
 
     strncpy(record_ptr->msg, msg, HATRACK_DEBUG_MSG_SIZE);
 
@@ -160,7 +164,7 @@ hatrack_debug_ptr(void *addr, char *msg)
     record_ptr = &__hatrack_debug[mysequence & HATRACK_DEBUG_RING_LAST_SLOT];
 
     record_ptr->sequence = mysequence;
-    record_ptr->thread   = mmm_mytid;
+    record_ptr->thread   = mmm_thread->tid;
 
     *--p = ' ';
     *--p = ':';
@@ -198,7 +202,7 @@ hatrack_debug2(void *addr, void *addr2, char *msg)
     end        = record_ptr->msg + HATRACK_DEBUG_MSG_SIZE;
 
     record_ptr->sequence = mysequence;
-    record_ptr->thread   = mmm_mytid;
+    record_ptr->thread   = mmm_thread->tid;
 
     *--p = ' ';
     *--p = ':';
@@ -250,7 +254,7 @@ hatrack_debug3(void *addr, void *addr2, void *addr3, char *msg)
     end        = record_ptr->msg + HATRACK_DEBUG_MSG_SIZE;
 
     record_ptr->sequence = mysequence;
-    record_ptr->thread   = mmm_mytid;
+    record_ptr->thread   = mmm_thread->tid;
 
     *--p = ' ';
     *--p = ':';

--- a/include/hatrack/debug.h
+++ b/include/hatrack/debug.h
@@ -116,7 +116,7 @@ hatrack_debug(char *msg)
     index                = mysequence & HATRACK_DEBUG_RING_LAST_SLOT;
     record_ptr           = &__hatrack_debug[index];
     record_ptr->sequence = mysequence;
-    record_ptr->thread   = mmm_thread->tid;
+    record_ptr->thread   = mmm_thread_acquire()->tid;
 
     strncpy(record_ptr->msg, msg, HATRACK_DEBUG_MSG_SIZE);
 
@@ -164,7 +164,7 @@ hatrack_debug_ptr(void *addr, char *msg)
     record_ptr = &__hatrack_debug[mysequence & HATRACK_DEBUG_RING_LAST_SLOT];
 
     record_ptr->sequence = mysequence;
-    record_ptr->thread   = mmm_thread->tid;
+    record_ptr->thread   = mmm_thread_acquire()->tid;
 
     *--p = ' ';
     *--p = ':';
@@ -202,7 +202,7 @@ hatrack_debug2(void *addr, void *addr2, char *msg)
     end        = record_ptr->msg + HATRACK_DEBUG_MSG_SIZE;
 
     record_ptr->sequence = mysequence;
-    record_ptr->thread   = mmm_thread->tid;
+    record_ptr->thread   = mmm_thread_acquire()->tid;
 
     *--p = ' ';
     *--p = ':';
@@ -254,7 +254,7 @@ hatrack_debug3(void *addr, void *addr2, void *addr3, char *msg)
     end        = record_ptr->msg + HATRACK_DEBUG_MSG_SIZE;
 
     record_ptr->sequence = mysequence;
-    record_ptr->thread   = mmm_thread->tid;
+    record_ptr->thread   = mmm_thread_acquire()->tid;
 
     *--p = ' ';
     *--p = ':';

--- a/include/hatrack/dict.h
+++ b/include/hatrack/dict.h
@@ -89,6 +89,22 @@ HATRACK_EXTERN void hatrack_dict_set_sorted_views    (hatrack_dict_t *, bool);
 HATRACK_EXTERN bool hatrack_dict_get_consistent_views(hatrack_dict_t *);
 HATRACK_EXTERN bool hatrack_dict_get_sorted_views    (hatrack_dict_t *);
 
+HATRACK_EXTERN void *hatrack_dict_get_mmm    (hatrack_dict_t *, mmm_thread_t *thread, void *, bool *);
+HATRACK_EXTERN void  hatrack_dict_put_mmm    (hatrack_dict_t *, mmm_thread_t *thread, void *, void *);
+HATRACK_EXTERN bool  hatrack_dict_replace_mmm(hatrack_dict_t *, mmm_thread_t *thread, void *, void *);
+HATRACK_EXTERN bool  hatrack_dict_add_mmm    (hatrack_dict_t *, mmm_thread_t *thread, void *, void *);
+HATRACK_EXTERN bool  hatrack_dict_remove_mmm (hatrack_dict_t *, mmm_thread_t *thread, void *);
+
+HATRACK_EXTERN hatrack_dict_key_t   *hatrack_dict_keys_mmm         (hatrack_dict_t *, mmm_thread_t *, uint64_t *);
+HATRACK_EXTERN hatrack_dict_value_t *hatrack_dict_values_mmm       (hatrack_dict_t *, mmm_thread_t *, uint64_t *);
+HATRACK_EXTERN hatrack_dict_item_t  *hatrack_dict_items_mmm        (hatrack_dict_t *, mmm_thread_t *, uint64_t *);
+HATRACK_EXTERN hatrack_dict_key_t   *hatrack_dict_keys_sort_mmm    (hatrack_dict_t *, mmm_thread_t *, uint64_t *);
+HATRACK_EXTERN hatrack_dict_value_t *hatrack_dict_values_sort_mmm  (hatrack_dict_t *, mmm_thread_t *, uint64_t *);
+HATRACK_EXTERN hatrack_dict_item_t  *hatrack_dict_items_sort_mmm   (hatrack_dict_t *, mmm_thread_t *, uint64_t *);
+HATRACK_EXTERN hatrack_dict_key_t   *hatrack_dict_keys_nosort_mmm  (hatrack_dict_t *, mmm_thread_t *, uint64_t *);
+HATRACK_EXTERN hatrack_dict_value_t *hatrack_dict_values_nosort_mmm(hatrack_dict_t *, mmm_thread_t *, uint64_t *);
+HATRACK_EXTERN hatrack_dict_item_t  *hatrack_dict_items_nosort_mmm (hatrack_dict_t *, mmm_thread_t *, uint64_t *);
+
 HATRACK_EXTERN void *hatrack_dict_get    (hatrack_dict_t *, void *, bool *);
 HATRACK_EXTERN void  hatrack_dict_put    (hatrack_dict_t *, void *, void *);
 HATRACK_EXTERN bool  hatrack_dict_replace(hatrack_dict_t *, void *, void *);

--- a/include/hatrack/duncecap.h
+++ b/include/hatrack/duncecap.h
@@ -37,6 +37,7 @@
 
 #include "base.h"
 #include "hatrack_common.h"
+#include "mmm.h"
 
 #ifndef HATRACK_NO_PTHREAD
 
@@ -246,19 +247,26 @@ duncecap_reader_exit(duncecap_store_t *store);
  */
 
 // clang-format off
-HATRACK_EXTERN duncecap_t     *duncecap_new      (void);
-HATRACK_EXTERN duncecap_t     *duncecap_new_size (char);
-HATRACK_EXTERN void            duncecap_init     (duncecap_t *);
-HATRACK_EXTERN void            duncecap_init_size(duncecap_t *, char);
-HATRACK_EXTERN void            duncecap_cleanup  (duncecap_t *);
-HATRACK_EXTERN void            duncecap_delete   (duncecap_t *);
-HATRACK_EXTERN void           *duncecap_get      (duncecap_t *, hatrack_hash_t, bool *);
-HATRACK_EXTERN void           *duncecap_put      (duncecap_t *, hatrack_hash_t, void *, bool *);
-HATRACK_EXTERN void           *duncecap_replace  (duncecap_t *, hatrack_hash_t, void *,	bool *);
-HATRACK_EXTERN bool            duncecap_add      (duncecap_t *, hatrack_hash_t, void *);
-HATRACK_EXTERN void           *duncecap_remove   (duncecap_t *, hatrack_hash_t, bool *);
-HATRACK_EXTERN uint64_t        duncecap_len      (duncecap_t *);
-HATRACK_EXTERN hatrack_view_t *duncecap_view     (duncecap_t *, uint64_t *, bool);
+HATRACK_EXTERN duncecap_t     *duncecap_new        (void);
+HATRACK_EXTERN duncecap_t     *duncecap_new_size   (char);
+HATRACK_EXTERN void            duncecap_init       (duncecap_t *);
+HATRACK_EXTERN void            duncecap_init_size  (duncecap_t *, char);
+HATRACK_EXTERN void            duncecap_cleanup    (duncecap_t *);
+HATRACK_EXTERN void            duncecap_delete     (duncecap_t *);
+HATRACK_EXTERN void           *duncecap_get_mmm    (duncecap_t *, mmm_thread_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *duncecap_get        (duncecap_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *duncecap_put_mmm    (duncecap_t *, mmm_thread_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *duncecap_put        (duncecap_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *duncecap_replace_mmm(duncecap_t *, mmm_thread_t *, hatrack_hash_t, void *,	bool *);
+HATRACK_EXTERN void           *duncecap_replace    (duncecap_t *, hatrack_hash_t, void *,	bool *);
+HATRACK_EXTERN bool            duncecap_add_mmm    (duncecap_t *, mmm_thread_t *, hatrack_hash_t, void *);
+HATRACK_EXTERN bool            duncecap_add        (duncecap_t *, hatrack_hash_t, void *);
+HATRACK_EXTERN void           *duncecap_remove_mmm (duncecap_t *, mmm_thread_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *duncecap_remove     (duncecap_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN uint64_t        duncecap_len_mmm    (duncecap_t *, mmm_thread_t *);
+HATRACK_EXTERN uint64_t        duncecap_len        (duncecap_t *);
+HATRACK_EXTERN hatrack_view_t *duncecap_view_mmm   (duncecap_t *, mmm_thread_t *, uint64_t *, bool);
+HATRACK_EXTERN hatrack_view_t *duncecap_view       (duncecap_t *, uint64_t *, bool);
 // clang-format on
 
 #endif

--- a/include/hatrack/duncecap.h
+++ b/include/hatrack/duncecap.h
@@ -38,6 +38,10 @@
 #include "base.h"
 #include "hatrack_common.h"
 
+#ifndef HATRACK_NO_PTHREAD
+
+#include <pthread.h>
+
 /* duncecap_record_t
  *
  * In this implementation, readers only use a mutex long enough to
@@ -255,4 +259,6 @@ HATRACK_EXTERN bool            duncecap_add      (duncecap_t *, hatrack_hash_t, 
 HATRACK_EXTERN void           *duncecap_remove   (duncecap_t *, hatrack_hash_t, bool *);
 HATRACK_EXTERN uint64_t        duncecap_len      (duncecap_t *);
 HATRACK_EXTERN hatrack_view_t *duncecap_view     (duncecap_t *, uint64_t *, bool);
- 
+// clang-format on
+
+#endif

--- a/include/hatrack/flexarray.h
+++ b/include/hatrack/flexarray.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "base.h"
+#include "mmm.h"
 
 typedef void (*flex_callback_t)(void *);
 
@@ -71,14 +72,23 @@ HATRACK_EXTERN void         flexarray_set_ret_callback   (flexarray_t *, flex_ca
 HATRACK_EXTERN void         flexarray_set_eject_callback (flexarray_t *, flex_callback_t);
 HATRACK_EXTERN void         flexarray_cleanup            (flexarray_t *);
 HATRACK_EXTERN void         flexarray_delete             (flexarray_t *);
+
+HATRACK_EXTERN void        *flexarray_get_mmm            (flexarray_t *, mmm_thread_t *, uint64_t, int *);
 HATRACK_EXTERN void        *flexarray_get                (flexarray_t *, uint64_t, int *);
+HATRACK_EXTERN bool         flexarray_set_mmm            (flexarray_t *, mmm_thread_t *, uint64_t, void *);        
 HATRACK_EXTERN bool         flexarray_set                (flexarray_t *, uint64_t, void *);
+HATRACK_EXTERN void         flexarray_grow_mmm           (flexarray_t *, mmm_thread_t *, uint64_t);
 HATRACK_EXTERN void         flexarray_grow               (flexarray_t *, uint64_t);
+HATRACK_EXTERN void         flexarray_shrink_mmm         (flexarray_t *, mmm_thread_t *, uint64_t);
 HATRACK_EXTERN void         flexarray_shrink             (flexarray_t *, uint64_t);
+HATRACK_EXTERN uint64_t     flexarray_len_mmm            (flexarray_t *, mmm_thread_t *);
 HATRACK_EXTERN uint64_t     flexarray_len                (flexarray_t *);
+HATRACK_EXTERN flex_view_t *flexarray_view_mmm           (flexarray_t *, mmm_thread_t *);
 HATRACK_EXTERN flex_view_t *flexarray_view               (flexarray_t *);
 HATRACK_EXTERN void        *flexarray_view_next          (flex_view_t *, int *);
+HATRACK_EXTERN void         flexarray_view_delete_mmm    (flex_view_t *, mmm_thread_t *);
 HATRACK_EXTERN void         flexarray_view_delete        (flex_view_t *);
 HATRACK_EXTERN void        *flexarray_view_get           (flex_view_t *, uint64_t, int *);
 HATRACK_EXTERN uint64_t     flexarray_view_len           (flex_view_t *);
+HATRACK_EXTERN flexarray_t *flexarray_add_mmm            (flexarray_t *, mmm_thread_t *, flexarray_t *);
 HATRACK_EXTERN flexarray_t *flexarray_add                (flexarray_t *, flexarray_t *);

--- a/include/hatrack/gate.h
+++ b/include/hatrack/gate.h
@@ -133,7 +133,7 @@ gate_thread_ready(gate_t *gate)
 static inline void
 gate_thread_done(gate_t *gate)
 {
-    get_timestamp(&gate->end_times[mmm_mytid]);
+    get_timestamp(&gate->end_times[mmm_thread->tid]);
 
     return;
 }

--- a/include/hatrack/gate.h
+++ b/include/hatrack/gate.h
@@ -42,6 +42,7 @@
 #include "mmm.h"
 
 #include <string.h>
+#include <time.h>
 
 #ifdef __MACH__
 #include <mach/clock.h>

--- a/include/hatrack/gate.h
+++ b/include/hatrack/gate.h
@@ -133,7 +133,8 @@ gate_thread_ready(gate_t *gate)
 static inline void
 gate_thread_done(gate_t *gate)
 {
-    get_timestamp(&gate->end_times[mmm_thread->tid]);
+    mmm_thread_t *thread = mmm_thread_acquire();
+    get_timestamp(&gate->end_times[thread->tid]);
 
     return;
 }

--- a/include/hatrack/hatrack_common.h
+++ b/include/hatrack/hatrack_common.h
@@ -22,6 +22,7 @@
 
 #pragma once
 #include "base.h"
+#include "mmm.h"
 
 /* hatrack_hash_t
  *
@@ -186,14 +187,14 @@ hatrack_round_up_to_power_of_2(uint64_t n)
 // clang-format off
 typedef void            (*hatrack_init_func)   (void *);
 typedef void            (*hatrack_init_sz_func)(void *, char);
-typedef void *          (*hatrack_get_func)    (void *, hatrack_hash_t, bool *);
-typedef void *          (*hatrack_put_func)    (void *, hatrack_hash_t, void *, bool *);
-typedef void *          (*hatrack_replace_func)(void *, hatrack_hash_t, void *, bool *);
-typedef bool            (*hatrack_add_func)    (void *, hatrack_hash_t,	void *);
-typedef void *          (*hatrack_remove_func) (void *, hatrack_hash_t,	bool *);
+typedef void *          (*hatrack_get_func)    (void *, mmm_thread_t *, hatrack_hash_t, bool *);
+typedef void *          (*hatrack_put_func)    (void *, mmm_thread_t *, hatrack_hash_t, void *, bool *);
+typedef void *          (*hatrack_replace_func)(void *, mmm_thread_t *, hatrack_hash_t, void *, bool *);
+typedef bool            (*hatrack_add_func)    (void *, mmm_thread_t *, hatrack_hash_t,	void *);
+typedef void *          (*hatrack_remove_func) (void *, mmm_thread_t *, hatrack_hash_t,	bool *);
 typedef void            (*hatrack_delete_func) (void *);
-typedef uint64_t        (*hatrack_len_func)    (void *);
-typedef hatrack_view_t *(*hatrack_view_func)   (void *, uint64_t *, bool);
+typedef uint64_t        (*hatrack_len_func)    (void *, mmm_thread_t *);
+typedef hatrack_view_t *(*hatrack_view_func)   (void *, mmm_thread_t *, uint64_t *, bool);
 
 typedef struct hatrack_vtable_st {
     hatrack_init_func    init;

--- a/include/hatrack/hatrack_config.h
+++ b/include/hatrack/hatrack_config.h
@@ -27,6 +27,15 @@
 
 #pragma once
 
+/* HATRACK_NO_PTHREAD
+ *
+ * Define this if you do not want to compile any part of Hatrack that
+ * depends on the POSIX pthread API. The core of Hatrack does not
+ * require pthread support, but there are a few hash types that do:
+ * ballcap, duncecap, newshat, swimcap, and tophat
+ */
+// #define HATRACK_NO_PTHREAD
+
 /* HATRACK_MIN_SIZE_LOG
  *
  * Specifies the minimum table size, but represented as a base two

--- a/include/hatrack/helpmanager.h
+++ b/include/hatrack/helpmanager.h
@@ -40,6 +40,7 @@
 
 #include "base.h"
 #include "capq.h"
+#include "mmm.h"
 
 typedef struct {
     void   *data;
@@ -54,7 +55,7 @@ typedef struct {
     _Atomic help_cell_t retval;
 } help_record_t;
 
-typedef void (*helper_func)(void *, help_record_t *, uint64_t);
+typedef void (*helper_func)(void *, mmm_thread_t *thread, help_record_t *, uint64_t);
 
 typedef struct {
     void        *parent;
@@ -63,5 +64,5 @@ typedef struct {
 } help_manager_t;
 
 HATRACK_EXTERN void  hatrack_help_init(help_manager_t *, void *, helper_func *, bool);
-HATRACK_EXTERN void *hatrack_perform_wf_op(help_manager_t *, uint64_t, void *, void *, bool *);
-HATRACK_EXTERN void  hatrack_complete_help(help_manager_t *, help_record_t *, int64_t, void *, bool);
+HATRACK_EXTERN void *hatrack_perform_wf_op(help_manager_t *, mmm_thread_t *, uint64_t, void *, void *, bool *);
+HATRACK_EXTERN void  hatrack_complete_help(help_manager_t *, mmm_thread_t *, help_record_t *, int64_t, void *, bool);

--- a/include/hatrack/hihat.h
+++ b/include/hatrack/hihat.h
@@ -27,6 +27,7 @@
 
 #include "base.h"
 #include "hatrack_common.h"
+#include "mmm.h"
 
 /* hihat_record_t
  *
@@ -179,19 +180,26 @@ typedef struct {
  */
 
 // clang-format off
-HATRACK_EXTERN hihat_t        *hihat_new      (void);
-HATRACK_EXTERN hihat_t        *hihat_new_size (char);
-HATRACK_EXTERN void            hihat_init     (hihat_t *);
-HATRACK_EXTERN void            hihat_init_size(hihat_t *, char);
-HATRACK_EXTERN void            hihat_cleanup  (hihat_t *);
-HATRACK_EXTERN void            hihat_delete   (hihat_t *);
-HATRACK_EXTERN void           *hihat_get      (hihat_t *, hatrack_hash_t, bool *);
-HATRACK_EXTERN void           *hihat_put      (hihat_t *, hatrack_hash_t, void *, bool *);
-HATRACK_EXTERN void           *hihat_replace  (hihat_t *, hatrack_hash_t, void *, bool *);
-HATRACK_EXTERN bool            hihat_add      (hihat_t *, hatrack_hash_t, void *);
-HATRACK_EXTERN void           *hihat_remove   (hihat_t *, hatrack_hash_t, bool *);
-HATRACK_EXTERN uint64_t        hihat_len      (hihat_t *);
-HATRACK_EXTERN hatrack_view_t *hihat_view     (hihat_t *, uint64_t *, bool);
+HATRACK_EXTERN hihat_t        *hihat_new        (void);
+HATRACK_EXTERN hihat_t        *hihat_new_size   (char);
+HATRACK_EXTERN void            hihat_init       (hihat_t *);
+HATRACK_EXTERN void            hihat_init_size  (hihat_t *, char);
+HATRACK_EXTERN void            hihat_cleanup    (hihat_t *);
+HATRACK_EXTERN void            hihat_delete     (hihat_t *);
+HATRACK_EXTERN void           *hihat_get_mmm    (hihat_t *, mmm_thread_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *hihat_get        (hihat_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *hihat_put_mmm    (hihat_t *, mmm_thread_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *hihat_put        (hihat_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *hihat_replace_mmm(hihat_t *, mmm_thread_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *hihat_replace    (hihat_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN bool            hihat_add_mmm    (hihat_t *, mmm_thread_t *, hatrack_hash_t, void *);
+HATRACK_EXTERN bool            hihat_add        (hihat_t *, hatrack_hash_t, void *);
+HATRACK_EXTERN void           *hihat_remove_mmm (hihat_t *, mmm_thread_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *hihat_remove     (hihat_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN uint64_t        hihat_len_mmm    (hihat_t *, mmm_thread_t *);
+HATRACK_EXTERN uint64_t        hihat_len        (hihat_t *);
+HATRACK_EXTERN hatrack_view_t *hihat_view_mmm   (hihat_t *, mmm_thread_t *, uint64_t *, bool);
+HATRACK_EXTERN hatrack_view_t *hihat_view       (hihat_t *, uint64_t *, bool);
 
 /*
  * Note that hihat_a is almost identical to hihat. It has the same
@@ -202,16 +210,23 @@ HATRACK_EXTERN hatrack_view_t *hihat_view     (hihat_t *, uint64_t *, bool);
  * Instead of adding an extra indirection for that second migration
  * function, we just copy all the methods.
  */
-HATRACK_EXTERN hihat_t        *hihat_a_new      (void);
-HATRACK_EXTERN hihat_t        *hihat_a_new_size (char);
-HATRACK_EXTERN void            hihat_a_init     (hihat_t *);
-HATRACK_EXTERN void            hihat_a_init_size(hihat_t *, char);
-HATRACK_EXTERN void            hihat_a_cleanup  (hihat_t *);
-HATRACK_EXTERN void            hihat_a_delete   (hihat_t *);
-HATRACK_EXTERN void           *hihat_a_get      (hihat_t *, hatrack_hash_t, bool *);
-HATRACK_EXTERN void           *hihat_a_put      (hihat_t *, hatrack_hash_t, void *, bool *);
-HATRACK_EXTERN void           *hihat_a_replace  (hihat_t *, hatrack_hash_t, void *, bool *);
-HATRACK_EXTERN bool            hihat_a_add      (hihat_t *, hatrack_hash_t, void *);
-HATRACK_EXTERN void           *hihat_a_remove   (hihat_t *, hatrack_hash_t, bool *);
-HATRACK_EXTERN uint64_t        hihat_a_len      (hihat_t *);
-HATRACK_EXTERN hatrack_view_t *hihat_a_view     (hihat_t *, uint64_t *, bool);
+HATRACK_EXTERN hihat_t        *hihat_a_new          (void);
+HATRACK_EXTERN hihat_t        *hihat_a_new_size     (char);
+HATRACK_EXTERN void            hihat_a_init         (hihat_t *);
+HATRACK_EXTERN void            hihat_a_init_size    (hihat_t *, char);
+HATRACK_EXTERN void            hihat_a_cleanup      (hihat_t *);
+HATRACK_EXTERN void            hihat_a_delete       (hihat_t *);
+HATRACK_EXTERN void           *hihat_a_get_mmm      (hihat_t *, mmm_thread_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *hihat_a_get          (hihat_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *hihat_a_put_mmm      (hihat_t *, mmm_thread_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *hihat_a_put          (hihat_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *hihat_a_replace_mmm  (hihat_t *, mmm_thread_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *hihat_a_replace      (hihat_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN bool            hihat_a_add_mmm      (hihat_t *, mmm_thread_t *, hatrack_hash_t, void *);
+HATRACK_EXTERN bool            hihat_a_add          (hihat_t *, hatrack_hash_t, void *);
+HATRACK_EXTERN void           *hihat_a_remove_mmm   (hihat_t *, mmm_thread_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *hihat_a_remove       (hihat_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN uint64_t        hihat_a_len_mmm      (hihat_t *, mmm_thread_t *);
+HATRACK_EXTERN uint64_t        hihat_a_len          (hihat_t *);
+HATRACK_EXTERN hatrack_view_t *hihat_a_view_mmm     (hihat_t *, mmm_thread_t *, uint64_t *, bool);
+HATRACK_EXTERN hatrack_view_t *hihat_a_view         (hihat_t *, uint64_t *, bool);

--- a/include/hatrack/hq.h
+++ b/include/hatrack/hq.h
@@ -34,6 +34,7 @@
 #pragma once
 
 #include "base.h"
+#include "mmm.h"
 
 typedef struct {
     void    *item;
@@ -66,15 +67,20 @@ typedef struct {
 } hq_t;
 
 // clang-format off
-HATRACK_EXTERN hq_t      *hq_new        (void);
-HATRACK_EXTERN hq_t      *hq_new_size   (uint64_t);
-HATRACK_EXTERN void       hq_init       (hq_t *);
-HATRACK_EXTERN void       hq_init_size  (hq_t *, uint64_t);
-HATRACK_EXTERN void       hq_cleanup    (hq_t *);
-HATRACK_EXTERN void       hq_delete     (hq_t *);
-HATRACK_EXTERN void       hq_enqueue    (hq_t *, void *);
-HATRACK_EXTERN void      *hq_dequeue    (hq_t *, bool *);
-HATRACK_EXTERN int64_t    hq_len        (hq_t *);
-HATRACK_EXTERN hq_view_t *hq_view       (hq_t *);
-HATRACK_EXTERN void      *hq_view_next  (hq_view_t *, bool *);
-HATRACK_EXTERN void       hq_view_delete(hq_view_t *);
+HATRACK_EXTERN hq_t      *hq_new            (void);
+HATRACK_EXTERN hq_t      *hq_new_size       (uint64_t);
+HATRACK_EXTERN void       hq_init           (hq_t *);
+HATRACK_EXTERN void       hq_init_size      (hq_t *, uint64_t);
+HATRACK_EXTERN void       hq_cleanup        (hq_t *);
+HATRACK_EXTERN void       hq_delete         (hq_t *);
+HATRACK_EXTERN void       hq_enqueue_mmm    (hq_t *, mmm_thread_t *, void *);
+HATRACK_EXTERN void       hq_enqueue        (hq_t *, void *);
+HATRACK_EXTERN void      *hq_dequeue_mmm    (hq_t *, mmm_thread_t *, bool *);
+HATRACK_EXTERN void      *hq_dequeue        (hq_t *, bool *);
+HATRACK_EXTERN int64_t    hq_len_mmm        (hq_t *, mmm_thread_t *);
+HATRACK_EXTERN int64_t    hq_len            (hq_t **);
+HATRACK_EXTERN hq_view_t *hq_view_mmm       (hq_t *, mmm_thread_t *);
+HATRACK_EXTERN hq_view_t *hq_view           (hq_t *);
+HATRACK_EXTERN void      *hq_view_next      (hq_view_t *, bool *);
+HATRACK_EXTERN void       hq_view_delete_mmm(hq_view_t *, mmm_thread_t *);
+HATRACK_EXTERN void       hq_view_delete    (hq_view_t *);

--- a/include/hatrack/llstack.h
+++ b/include/hatrack/llstack.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include "base.h"
+#include "mmm.h"
 
 typedef struct llstack_node_t llstack_node_t;
 
@@ -37,9 +38,11 @@ typedef struct {
 } llstack_t;
 
 // clang-format off
-HATRACK_EXTERN llstack_t *llstack_new    (void);
-HATRACK_EXTERN void       llstack_init   (llstack_t *);
-HATRACK_EXTERN void       llstack_cleanup(llstack_t *);
-HATRACK_EXTERN void       llstack_delete (llstack_t *);
-HATRACK_EXTERN void       llstack_push   (llstack_t *, void *);
-HATRACK_EXTERN void      *llstack_pop    (llstack_t *, bool *);
+HATRACK_EXTERN llstack_t *llstack_new     (void);
+HATRACK_EXTERN void       llstack_init    (llstack_t *);
+HATRACK_EXTERN void       llstack_cleanup (llstack_t *);
+HATRACK_EXTERN void       llstack_delete  (llstack_t *);
+HATRACK_EXTERN void       llstack_push_mmm(llstack_t *, mmm_thread_t *, void *);
+HATRACK_EXTERN void       llstack_push    (llstack_t *, void *);
+HATRACK_EXTERN void      *llstack_pop_mmm (llstack_t *, mmm_thread_t *, bool *);
+HATRACK_EXTERN void      *llstack_pop     (llstack_t *, bool *);

--- a/include/hatrack/logring.h
+++ b/include/hatrack/logring.h
@@ -151,6 +151,7 @@
 
 #include "base.h"
 #include "hatring.h"
+#include "mmm.h"
 
 /* Information about the current entry.
  *
@@ -202,12 +203,16 @@ typedef struct {
 } logring_t;
 
 // clang-format off
-HATRACK_EXTERN logring_t      *logring_new        (uint64_t, uint64_t);
-HATRACK_EXTERN void            logring_init       (logring_t *, uint64_t, uint64_t);
-HATRACK_EXTERN void            logring_cleanup    (logring_t *);
-HATRACK_EXTERN void            logring_delete     (logring_t *);
-HATRACK_EXTERN void            logring_enqueue    (logring_t *, void *, uint64_t);
-HATRACK_EXTERN bool            logring_dequeue    (logring_t *, void *, uint64_t *);
-HATRACK_EXTERN logring_view_t *logring_view       (logring_t *, bool);
-HATRACK_EXTERN void           *logring_view_next  (logring_view_t *, uint64_t *);
-HATRACK_EXTERN void            logring_view_delete(logring_view_t *);
+HATRACK_EXTERN logring_t      *logring_new            (uint64_t, uint64_t);
+HATRACK_EXTERN void            logring_init           (logring_t *, uint64_t, uint64_t);
+HATRACK_EXTERN void            logring_cleanup        (logring_t *);
+HATRACK_EXTERN void            logring_delete         (logring_t *);
+HATRACK_EXTERN void            logring_enqueue_mmm    (logring_t *, mmm_thread_t *, void *, uint64_t);
+HATRACK_EXTERN void            logring_enqueue        (logring_t *, void *, uint64_t);
+HATRACK_EXTERN bool            logring_dequeue_mmm    (logring_t *, mmm_thread_t *, void *, uint64_t *);
+HATRACK_EXTERN bool            logring_dequeue        (logring_t *, void *, uint64_t *);
+HATRACK_EXTERN logring_view_t *logring_view_mmm       (logring_t *, mmm_thread_t *, bool);
+HATRACK_EXTERN logring_view_t *logring_view           (logring_t *, bool);
+HATRACK_EXTERN void           *logring_view_next      (logring_view_t *, uint64_t *);
+HATRACK_EXTERN void            logring_view_delete_mmm(logring_view_t *, mmm_thread_t *);
+HATRACK_EXTERN void            logring_view_delete    (logring_view_t *);

--- a/include/hatrack/lohat-a.h
+++ b/include/hatrack/lohat-a.h
@@ -123,6 +123,7 @@
 #include "base.h"
 #include "hatrack_common.h"
 #include "lohat_common.h"
+#include "mmm.h"
 
 /* lohat_a_history_t
  *
@@ -222,16 +223,23 @@ typedef struct {
 } lohat_a_t;
 
 // clang-format off
-HATRACK_EXTERN lohat_a_t      *lohat_a_new      (void);
-HATRACK_EXTERN lohat_a_t      *lohat_a_new_size (char);
-HATRACK_EXTERN void            lohat_a_init     (lohat_a_t *);
-HATRACK_EXTERN void            lohat_a_init_size(lohat_a_t *, char);
-HATRACK_EXTERN void            lohat_a_cleanup  (lohat_a_t *);
-HATRACK_EXTERN void            lohat_a_delete   (lohat_a_t *);
-HATRACK_EXTERN void           *lohat_a_get      (lohat_a_t *, hatrack_hash_t, bool *);
-HATRACK_EXTERN void           *lohat_a_put      (lohat_a_t *, hatrack_hash_t, void *, bool *);
-HATRACK_EXTERN void           *lohat_a_replace  (lohat_a_t *, hatrack_hash_t, void *, bool *);
-HATRACK_EXTERN bool            lohat_a_add      (lohat_a_t *, hatrack_hash_t, void *);
-HATRACK_EXTERN void           *lohat_a_remove   (lohat_a_t *, hatrack_hash_t, bool *);
-HATRACK_EXTERN uint64_t        lohat_a_len      (lohat_a_t *);
-HATRACK_EXTERN hatrack_view_t *lohat_a_view     (lohat_a_t *, uint64_t *, bool);
+HATRACK_EXTERN lohat_a_t      *lohat_a_new        (void);
+HATRACK_EXTERN lohat_a_t      *lohat_a_new_size   (char);
+HATRACK_EXTERN void            lohat_a_init       (lohat_a_t *);
+HATRACK_EXTERN void            lohat_a_init_size  (lohat_a_t *, char);
+HATRACK_EXTERN void            lohat_a_cleanup    (lohat_a_t *);
+HATRACK_EXTERN void            lohat_a_delete     (lohat_a_t *);
+HATRACK_EXTERN void           *lohat_a_get_mmm    (lohat_a_t *, mmm_thread_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *lohat_a_get        (lohat_a_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *lohat_a_put_mmm    (lohat_a_t *, mmm_thread_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *lohat_a_put        (lohat_a_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *lohat_a_replace_mmm(lohat_a_t *, mmm_thread_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *lohat_a_replace    (lohat_a_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN bool            lohat_a_add_mmm    (lohat_a_t *, mmm_thread_t *, hatrack_hash_t, void *);
+HATRACK_EXTERN bool            lohat_a_add        (lohat_a_t *, hatrack_hash_t, void *);
+HATRACK_EXTERN void           *lohat_a_remove_mmm (lohat_a_t *, mmm_thread_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *lohat_a_remove     (lohat_a_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN uint64_t        lohat_a_len_mmm    (lohat_a_t *, mmm_thread_t *);
+HATRACK_EXTERN uint64_t        lohat_a_len        (lohat_a_t *);
+HATRACK_EXTERN hatrack_view_t *lohat_a_view_mmm   (lohat_a_t *, mmm_thread_t *, uint64_t *, bool);
+HATRACK_EXTERN hatrack_view_t *lohat_a_view       (lohat_a_t *, uint64_t *, bool);

--- a/include/hatrack/lohat.h
+++ b/include/hatrack/lohat.h
@@ -264,6 +264,7 @@
 #include "base.h"
 #include "hatrack_common.h"
 #include "lohat_common.h"
+#include "mmm.h"
 
 /* lohat_history_t
  *
@@ -560,16 +561,23 @@ typedef struct lohat_st {
  */
 
 // clang-format off
-HATRACK_EXTERN lohat_t        *lohat_new      (void);
-HATRACK_EXTERN lohat_t        *lohat_new_size (char);
-HATRACK_EXTERN void            lohat_init     (lohat_t *);
-HATRACK_EXTERN void            lohat_init_size(lohat_t *, char);
-HATRACK_EXTERN void            lohat_cleanup  (lohat_t *);
-HATRACK_EXTERN void            lohat_delete   (lohat_t *);
-HATRACK_EXTERN void           *lohat_get      (lohat_t *, hatrack_hash_t, bool *);
-HATRACK_EXTERN void           *lohat_put      (lohat_t *, hatrack_hash_t, void *, bool *);
-HATRACK_EXTERN void           *lohat_replace  (lohat_t *, hatrack_hash_t, void *, bool *);
-HATRACK_EXTERN bool            lohat_add      (lohat_t *, hatrack_hash_t, void *);
-HATRACK_EXTERN void           *lohat_remove   (lohat_t *, hatrack_hash_t, bool *);
-HATRACK_EXTERN uint64_t        lohat_len      (lohat_t *);
-HATRACK_EXTERN hatrack_view_t *lohat_view     (lohat_t *, uint64_t *, bool);
+HATRACK_EXTERN lohat_t        *lohat_new        (void);
+HATRACK_EXTERN lohat_t        *lohat_new_size   (char);
+HATRACK_EXTERN void            lohat_init       (lohat_t *);
+HATRACK_EXTERN void            lohat_init_size  (lohat_t *, char);
+HATRACK_EXTERN void            lohat_cleanup    (lohat_t *);
+HATRACK_EXTERN void            lohat_delete     (lohat_t *);
+HATRACK_EXTERN void           *lohat_get_mmm    (lohat_t *, mmm_thread_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *lohat_get        (lohat_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *lohat_put_mmm    (lohat_t *, mmm_thread_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *lohat_put        (lohat_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *lohat_replace_mmm(lohat_t *, mmm_thread_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *lohat_replace    (lohat_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN bool            lohat_add_mmm    (lohat_t *, mmm_thread_t *, hatrack_hash_t, void *);
+HATRACK_EXTERN bool            lohat_add        (lohat_t *, hatrack_hash_t, void *);
+HATRACK_EXTERN void           *lohat_remove_mmm (lohat_t *, mmm_thread_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *lohat_remove     (lohat_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN uint64_t        lohat_len_mmm    (lohat_t *, mmm_thread_t *);
+HATRACK_EXTERN uint64_t        lohat_len        (lohat_t *);
+HATRACK_EXTERN hatrack_view_t *lohat_view_mmm   (lohat_t *, mmm_thread_t *, uint64_t *, bool);
+HATRACK_EXTERN hatrack_view_t *lohat_view       (lohat_t *, uint64_t *, bool);

--- a/include/hatrack/mmm.h
+++ b/include/hatrack/mmm.h
@@ -127,7 +127,7 @@ mmm_setthreadfns(mmm_thread_acquire_func acquirefn,
 extern _Atomic uint64_t mmm_epoch;
 
 HATRACK_EXTERN void
-mmm_retire(void *);
+mmm_retire(mmm_thread_t *, void *);
 
 /* This epoch system was inspired by my research into what was out
  * there that would be faster and easier to use than hazard
@@ -361,7 +361,7 @@ enum64(mmm_enum_t,
  * operation.
  */
 HATRACK_EXTERN void
-mmm_start_basic_op(void);
+mmm_start_basic_op(mmm_thread_t *thread);
 
 /* mmm_start_linearized_op() is used to help ensure we can safely recover
  * a consistent, full ordering of data objects in the lohat family.
@@ -415,7 +415,7 @@ mmm_start_basic_op(void);
  *    boundary, with only one write per epoch.
  */
 HATRACK_EXTERN uint64_t
-mmm_start_linearized_op(void);
+mmm_start_linearized_op(mmm_thread_t *thread);
 
 /* This does two things:
  *
@@ -429,7 +429,7 @@ mmm_start_linearized_op(void);
  * because they both use a memory fence.
  */
 HATRACK_EXTERN void
-mmm_end_op(void);
+mmm_end_op(mmm_thread_t *thread);
 
 /* Note that the API for allocating via MMM is a little non-intuitive.
  * for malloc users, partially because it supports a couple of
@@ -536,4 +536,4 @@ mmm_copy_create_epoch(void *dst, void *src)
 // Use this in migration functions to avoid unnecessary scanning of the
 // retire list, when we know the epoch won't have changed.
 HATRACK_EXTERN void
-mmm_retire_fast(void *ptr);
+mmm_retire_fast(mmm_thread_t *thread, void *ptr);

--- a/include/hatrack/newshat.h
+++ b/include/hatrack/newshat.h
@@ -27,6 +27,7 @@
 
 #include "base.h"
 #include "hatrack_common.h"
+#include "mmm.h"
 
 #ifndef HATRACK_NO_PTHREAD
 
@@ -198,18 +199,25 @@ typedef struct {
  */
 
 // clang-format off
-HATRACK_EXTERN newshat_t      *newshat_new      (void);
-HATRACK_EXTERN newshat_t      *newshat_new_size (char);
-HATRACK_EXTERN void            newshat_init     (newshat_t *);
-HATRACK_EXTERN void            newshat_init_size(newshat_t *, char);
-HATRACK_EXTERN void            newshat_cleanup  (newshat_t *);
-HATRACK_EXTERN void            newshat_delete   (newshat_t *);
-HATRACK_EXTERN void           *newshat_get      (newshat_t *, hatrack_hash_t, bool *);
-HATRACK_EXTERN void           *newshat_put      (newshat_t *, hatrack_hash_t, void *, bool *);
-HATRACK_EXTERN void           *newshat_replace  (newshat_t *, hatrack_hash_t, void *, bool *);
-HATRACK_EXTERN bool            newshat_add      (newshat_t *, hatrack_hash_t, void *);
-HATRACK_EXTERN void           *newshat_remove   (newshat_t *, hatrack_hash_t, bool *);
-HATRACK_EXTERN uint64_t        newshat_len      (newshat_t *);
-HATRACK_EXTERN hatrack_view_t *newshat_view     (newshat_t *, uint64_t *, bool);
+HATRACK_EXTERN newshat_t      *newshat_new        (void);
+HATRACK_EXTERN newshat_t      *newshat_new_size   (char);
+HATRACK_EXTERN void            newshat_init       (newshat_t *);
+HATRACK_EXTERN void            newshat_init_size  (newshat_t *, char);
+HATRACK_EXTERN void            newshat_cleanup    (newshat_t *);
+HATRACK_EXTERN void            newshat_delete     (newshat_t *);
+HATRACK_EXTERN void           *newshat_get_mmm    (newshat_t *, mmm_thread_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *newshat_get        (newshat_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *newshat_put_mmm    (newshat_t *, mmm_thread_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *newshat_put        (newshat_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *newshat_replace_mmm(newshat_t *, mmm_thread_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *newshat_replace    (newshat_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN bool            newshat_add_mmm    (newshat_t *, mmm_thread_t *, hatrack_hash_t, void *);
+HATRACK_EXTERN bool            newshat_add        (newshat_t *, hatrack_hash_t, void *);
+HATRACK_EXTERN void           *newshat_remove_mmm (newshat_t *, mmm_thread_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *newshat_remove     (newshat_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN uint64_t        newshat_len_mmm    (newshat_t *, mmm_thread_t *);
+HATRACK_EXTERN uint64_t        newshat_len        (newshat_t *);
+HATRACK_EXTERN hatrack_view_t *newshat_view_mmm   (newshat_t *, mmm_thread_t *, uint64_t *, bool);
+HATRACK_EXTERN hatrack_view_t *newshat_view       (newshat_t *, uint64_t *, bool);
 
 #endif

--- a/include/hatrack/newshat.h
+++ b/include/hatrack/newshat.h
@@ -28,6 +28,10 @@
 #include "base.h"
 #include "hatrack_common.h"
 
+#ifndef HATRACK_NO_PTHREAD
+
+#include <pthread.h>
+
 /* newshat_record_t
  *
  * Each newshat bucket is individually locked, so that only one thread
@@ -207,3 +211,5 @@ HATRACK_EXTERN bool            newshat_add      (newshat_t *, hatrack_hash_t, vo
 HATRACK_EXTERN void           *newshat_remove   (newshat_t *, hatrack_hash_t, bool *);
 HATRACK_EXTERN uint64_t        newshat_len      (newshat_t *);
 HATRACK_EXTERN hatrack_view_t *newshat_view     (newshat_t *, uint64_t *, bool);
+
+#endif

--- a/include/hatrack/oldhat.h
+++ b/include/hatrack/oldhat.h
@@ -31,6 +31,7 @@
 
 #include "base.h"
 #include "hatrack_common.h"
+#include "mmm.h"
 
 /* oldhat_record_t
  *
@@ -180,16 +181,23 @@ typedef struct {
  */
 
 // clang-format off
-HATRACK_EXTERN oldhat_t       *oldhat_new      (void);
-HATRACK_EXTERN oldhat_t       *oldhat_new_size (char);
-HATRACK_EXTERN void            oldhat_init     (oldhat_t *);
-HATRACK_EXTERN void            oldhat_init_size(oldhat_t *, char);
-HATRACK_EXTERN void            oldhat_cleanup  (oldhat_t *);
-HATRACK_EXTERN void            oldhat_delete   (oldhat_t *);
-HATRACK_EXTERN void           *oldhat_get      (oldhat_t *, hatrack_hash_t, bool *);
-HATRACK_EXTERN void           *oldhat_put      (oldhat_t *, hatrack_hash_t, void *, bool *);
-HATRACK_EXTERN void           *oldhat_replace  (oldhat_t *, hatrack_hash_t, void *, bool *);
-HATRACK_EXTERN bool            oldhat_add      (oldhat_t *, hatrack_hash_t, void *);
-HATRACK_EXTERN void           *oldhat_remove   (oldhat_t *, hatrack_hash_t, bool *);
-HATRACK_EXTERN uint64_t        oldhat_len      (oldhat_t *);
-HATRACK_EXTERN hatrack_view_t *oldhat_view     (oldhat_t *, uint64_t *, bool);
+HATRACK_EXTERN oldhat_t       *oldhat_new        (void);
+HATRACK_EXTERN oldhat_t       *oldhat_new_size   (char);
+HATRACK_EXTERN void            oldhat_init       (oldhat_t *);
+HATRACK_EXTERN void            oldhat_init_size  (oldhat_t *, char);
+HATRACK_EXTERN void            oldhat_cleanup    (oldhat_t *);
+HATRACK_EXTERN void            oldhat_delete     (oldhat_t *);
+HATRACK_EXTERN void           *oldhat_get_mmm    (oldhat_t *, mmm_thread_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *oldhat_get        (oldhat_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *oldhat_put_mmm    (oldhat_t *, mmm_thread_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *oldhat_put        (oldhat_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *oldhat_replace_mmm(oldhat_t *, mmm_thread_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *oldhat_replace    (oldhat_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN bool            oldhat_add_mmm    (oldhat_t *, mmm_thread_t *, hatrack_hash_t, void *);
+HATRACK_EXTERN bool            oldhat_add        (oldhat_t *, hatrack_hash_t, void *);
+HATRACK_EXTERN void           *oldhat_remove_mmm (oldhat_t *, mmm_thread_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *oldhat_remove     (oldhat_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN uint64_t        oldhat_len_mmm    (oldhat_t *, mmm_thread_t *);
+HATRACK_EXTERN uint64_t        oldhat_len        (oldhat_t *);
+HATRACK_EXTERN hatrack_view_t *oldhat_view_mmm   (oldhat_t *, mmm_thread_t *, uint64_t *, bool);
+HATRACK_EXTERN hatrack_view_t *oldhat_view       (oldhat_t *, uint64_t *, bool);

--- a/include/hatrack/q64.h
+++ b/include/hatrack/q64.h
@@ -34,6 +34,7 @@
 #pragma once
 
 #include "base.h"
+#include "mmm.h"
 
 typedef uint64_t           q64_item_t;
 typedef _Atomic q64_item_t q64_cell_t;
@@ -69,12 +70,15 @@ typedef struct {
 } q64_t;
 
 // clang-format off
-HATRACK_EXTERN q64_t   *q64_new      (void);
-HATRACK_EXTERN q64_t   *q64_new_size (char);
-HATRACK_EXTERN void     q64_init     (q64_t *);
-HATRACK_EXTERN void     q64_init_size(q64_t *, char);
-HATRACK_EXTERN void     q64_cleanup  (q64_t *);
-HATRACK_EXTERN void     q64_delete   (q64_t *);
-HATRACK_EXTERN uint64_t q64_len      (q64_t *);
-HATRACK_EXTERN void     q64_enqueue  (q64_t *, void *);
-HATRACK_EXTERN void    *q64_dequeue  (q64_t *, bool *);
+HATRACK_EXTERN q64_t   *q64_new        (void);
+HATRACK_EXTERN q64_t   *q64_new_size   (char);
+HATRACK_EXTERN void     q64_init       (q64_t *);
+HATRACK_EXTERN void     q64_init_size  (q64_t *, char);
+HATRACK_EXTERN void     q64_cleanup    (q64_t *);
+HATRACK_EXTERN void     q64_delete     (q64_t *);
+HATRACK_EXTERN uint64_t q64_len_mmm    (q64_t *, mmm_thread_t *);
+HATRACK_EXTERN uint64_t q64_len        (q64_t *);
+HATRACK_EXTERN void     q64_enqueue_mmm(q64_t *, mmm_thread_t *, void *);
+HATRACK_EXTERN void     q64_enqueue    (q64_t *, void *);
+HATRACK_EXTERN void    *q64_dequeue_mmm(q64_t *, mmm_thread_t *, bool *);
+HATRACK_EXTERN void    *q64_dequeue    (q64_t *, bool *);

--- a/include/hatrack/queue.h
+++ b/include/hatrack/queue.h
@@ -77,6 +77,7 @@
 #pragma once
 
 #include "base.h"
+#include "mmm.h"
 
 typedef struct {
     void    *item;
@@ -117,12 +118,15 @@ typedef struct hatrack_queue_t {
 } queue_t;
 
 // clang-format off
-HATRACK_EXTERN queue_t *queue_new      (void);
-HATRACK_EXTERN queue_t *queue_new_size (char);
-HATRACK_EXTERN void     queue_init     (queue_t *);
-HATRACK_EXTERN void     queue_init_size(queue_t *, char);
-HATRACK_EXTERN void     queue_cleanup  (queue_t *);
-HATRACK_EXTERN void     queue_delete   (queue_t *);
-HATRACK_EXTERN uint64_t queue_len      (queue_t *);
-HATRACK_EXTERN void     queue_enqueue  (queue_t *, void *);
-HATRACK_EXTERN void    *queue_dequeue  (queue_t *, bool *);
+HATRACK_EXTERN queue_t *queue_new        (void);
+HATRACK_EXTERN queue_t *queue_new_size   (char);
+HATRACK_EXTERN void     queue_init       (queue_t *);
+HATRACK_EXTERN void     queue_init_size  (queue_t *, char);
+HATRACK_EXTERN void     queue_cleanup    (queue_t *);
+HATRACK_EXTERN void     queue_delete     (queue_t *);
+HATRACK_EXTERN uint64_t queue_len_mmm    (queue_t *, mmm_thread_t *);
+HATRACK_EXTERN uint64_t queue_len        (queue_t *);
+HATRACK_EXTERN void     queue_enqueue_mmm(queue_t *, mmm_thread_t *, void *);
+HATRACK_EXTERN void     queue_enqueue    (queue_t *, void *);
+HATRACK_EXTERN void    *queue_dequeue_mmm(queue_t *, mmm_thread_t *, bool *);
+HATRACK_EXTERN void    *queue_dequeue    (queue_t *, bool *);

--- a/include/hatrack/refhat.h
+++ b/include/hatrack/refhat.h
@@ -23,6 +23,7 @@
 
 #include "base.h"
 #include "hatrack_common.h"
+#include "mmm.h"
 
 /* refhat_bucket_t
  *
@@ -117,16 +118,23 @@ typedef struct {
  */
 
 // clang-format off
-HATRACK_EXTERN refhat_t       *refhat_new      (void);
-HATRACK_EXTERN refhat_t       *refhat_new_size (char);
-HATRACK_EXTERN void            refhat_init     (refhat_t *);
-HATRACK_EXTERN void            refhat_init_size(refhat_t *, char);
-HATRACK_EXTERN void            refhat_cleanup  (refhat_t *);
-HATRACK_EXTERN void            refhat_delete   (refhat_t *);
-HATRACK_EXTERN void           *refhat_get      (refhat_t *, hatrack_hash_t, bool *);
-HATRACK_EXTERN void           *refhat_put      (refhat_t *, hatrack_hash_t, void *, bool *);
-HATRACK_EXTERN void           *refhat_replace  (refhat_t *, hatrack_hash_t, void *, bool *);
-HATRACK_EXTERN bool            refhat_add      (refhat_t *, hatrack_hash_t, void *);
-HATRACK_EXTERN void           *refhat_remove   (refhat_t *, hatrack_hash_t, bool *);
-HATRACK_EXTERN uint64_t        refhat_len      (refhat_t *);
-HATRACK_EXTERN hatrack_view_t *refhat_view     (refhat_t *, uint64_t *, bool);
+HATRACK_EXTERN refhat_t       *refhat_new        (void);
+HATRACK_EXTERN refhat_t       *refhat_new_size   (char);
+HATRACK_EXTERN void            refhat_init       (refhat_t *);
+HATRACK_EXTERN void            refhat_init_size  (refhat_t *, char);
+HATRACK_EXTERN void            refhat_cleanup    (refhat_t *);
+HATRACK_EXTERN void            refhat_delete     (refhat_t *);
+HATRACK_EXTERN void           *refhat_get_mmm    (refhat_t *, mmm_thread_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *refhat_get        (refhat_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *refhat_put_mmm    (refhat_t *, mmm_thread_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *refhat_put        (refhat_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *refhat_replace_mmm(refhat_t *, mmm_thread_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *refhat_replace    (refhat_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN bool            refhat_add_mmm    (refhat_t *, mmm_thread_t *, hatrack_hash_t, void *);
+HATRACK_EXTERN bool            refhat_add        (refhat_t *, hatrack_hash_t, void *);
+HATRACK_EXTERN void           *refhat_remove_mmm (refhat_t *, mmm_thread_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *refhat_remove     (refhat_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN uint64_t        refhat_len_mmm    (refhat_t *, mmm_thread_t *);
+HATRACK_EXTERN uint64_t        refhat_len        (refhat_t *);
+HATRACK_EXTERN hatrack_view_t *refhat_view_mmm   (refhat_t *, mmm_thread_t *, uint64_t *, bool);
+HATRACK_EXTERN hatrack_view_t *refhat_view       (refhat_t *, uint64_t *, bool);

--- a/include/hatrack/set.h
+++ b/include/hatrack/set.h
@@ -25,6 +25,7 @@
 #include "hatrack_common.h"
 #include "dict.h"
 #include "woolhat.h"
+#include "mmm.h"
 
 typedef struct hatrack_set_st hatrack_set_t;
 
@@ -46,18 +47,35 @@ HATRACK_EXTERN void            hatrack_set_set_cache_offset(hatrack_set_t *, int
 HATRACK_EXTERN void            hatrack_set_set_custom_hash (hatrack_set_t *, hatrack_hash_func_t);
 HATRACK_EXTERN void            hatrack_set_set_free_handler(hatrack_set_t *, hatrack_mem_hook_t);
 HATRACK_EXTERN void            hatrack_set_set_return_hook (hatrack_set_t *, hatrack_mem_hook_t);
-HATRACK_EXTERN bool            hatrack_set_contains        (hatrack_set_t *, void *);
-HATRACK_EXTERN bool            hatrack_set_put             (hatrack_set_t *, void *);
-HATRACK_EXTERN bool            hatrack_set_add             (hatrack_set_t *, void *);
-HATRACK_EXTERN bool            hatrack_set_remove          (hatrack_set_t *, void *);
-HATRACK_EXTERN void           *hatrack_set_items           (hatrack_set_t *, uint64_t *);
-HATRACK_EXTERN void           *hatrack_set_items_sort      (hatrack_set_t *, uint64_t *);
-HATRACK_EXTERN void           *hatrack_set_any_item        (hatrack_set_t *, bool *);
-HATRACK_EXTERN bool            hatrack_set_is_eq           (hatrack_set_t *, hatrack_set_t *);
-HATRACK_EXTERN bool            hatrack_set_is_superset     (hatrack_set_t *, hatrack_set_t *, bool);
-HATRACK_EXTERN bool            hatrack_set_is_subset       (hatrack_set_t *, hatrack_set_t *, bool);
-HATRACK_EXTERN bool            hatrack_set_is_disjoint     (hatrack_set_t *, hatrack_set_t *);
-HATRACK_EXTERN hatrack_set_t  *hatrack_set_difference      (hatrack_set_t *, hatrack_set_t *);
-HATRACK_EXTERN hatrack_set_t  *hatrack_set_union           (hatrack_set_t *, hatrack_set_t *);
-HATRACK_EXTERN hatrack_set_t  *hatrack_set_intersection    (hatrack_set_t *, hatrack_set_t *);
-HATRACK_EXTERN hatrack_set_t  *hatrack_set_disjunction     (hatrack_set_t *, hatrack_set_t *);
+
+HATRACK_EXTERN bool            hatrack_set_contains_mmm    (hatrack_set_t *, mmm_thread_t *, void *);
+HATRACK_EXTERN bool            hatrack_set_put_mmm         (hatrack_set_t *, mmm_thread_t *, void *);
+HATRACK_EXTERN bool            hatrack_set_add_mmm         (hatrack_set_t *, mmm_thread_t *, void *);
+HATRACK_EXTERN bool            hatrack_set_remove_mmm      (hatrack_set_t *, mmm_thread_t *, void *);
+HATRACK_EXTERN void           *hatrack_set_items_mmm       (hatrack_set_t *, mmm_thread_t *, uint64_t *);
+HATRACK_EXTERN void           *hatrack_set_items_sort_mmm  (hatrack_set_t *, mmm_thread_t *, uint64_t *);
+HATRACK_EXTERN void           *hatrack_set_any_item_mmm    (hatrack_set_t *, mmm_thread_t *, bool *);
+HATRACK_EXTERN bool            hatrack_set_is_eq_mmm       (hatrack_set_t *, mmm_thread_t *, hatrack_set_t *);
+HATRACK_EXTERN bool            hatrack_set_is_superset_mmm (hatrack_set_t *, mmm_thread_t *, hatrack_set_t *, bool);
+HATRACK_EXTERN bool            hatrack_set_is_subset_mmm   (hatrack_set_t *, mmm_thread_t *, hatrack_set_t *, bool);
+HATRACK_EXTERN bool            hatrack_set_is_disjoint_mmm (hatrack_set_t *, mmm_thread_t *, hatrack_set_t *);
+HATRACK_EXTERN hatrack_set_t  *hatrack_set_difference_mmm  (hatrack_set_t *, mmm_thread_t *, hatrack_set_t *);
+HATRACK_EXTERN hatrack_set_t  *hatrack_set_union_mmm       (hatrack_set_t *, mmm_thread_t *, hatrack_set_t *);
+HATRACK_EXTERN hatrack_set_t  *hatrack_set_intersection_mmm(hatrack_set_t *, mmm_thread_t *, hatrack_set_t *);
+HATRACK_EXTERN hatrack_set_t  *hatrack_set_disjunction_mmm (hatrack_set_t *, mmm_thread_t *, hatrack_set_t *);
+
+HATRACK_EXTERN bool            hatrack_set_contains    (hatrack_set_t *, void *);
+HATRACK_EXTERN bool            hatrack_set_put         (hatrack_set_t *, void *);
+HATRACK_EXTERN bool            hatrack_set_add         (hatrack_set_t *, void *);
+HATRACK_EXTERN bool            hatrack_set_remove      (hatrack_set_t *, void *);
+HATRACK_EXTERN void           *hatrack_set_items       (hatrack_set_t *, uint64_t *);
+HATRACK_EXTERN void           *hatrack_set_items_sort  (hatrack_set_t *, uint64_t *);
+HATRACK_EXTERN void           *hatrack_set_any_item    (hatrack_set_t *, bool *);
+HATRACK_EXTERN bool            hatrack_set_is_eq       (hatrack_set_t *, hatrack_set_t *);
+HATRACK_EXTERN bool            hatrack_set_is_superset (hatrack_set_t *, hatrack_set_t *, bool);
+HATRACK_EXTERN bool            hatrack_set_is_subset   (hatrack_set_t *, hatrack_set_t *, bool);
+HATRACK_EXTERN bool            hatrack_set_is_disjoint (hatrack_set_t *, hatrack_set_t *);
+HATRACK_EXTERN hatrack_set_t  *hatrack_set_difference  (hatrack_set_t *, hatrack_set_t *);
+HATRACK_EXTERN hatrack_set_t  *hatrack_set_union       (hatrack_set_t *, hatrack_set_t *);
+HATRACK_EXTERN hatrack_set_t  *hatrack_set_intersection(hatrack_set_t *, hatrack_set_t *);
+HATRACK_EXTERN hatrack_set_t  *hatrack_set_disjunction (hatrack_set_t *, hatrack_set_t *);

--- a/include/hatrack/stack.h
+++ b/include/hatrack/stack.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include "base.h"
+#include "mmm.h"
 
 /* "Valid after" means that, in any epoch after the epoch stored in
  * this field, pushers that are assigned that slot are free to try
@@ -74,12 +75,18 @@ typedef struct {
 } hatstack_t;
 
 // clang-format off
-HATRACK_EXTERN hatstack_t   *hatstack_new        (uint64_t);
-HATRACK_EXTERN void          hatstack_init       (hatstack_t *, uint64_t);
-HATRACK_EXTERN void          hatstack_cleanup    (hatstack_t *);
-HATRACK_EXTERN void          hatstack_delete     (hatstack_t *);
-HATRACK_EXTERN void          hatstack_push       (hatstack_t *, void *);
-HATRACK_EXTERN void         *hatstack_pop        (hatstack_t *, bool *);
-HATRACK_EXTERN stack_view_t *hatstack_view       (hatstack_t *);
-HATRACK_EXTERN void         *hatstack_view_next  (stack_view_t *, bool *);
-HATRACK_EXTERN void          hatstack_view_delete(stack_view_t *);
+HATRACK_EXTERN hatstack_t   *hatstack_new            (uint64_t);
+HATRACK_EXTERN void          hatstack_init           (hatstack_t *, uint64_t);
+HATRACK_EXTERN void          hatstack_cleanup        (hatstack_t *);
+HATRACK_EXTERN void          hatstack_delete         (hatstack_t *);
+HATRACK_EXTERN void          hatstack_push_mmm       (hatstack_t *, mmm_thread_t *, void *);
+HATRACK_EXTERN void          hatstack_push           (hatstack_t *, void *);
+HATRACK_EXTERN void         *hatstack_pop_mmm        (hatstack_t *, mmm_thread_t *, bool *);
+HATRACK_EXTERN void         *hatstack_pop            (hatstack_t *, bool *);
+HATRACK_EXTERN void         *hatstack_peek_mmm       (hatstack_t *, mmm_thread_t *, bool *);
+HATRACK_EXTERN void         *hatstack_peek           (hatstack_t *, bool *);
+HATRACK_EXTERN stack_view_t *hatstack_view_mmm       (hatstack_t *, mmm_thread_t *);
+HATRACK_EXTERN stack_view_t *hatstack_view           (hatstack_t *);
+HATRACK_EXTERN void         *hatstack_view_next      (stack_view_t *, bool *);
+HATRACK_EXTERN void          hatstack_view_delete_mmm(stack_view_t *, mmm_thread_t *);
+HATRACK_EXTERN void          hatstack_view_delete    (stack_view_t *);

--- a/include/hatrack/swimcap.h
+++ b/include/hatrack/swimcap.h
@@ -36,6 +36,7 @@
 
 #include "base.h"
 #include "hatrack_common.h"
+#include "mmm.h"
 
 #ifndef HATRACK_NO_PTHREAD
 
@@ -217,19 +218,26 @@ typedef struct {
  */
 
 // clang-format off
-HATRACK_EXTERN swimcap_t      *swimcap_new      (void);
-HATRACK_EXTERN swimcap_t      *swimcap_new_size (char);
-HATRACK_EXTERN void            swimcap_init     (swimcap_t *);
-HATRACK_EXTERN void            swimcap_init_size(swimcap_t *, char);
-HATRACK_EXTERN void            swimcap_cleanup  (swimcap_t *);
-HATRACK_EXTERN void            swimcap_delete   (swimcap_t *);
-HATRACK_EXTERN void           *swimcap_get      (swimcap_t *, hatrack_hash_t, bool *);
-HATRACK_EXTERN void           *swimcap_put      (swimcap_t *, hatrack_hash_t, void *, bool *);
-HATRACK_EXTERN void           *swimcap_replace  (swimcap_t *, hatrack_hash_t, void *, bool *);
-HATRACK_EXTERN bool            swimcap_add      (swimcap_t *, hatrack_hash_t, void *);
-HATRACK_EXTERN void           *swimcap_remove   (swimcap_t *, hatrack_hash_t, bool *);
-HATRACK_EXTERN uint64_t        swimcap_len      (swimcap_t *);
-HATRACK_EXTERN hatrack_view_t *swimcap_view     (swimcap_t *, uint64_t *, bool);
+HATRACK_EXTERN swimcap_t      *swimcap_new        (void);
+HATRACK_EXTERN swimcap_t      *swimcap_new_size   (char);
+HATRACK_EXTERN void            swimcap_init       (swimcap_t *);
+HATRACK_EXTERN void            swimcap_init_size  (swimcap_t *, char);
+HATRACK_EXTERN void            swimcap_cleanup    (swimcap_t *);
+HATRACK_EXTERN void            swimcap_delete     (swimcap_t *);
+HATRACK_EXTERN void           *swimcap_get_mmm    (swimcap_t *, mmm_thread_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *swimcap_get        (swimcap_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *swimcap_put_mmm    (swimcap_t *, mmm_thread_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *swimcap_put        (swimcap_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *swimcap_replace_mmm(swimcap_t *, mmm_thread_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *swimcap_replace    (swimcap_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN bool            swimcap_add_mmm    (swimcap_t *, mmm_thread_t *, hatrack_hash_t, void *);
+HATRACK_EXTERN bool            swimcap_add        (swimcap_t *, hatrack_hash_t, void *);
+HATRACK_EXTERN void           *swimcap_remove_mmm (swimcap_t *, mmm_thread_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *swimcap_remove     (swimcap_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN uint64_t        swimcap_len_mmm    (swimcap_t *, mmm_thread_t *);
+HATRACK_EXTERN uint64_t        swimcap_len        (swimcap_t *);
+HATRACK_EXTERN hatrack_view_t *swimcap_view_mmm   (swimcap_t *, mmm_thread_t *, uint64_t *, bool);
+HATRACK_EXTERN hatrack_view_t *swimcap_view       (swimcap_t *, uint64_t *, bool);
 // clang-format on
 
 #endif

--- a/include/hatrack/swimcap.h
+++ b/include/hatrack/swimcap.h
@@ -37,6 +37,10 @@
 #include "base.h"
 #include "hatrack_common.h"
 
+#ifndef HATRACK_NO_PTHREAD
+
+#include <pthread.h>
+
 /* swimcap_record_t
  *
  * This is unchanged from duncecap_record_t.
@@ -226,3 +230,6 @@ HATRACK_EXTERN bool            swimcap_add      (swimcap_t *, hatrack_hash_t, vo
 HATRACK_EXTERN void           *swimcap_remove   (swimcap_t *, hatrack_hash_t, bool *);
 HATRACK_EXTERN uint64_t        swimcap_len      (swimcap_t *);
 HATRACK_EXTERN hatrack_view_t *swimcap_view     (swimcap_t *, uint64_t *, bool);
+// clang-format on
+
+#endif

--- a/include/hatrack/tiara.h
+++ b/include/hatrack/tiara.h
@@ -54,6 +54,7 @@
 
 #include "base.h"
 #include "hatrack_common.h"
+#include "mmm.h"
 
 typedef struct {
     uint64_t hv;
@@ -78,16 +79,23 @@ typedef struct {
 } tiara_t;
 
 // clang-format off
-HATRACK_EXTERN tiara_t        *tiara_new      (void);
-HATRACK_EXTERN tiara_t        *tiara_new_size (char);
-HATRACK_EXTERN void            tiara_init     (tiara_t *);
-HATRACK_EXTERN void            tiara_init_size(tiara_t *, char);
-HATRACK_EXTERN void            tiara_cleanup  (tiara_t *);
-HATRACK_EXTERN void            tiara_delete   (tiara_t *);
-HATRACK_EXTERN void           *tiara_get      (tiara_t *, uint64_t);
-HATRACK_EXTERN void           *tiara_put      (tiara_t *, uint64_t, void *);
-HATRACK_EXTERN void           *tiara_replace  (tiara_t *, uint64_t, void *);
-HATRACK_EXTERN bool            tiara_add      (tiara_t *, uint64_t, void *);
-HATRACK_EXTERN void           *tiara_remove   (tiara_t *, uint64_t);
-HATRACK_EXTERN uint64_t        tiara_len      (tiara_t *);
-HATRACK_EXTERN hatrack_view_t *tiara_view     (tiara_t *, uint64_t *, bool);
+HATRACK_EXTERN tiara_t        *tiara_new        (void);
+HATRACK_EXTERN tiara_t        *tiara_new_size   (char);
+HATRACK_EXTERN void            tiara_init       (tiara_t *);
+HATRACK_EXTERN void            tiara_init_size  (tiara_t *, char);
+HATRACK_EXTERN void            tiara_cleanup    (tiara_t *);
+HATRACK_EXTERN void            tiara_delete     (tiara_t *);
+HATRACK_EXTERN void           *tiara_get_mmm    (tiara_t *, mmm_thread_t *, uint64_t);
+HATRACK_EXTERN void           *tiara_get        (tiara_t *, uint64_t);
+HATRACK_EXTERN void           *tiara_put_mmm    (tiara_t *, mmm_thread_t *, uint64_t, void *);
+HATRACK_EXTERN void           *tiara_put        (tiara_t *, uint64_t, void *);
+HATRACK_EXTERN void           *tiara_replace_mmm(tiara_t *, mmm_thread_t *, uint64_t, void *);
+HATRACK_EXTERN void           *tiara_replace    (tiara_t *, uint64_t, void *);
+HATRACK_EXTERN bool            tiara_add_mmm    (tiara_t *, mmm_thread_t *, uint64_t, void *);
+HATRACK_EXTERN bool            tiara_add        (tiara_t *, uint64_t, void *);
+HATRACK_EXTERN void           *tiara_remove_mmm (tiara_t *, mmm_thread_t *, uint64_t);
+HATRACK_EXTERN void           *tiara_remove     (tiara_t *, uint64_t);
+HATRACK_EXTERN uint64_t        tiara_len_mmm    (tiara_t *, mmm_thread_t *);
+HATRACK_EXTERN uint64_t        tiara_len        (tiara_t *);
+HATRACK_EXTERN hatrack_view_t *tiara_view_mmm   (tiara_t *, mmm_thread_t *, uint64_t *, bool);
+HATRACK_EXTERN hatrack_view_t *tiara_view       (tiara_t *, uint64_t *, bool);

--- a/include/hatrack/tophat.h
+++ b/include/hatrack/tophat.h
@@ -98,6 +98,10 @@
 #include "base.h"
 #include "hatrack_common.h"
 
+#ifndef HATRACK_NO_PTHREAD
+
+#include <pthread.h>
+
 /* tophat_migration_t
  *
  * We use this enumeration only to figure out, once we've decided to
@@ -241,3 +245,6 @@ HATRACK_EXTERN bool            tophat_add         (tophat_t *, hatrack_hash_t, v
 HATRACK_EXTERN void           *tophat_remove      (tophat_t *, hatrack_hash_t, bool *);
 HATRACK_EXTERN uint64_t        tophat_len         (tophat_t *);
 HATRACK_EXTERN hatrack_view_t *tophat_view        (tophat_t *, uint64_t *, bool);
+// clang-format on
+
+#endif

--- a/include/hatrack/tophat.h
+++ b/include/hatrack/tophat.h
@@ -97,6 +97,7 @@
 
 #include "base.h"
 #include "hatrack_common.h"
+#include "mmm.h"
 
 #ifndef HATRACK_NO_PTHREAD
 
@@ -236,15 +237,22 @@ HATRACK_EXTERN void            tophat_init_fast_wf_size(tophat_t *, char);
 HATRACK_EXTERN void            tophat_init_cst_mx_size (tophat_t *, char);
 HATRACK_EXTERN void            tophat_init_cst_wf_size (tophat_t *, char);
 
-HATRACK_EXTERN void            tophat_cleanup     (tophat_t *);
-HATRACK_EXTERN void            tophat_delete      (tophat_t *);
-HATRACK_EXTERN void           *tophat_get         (tophat_t *, hatrack_hash_t, bool *);
-HATRACK_EXTERN void           *tophat_put         (tophat_t *, hatrack_hash_t, void *, bool *);
-HATRACK_EXTERN void           *tophat_replace     (tophat_t *, hatrack_hash_t, void *, bool *);
-HATRACK_EXTERN bool            tophat_add         (tophat_t *, hatrack_hash_t, void *);
-HATRACK_EXTERN void           *tophat_remove      (tophat_t *, hatrack_hash_t, bool *);
-HATRACK_EXTERN uint64_t        tophat_len         (tophat_t *);
-HATRACK_EXTERN hatrack_view_t *tophat_view        (tophat_t *, uint64_t *, bool);
+HATRACK_EXTERN void            tophat_cleanup    (tophat_t *);
+HATRACK_EXTERN void            tophat_delete     (tophat_t *);
+HATRACK_EXTERN void           *tophat_get_mmm    (tophat_t *, mmm_thread_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *tophat_get        (tophat_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *tophat_put_mmm    (tophat_t *, mmm_thread_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *tophat_put        (tophat_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *tophat_replace_mmm(tophat_t *, mmm_thread_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *tophat_replace    (tophat_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN bool            tophat_add_mmm    (tophat_t *, mmm_thread_t *, hatrack_hash_t, void *);
+HATRACK_EXTERN bool            tophat_add        (tophat_t *, hatrack_hash_t, void *);
+HATRACK_EXTERN void           *tophat_remove_mmm (tophat_t *, mmm_thread_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *tophat_remove     (tophat_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN uint64_t        tophat_len_mmm    (tophat_t *, mmm_thread_t *);
+HATRACK_EXTERN uint64_t        tophat_len        (tophat_t *);
+HATRACK_EXTERN hatrack_view_t *tophat_view_mmm   (tophat_t *, mmm_thread_t *, uint64_t *, bool);
+HATRACK_EXTERN hatrack_view_t *tophat_view       (tophat_t *, uint64_t *, bool);
 // clang-format on
 
 #endif

--- a/include/hatrack/vector.h
+++ b/include/hatrack/vector.h
@@ -23,6 +23,7 @@
 
 #include "base.h"
 #include "helpmanager.h"
+#include "mmm.h"
 
 typedef void (*vector_callback_t)(void *);
 
@@ -69,14 +70,24 @@ HATRACK_EXTERN void           vector_set_ret_callback  (vector_t *, vector_callb
 HATRACK_EXTERN void           vector_set_eject_callback(vector_t *, vector_callback_t);
 HATRACK_EXTERN void           vector_cleanup           (vector_t *);
 HATRACK_EXTERN void           vector_delete            (vector_t *);
+HATRACK_EXTERN void          *vector_get_mmm           (vector_t *, mmm_thread_t *, int64_t, int *);
 HATRACK_EXTERN void          *vector_get               (vector_t *, int64_t, int *);
+HATRACK_EXTERN bool           vector_set_mmm           (vector_t *, mmm_thread_t *, int64_t, void *);
 HATRACK_EXTERN bool           vector_set               (vector_t *, int64_t, void *);
+HATRACK_EXTERN void           vector_grow_mmm          (vector_t *, mmm_thread_t *, int64_t);
 HATRACK_EXTERN void           vector_grow              (vector_t *, int64_t);
+HATRACK_EXTERN void           vector_shrink_mmm        (vector_t *, mmm_thread_t *, int64_t);
 HATRACK_EXTERN void           vector_shrink            (vector_t *, int64_t);
+HATRACK_EXTERN uint32_t       vector_len_mmm           (vector_t *, mmm_thread_t *);
 HATRACK_EXTERN uint32_t       vector_len               (vector_t *);
+HATRACK_EXTERN void           vector_push_mmm          (vector_t *, mmm_thread_t *, void *);
 HATRACK_EXTERN void           vector_push              (vector_t *, void *);
+HATRACK_EXTERN void          *vector_pop_mmm           (vector_t *, mmm_thread_t *, bool *);
 HATRACK_EXTERN void          *vector_pop               (vector_t *, bool *);
+HATRACK_EXTERN void          *vector_peek_mmm          (vector_t *, mmm_thread_t *, bool *);
 HATRACK_EXTERN void          *vector_peek              (vector_t *, bool *);
+HATRACK_EXTERN vector_view_t *vector_view_mmm          (vector_t *, mmm_thread_t *);
 HATRACK_EXTERN vector_view_t *vector_view              (vector_t *);
 HATRACK_EXTERN void          *vector_view_next         (vector_view_t *, bool *);
+HATRACK_EXTERN void           vector_view_delete_mmm   (vector_view_t *, mmm_thread_t *);
 HATRACK_EXTERN void           vector_view_delete       (vector_view_t *);

--- a/include/hatrack/witchhat.h
+++ b/include/hatrack/witchhat.h
@@ -36,6 +36,7 @@
 
 #include "base.h"
 #include "hatrack_common.h"
+#include "mmm.h"
 
 typedef struct {
     void    *item;
@@ -71,11 +72,18 @@ HATRACK_EXTERN void            witchhat_init       (witchhat_t *);
 HATRACK_EXTERN void            witchhat_init_size  (witchhat_t *, char);
 HATRACK_EXTERN void            witchhat_cleanup    (witchhat_t *);
 HATRACK_EXTERN void            witchhat_delete     (witchhat_t *);
+HATRACK_EXTERN void           *witchhat_get_mmm    (witchhat_t *, mmm_thread_t *, hatrack_hash_t, bool *);
 HATRACK_EXTERN void           *witchhat_get        (witchhat_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *witchhat_put_mmm    (witchhat_t *, mmm_thread_t *, hatrack_hash_t, void *, bool *);
 HATRACK_EXTERN void           *witchhat_put        (witchhat_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *witchhat_replace_mmm(witchhat_t *, mmm_thread_t *, hatrack_hash_t, void *, bool *);
 HATRACK_EXTERN void           *witchhat_replace    (witchhat_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN bool            witchhat_add_mmm    (witchhat_t *, mmm_thread_t *, hatrack_hash_t, void *);
 HATRACK_EXTERN bool            witchhat_add        (witchhat_t *, hatrack_hash_t, void *);
+HATRACK_EXTERN void           *witchhat_remove_mmm (witchhat_t *, mmm_thread_t *, hatrack_hash_t, bool *);
 HATRACK_EXTERN void           *witchhat_remove     (witchhat_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN uint64_t        witchhat_len_mmm    (witchhat_t *, mmm_thread_t *);
 HATRACK_EXTERN uint64_t        witchhat_len        (witchhat_t *);
+HATRACK_EXTERN hatrack_view_t *witchhat_view_mmm   (witchhat_t *, mmm_thread_t *, uint64_t *, bool);
 HATRACK_EXTERN hatrack_view_t *witchhat_view       (witchhat_t *, uint64_t *, bool);
-HATRACK_EXTERN hatrack_view_t *witchhat_view_no_mmm(witchhat_t *, uint64_t *, bool);
+// clang-format on 

--- a/include/hatrack/woolhat.h
+++ b/include/hatrack/woolhat.h
@@ -82,13 +82,20 @@ HATRACK_EXTERN void            woolhat_init_size       (woolhat_t *, char);
 HATRACK_EXTERN void            woolhat_cleanup         (woolhat_t *);
 HATRACK_EXTERN void            woolhat_delete          (woolhat_t *);
 HATRACK_EXTERN void            woolhat_set_cleanup_func(woolhat_t *, mmm_cleanup_func, void *);
+HATRACK_EXTERN void           *woolhat_get_mmm         (woolhat_t *, mmm_thread_t *, hatrack_hash_t, bool *);
 HATRACK_EXTERN void           *woolhat_get             (woolhat_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN void           *woolhat_put_mmm         (woolhat_t *, mmm_thread_t *, hatrack_hash_t, void *, bool *);
 HATRACK_EXTERN void           *woolhat_put             (woolhat_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN void           *woolhat_replace_mmm     (woolhat_t *, mmm_thread_t *, hatrack_hash_t, void *, bool *);
 HATRACK_EXTERN void           *woolhat_replace         (woolhat_t *, hatrack_hash_t, void *, bool *);
+HATRACK_EXTERN bool            woolhat_add_mmm         (woolhat_t *, mmm_thread_t *, hatrack_hash_t, void *);
 HATRACK_EXTERN bool            woolhat_add             (woolhat_t *, hatrack_hash_t, void *);
+HATRACK_EXTERN void           *woolhat_remove_mmm      (woolhat_t *, mmm_thread_t *, hatrack_hash_t, bool *);
 HATRACK_EXTERN void           *woolhat_remove          (woolhat_t *, hatrack_hash_t, bool *);
+HATRACK_EXTERN uint64_t        woolhat_len_mmm         (woolhat_t *, mmm_thread_t *);
 HATRACK_EXTERN uint64_t        woolhat_len             (woolhat_t *);
 
+HATRACK_EXTERN hatrack_view_t     *woolhat_view_mmm    (woolhat_t *, mmm_thread_t *, uint64_t *, bool);
 HATRACK_EXTERN hatrack_view_t     *woolhat_view        (woolhat_t *, uint64_t *, bool);
 HATRACK_EXTERN hatrack_set_view_t *woolhat_view_epoch  (woolhat_t *, uint64_t *, uint64_t);
 

--- a/include/test/testhat.h
+++ b/include/test/testhat.h
@@ -29,6 +29,7 @@
 #ifndef __TESTHAT_H__
 #define __TESTHAT_H__
 
+#include "hatrack/hatrack_common.h"
 #include "hatrack/malloc.h"
 #include "hatrack/counters.h"
 
@@ -54,33 +55,33 @@ typedef struct {
 } testhat_t;
 
 static inline void *
-testhat_get(testhat_t *self, hatrack_hash_t hv, bool *found)
+testhat_get(testhat_t *self, mmm_thread_t *thread, hatrack_hash_t hv, bool *found)
 {
-    return (*self->vtable.get)(self->htable, hv, found);
+    return (*self->vtable.get)(self->htable, thread, hv, found);
 }
 
 static inline void *
-testhat_put(testhat_t *self, hatrack_hash_t hv, void *item, bool *found)
+testhat_put(testhat_t *self, mmm_thread_t *thread, hatrack_hash_t hv, void *item, bool *found)
 {
-    return (*self->vtable.put)(self->htable, hv, item, found);
+    return (*self->vtable.put)(self->htable, thread, hv, item, found);
 }
 
 static inline void *
-testhat_replace(testhat_t *self, hatrack_hash_t hv, void *item, bool *found)
+testhat_replace(testhat_t *self, mmm_thread_t *thread, hatrack_hash_t hv, void *item, bool *found)
 {
-    return (*self->vtable.replace)(self->htable, hv, item, found);
+    return (*self->vtable.replace)(self->htable, thread, hv, item, found);
 }
 
 static inline bool
-testhat_add(testhat_t *self, hatrack_hash_t hv, void *item)
+testhat_add(testhat_t *self, mmm_thread_t *thread, hatrack_hash_t hv, void *item)
 {
-    return (*self->vtable.add)(self->htable, hv, item);
+    return (*self->vtable.add)(self->htable, thread, hv, item);
 }
 
 static inline void *
-testhat_remove(testhat_t *self, hatrack_hash_t hv, bool *found)
+testhat_remove(testhat_t *self, mmm_thread_t *thread, hatrack_hash_t hv, bool *found)
 {
-    return (*self->vtable.remove)(self->htable, hv, found);
+    return (*self->vtable.remove)(self->htable, thread, hv, found);
 }
 
 static inline void
@@ -93,52 +94,52 @@ testhat_delete(testhat_t *self)
 }
 
 static inline uint64_t
-testhat_len(testhat_t *self)
+testhat_len(testhat_t *self, mmm_thread_t *thread)
 {
-    return (*self->vtable.len)(self->htable);
+    return (*self->vtable.len)(self->htable, thread);
 }
 
 static inline hatrack_view_t *
-testhat_view(testhat_t *self, uint64_t *num_items, bool sort)
+testhat_view(testhat_t *self, mmm_thread_t *thread, uint64_t *num_items, bool sort)
 {
-    return (*self->vtable.view)(self->htable, num_items, sort);
+    return (*self->vtable.view)(self->htable, thread, num_items, sort);
 }
 
 // Convince the type system we're not crazy.
-typedef void *(*get64f)(void *, uint64_t);
-typedef void *(*put64f)(void *, uint64_t, void *);
-typedef void *(*rep64f)(void *, uint64_t, void *);
-typedef bool (*add64f)(void *, uint64_t, void *);
-typedef void *(*rm64f)(void *, uint64_t);
+typedef void *(*get64f)(void *, mmm_thread_t *, uint64_t);
+typedef void *(*put64f)(void *, mmm_thread_t *, uint64_t, void *);
+typedef void *(*rep64f)(void *, mmm_thread_t *, uint64_t, void *);
+typedef bool (*add64f)(void *, mmm_thread_t *, uint64_t, void *);
+typedef void *(*rm64f)(void *, mmm_thread_t *, uint64_t);
 
 static inline void *
-testhat_get64(testhat_t *self, hatrack_hash_t *hv)
+testhat_get64(testhat_t *self, mmm_thread_t *thread, hatrack_hash_t *hv)
 {
-    return (*(get64f)self->vtable.get)(self->htable, *(uint64_t *)hv);
+    return (*(get64f)self->vtable.get)(self->htable, thread, *(uint64_t *)hv);
 }
 
 static inline void *
-testhat_put64(testhat_t *self, hatrack_hash_t *hv, void *item)
+testhat_put64(testhat_t *self, mmm_thread_t *thread, hatrack_hash_t *hv, void *item)
 {
-    return (*(put64f)self->vtable.put)(self->htable, *(uint64_t *)hv, item);
+    return (*(put64f)self->vtable.put)(self->htable, thread, *(uint64_t *)hv, item);
 }
 
 static inline void *
-testhat_replace64(testhat_t *self, hatrack_hash_t *hv, void *item)
+testhat_replace64(testhat_t *self, mmm_thread_t *thread, hatrack_hash_t *hv, void *item)
 {
-    return (*(rep64f)self->vtable.replace)(self->htable, *(uint64_t *)hv, item);
+    return (*(rep64f)self->vtable.replace)(self->htable, thread, *(uint64_t *)hv, item);
 }
 
 static inline bool
-testhat_add64(testhat_t *self, hatrack_hash_t *hv, void *item)
+testhat_add64(testhat_t *self, mmm_thread_t *thread, hatrack_hash_t *hv, void *item)
 {
-    return (*(add64f)self->vtable.add)(self->htable, *(uint64_t *)hv, item);
+    return (*(add64f)self->vtable.add)(self->htable, thread, *(uint64_t *)hv, item);
 }
 
 static inline void *
-testhat_remove64(testhat_t *self, hatrack_hash_t *hv)
+testhat_remove64(testhat_t *self, mmm_thread_t *thread, hatrack_hash_t *hv)
 {
-    return (*(rm64f)self->vtable.remove)(self->htable, *(uint64_t *)hv);
+    return (*(rm64f)self->vtable.remove)(self->htable, thread, *(uint64_t *)hv);
 }
 
 static inline void
@@ -151,15 +152,15 @@ testhat_delete64(testhat_t *self)
 }
 
 static inline uint64_t
-testhat_len64(testhat_t *self)
+testhat_len64(testhat_t *self, mmm_thread_t *thread)
 {
-    return (*self->vtable.len)(self->htable);
+    return (*self->vtable.len)(self->htable, thread);
 }
 
 static inline hatrack_view_t *
-testhat_view64(testhat_t *self, uint64_t *num_items, bool sort)
+testhat_view64(testhat_t *self, mmm_thread_t *thread, uint64_t *num_items, bool sort)
 {
-    return (*self->vtable.view)(self->htable, num_items, sort);
+    return (*self->vtable.view)(self->htable, thread, num_items, sort);
 }
 
 typedef struct {
@@ -241,121 +242,121 @@ typedef union {
 } test_item;
 
 static inline uint32_t
-test_get(testhat_t *self, uint32_t key)
+test_get(testhat_t *self, mmm_thread_t *thread, uint32_t key)
 {
     test_item item;
 
-    item.i = (uint64_t)testhat_get(self, precomputed_hashes[key], NULL);
+    item.i = (uint64_t)testhat_get(self, thread, precomputed_hashes[key], NULL);
 
     return item.s.value;
 }
 
 static inline void
-test_put(testhat_t *self, uint32_t key, uint32_t value)
+test_put(testhat_t *self, mmm_thread_t *thread, uint32_t key, uint32_t value)
 {
     test_item item;
 
     item.s.key   = key;
     item.s.value = value;
 
-    testhat_put(self, precomputed_hashes[key], (void *)item.i, NULL);
+    testhat_put(self, thread, precomputed_hashes[key], (void *)item.i, NULL);
 
     return;
 }
 
 static inline void
-test_replace(testhat_t *self, uint32_t key, uint32_t value)
+test_replace(testhat_t *self, mmm_thread_t *thread, uint32_t key, uint32_t value)
 {
     test_item item;
 
     item.s.key   = key;
     item.s.value = value;
 
-    testhat_replace(self, precomputed_hashes[key], (void *)item.i, NULL);
+    testhat_replace(self, thread, precomputed_hashes[key], (void *)item.i, NULL);
 
     return;
 }
 
 static inline bool
-test_add(testhat_t *self, uint32_t key, uint32_t value)
+test_add(testhat_t *self, mmm_thread_t *thread, uint32_t key, uint32_t value)
 {
     test_item item;
 
     item.s.key   = key;
     item.s.value = value;
 
-    return testhat_add(self, precomputed_hashes[key], (void *)item.i);
+    return testhat_add(self, thread, precomputed_hashes[key], (void *)item.i);
 }
 
 static inline void
-test_remove(testhat_t *self, uint32_t key)
+test_remove(testhat_t *self, mmm_thread_t *thread, uint32_t key)
 {
-    testhat_remove(self, precomputed_hashes[key], NULL);
+    testhat_remove(self, thread, precomputed_hashes[key], NULL);
 
     return;
 }
 
 static inline hatrack_view_t *
-test_view(testhat_t *self, uint64_t *n, bool sort)
+test_view(testhat_t *self, mmm_thread_t *thread, uint64_t *n, bool sort)
 {
-    return testhat_view(self, n, sort);
+    return testhat_view(self, thread, n, sort);
 }
 
 static inline uint32_t
-test_get64(testhat_t *self, uint32_t key)
+test_get64(testhat_t *self, mmm_thread_t *thread, uint32_t key)
 {
     uint64_t n;
 
-    n = (uint64_t)testhat_get64(self, &precomputed_hashes[key]);
+    n = (uint64_t)testhat_get64(self, thread, &precomputed_hashes[key]);
 
     return n >> 3;
 }
 
 static inline void
-test_put64(testhat_t *self, uint32_t key, uint32_t value)
+test_put64(testhat_t *self, mmm_thread_t *thread, uint32_t key, uint32_t value)
 {
     uint64_t n;
 
     n = value << 3;
-    testhat_put64(self, &precomputed_hashes[key], (void *)n);
+    testhat_put64(self, thread, &precomputed_hashes[key], (void *)n);
 
     return;
 }
 
 static inline void
-test_replace64(testhat_t *self, uint32_t key, uint32_t value)
+test_replace64(testhat_t *self, mmm_thread_t *thread, uint32_t key, uint32_t value)
 {
     uint64_t n;
 
     n = value << 3;
 
-    testhat_replace64(self, &precomputed_hashes[key], (void *)n);
+    testhat_replace64(self, thread, &precomputed_hashes[key], (void *)n);
 
     return;
 }
 
 static inline bool
-test_add64(testhat_t *self, uint32_t key, uint32_t value)
+test_add64(testhat_t *self, mmm_thread_t *thread, uint32_t key, uint32_t value)
 {
     uint64_t n;
 
     n = value << 3;
 
-    return testhat_add64(self, &precomputed_hashes[key], (void *)n);
+    return testhat_add64(self, thread, &precomputed_hashes[key], (void *)n);
 }
 
 static inline void
-test_remove64(testhat_t *self, uint32_t key)
+test_remove64(testhat_t *self, mmm_thread_t *thread, uint32_t key)
 {
-    testhat_remove64(self, &precomputed_hashes[key]);
+    testhat_remove64(self, thread, &precomputed_hashes[key]);
 
     return;
 }
 
 static inline hatrack_view_t *
-test_view64(testhat_t *self, uint64_t *n, bool sort)
+test_view64(testhat_t *self, mmm_thread_t *thread, uint64_t *n, bool sort)
 {
-    return testhat_view64(self, n, sort);
+    return testhat_view64(self, thread, n, sort);
 }
 
 #endif

--- a/src/con4m/set.c
+++ b/src/con4m/set.c
@@ -191,8 +191,10 @@ c4m_set_union(c4m_set_t *set1, c4m_set_t *set2)
     hatrack_set_view_t *view2;
     uint64_t            i, j;
 
+    mmm_thread_t *thread = mmm_thread_acquire();
+
     ret   = c4m_new(c4m_get_my_type(set1));
-    epoch = mmm_start_linearized_op();
+    epoch = mmm_start_linearized_op(thread);
 
     view1 = woolhat_view_epoch(&set1->woolhat_instance, &num1, epoch);
     view2 = woolhat_view_epoch(&set2->woolhat_instance, &num2, epoch);
@@ -208,14 +210,14 @@ c4m_set_union(c4m_set_t *set1, c4m_set_t *set2)
 
     while ((i < num1) && (j < num2)) {
         if (view1[i].sort_epoch < view2[j].sort_epoch) {
-            if (woolhat_add(&ret->woolhat_instance, view1[i].hv, view1[i].item)
+            if (woolhat_add_mmm(&ret->woolhat_instance, thread, view1[i].hv, view1[i].item)
                 && set1->pre_return_hook) {
                 (*set1->pre_return_hook)(set1, view1[i].item);
             }
             i++;
         }
         else {
-            if (woolhat_add(&ret->woolhat_instance, view2[j].hv, view2[j].item)
+            if (woolhat_add_mmm(&ret->woolhat_instance, thread, view2[j].hv, view2[j].item)
                 && set2->pre_return_hook) {
                 (*set2->pre_return_hook)(set2, view2[j].item);
             }
@@ -225,7 +227,7 @@ c4m_set_union(c4m_set_t *set1, c4m_set_t *set2)
     }
 
     while (i < num1) {
-        if (woolhat_add(&ret->woolhat_instance, view1[i].hv, view1[i].item)
+        if (woolhat_add_mmm(&ret->woolhat_instance, thread, view1[i].hv, view1[i].item)
             && set1->pre_return_hook) {
             (*set1->pre_return_hook)(set1, view1[i].item);
         }
@@ -233,14 +235,14 @@ c4m_set_union(c4m_set_t *set1, c4m_set_t *set2)
     }
 
     while (j < num2) {
-        if (woolhat_add(&ret->woolhat_instance, view2[j].hv, view2[j].item)
+        if (woolhat_add_mmm(&ret->woolhat_instance, thread, view2[j].hv, view2[j].item)
             && set2->pre_return_hook) {
             (*set2->pre_return_hook)(set2, view2[j].item);
         }
         j++;
     }
 
-    mmm_end_op();
+    mmm_end_op(thread);
 
     return ret;
 }
@@ -279,8 +281,10 @@ c4m_set_intersection(c4m_set_t *set1, c4m_set_t *set2)
     hatrack_set_view_t *view2;
     uint64_t            i, j;
 
+    mmm_thread_t *thread = mmm_thread_acquire();
+
     ret   = c4m_new(c4m_get_my_type(set1));
-    epoch = mmm_start_linearized_op();
+    epoch = mmm_start_linearized_op(thread);
 
     view1 = woolhat_view_epoch(&set1->woolhat_instance, &num1, epoch);
     view2 = woolhat_view_epoch(&set2->woolhat_instance, &num2, epoch);
@@ -297,7 +301,7 @@ c4m_set_intersection(c4m_set_t *set1, c4m_set_t *set2)
                 (*set1->pre_return_hook)(set1, view1[i].item);
             }
 
-            woolhat_add(&ret->woolhat_instance, view1[i].hv, view1[i].item);
+            woolhat_add_mmm(&ret->woolhat_instance, thread, view1[i].hv, view1[i].item);
             i++;
             j++;
             continue;
@@ -312,7 +316,7 @@ c4m_set_intersection(c4m_set_t *set1, c4m_set_t *set2)
         }
     }
 
-    mmm_end_op();
+    mmm_end_op(thread);
 
     return ret;
 }
@@ -341,8 +345,10 @@ c4m_set_disjunction(c4m_set_t *set1, c4m_set_t *set2)
     hatrack_set_view_t *view2;
     uint64_t            i, j;
 
+    mmm_thread_t *thread = mmm_thread_acquire();
+
     ret   = c4m_new(c4m_get_my_type(set1));
-    epoch = mmm_start_linearized_op();
+    epoch = mmm_start_linearized_op(thread);
 
     view1 = woolhat_view_epoch(&set1->woolhat_instance, &num1, epoch);
     view2 = woolhat_view_epoch(&set2->woolhat_instance, &num2, epoch);
@@ -365,7 +371,7 @@ c4m_set_disjunction(c4m_set_t *set1, c4m_set_t *set2)
                 (*set2->pre_return_hook)(set2, view2[j].item);
             }
 
-            woolhat_add(&ret->woolhat_instance, view2[j].hv, view2[j].item);
+            woolhat_add_mmm(&ret->woolhat_instance, thread, view2[j].hv, view2[j].item);
             j++;
         }
 
@@ -374,12 +380,12 @@ c4m_set_disjunction(c4m_set_t *set1, c4m_set_t *set2)
                 (*set1->pre_return_hook)(set1, view1[i].item);
             }
 
-            woolhat_add(&ret->woolhat_instance, view1[i].hv, view1[i].item);
+            woolhat_add_mmm(&ret->woolhat_instance, thread, view1[i].hv, view1[i].item);
             i++;
         }
     }
 
-    mmm_end_op();
+    mmm_end_op(thread);
 
     return ret;
 }

--- a/src/hatrack/hash/ballcap.c
+++ b/src/hatrack/hash/ballcap.c
@@ -53,6 +53,8 @@
 
 #include <stdlib.h>
 
+#ifndef HATRACK_NO_PTHREAD
+
 // clang-format off
 
        ballcap_store_t *ballcap_store_new    (uint64_t);
@@ -943,3 +945,5 @@ ballcap_store_migrate(ballcap_store_t *store, ballcap_t *top)
 
     return new_store;
 }
+
+#endif

--- a/src/hatrack/hash/crown-internal.h
+++ b/src/hatrack/hash/crown-internal.h
@@ -30,14 +30,20 @@ enum64(crown_flag_t,
  * part of the public API.
  */
 
-// clang-format off
-crown_store_t    *crown_store_new    (uint64_t);
-void             *crown_store_get    (crown_store_t *, hatrack_hash_t, bool *);
-void             *crown_store_put    (crown_store_t *, crown_t *,
-				      hatrack_hash_t, void *, bool *, uint64_t);
-void             *crown_store_replace(crown_store_t *, crown_t *,
-				      hatrack_hash_t, void *, bool *, uint64_t);
-bool              crown_store_add    (crown_store_t *, crown_t *,
-				      hatrack_hash_t, void *, uint64_t);
-void             *crown_store_remove (crown_store_t *, crown_t *,
-				      hatrack_hash_t, bool *, uint64_t);
+extern crown_store_t *
+crown_store_new(uint64_t size);
+
+extern void *
+crown_store_get(crown_store_t *, hatrack_hash_t, bool *);
+
+extern void *
+crown_store_put(crown_store_t *, mmm_thread_t *, crown_t *, hatrack_hash_t, void *, bool *, uint64_t);
+
+extern void *
+crown_store_replace(crown_store_t *, mmm_thread_t *, crown_t *, hatrack_hash_t, void *, bool *, uint64_t);
+
+extern bool
+crown_store_add(crown_store_t *, mmm_thread_t *, crown_t *, hatrack_hash_t, void *, uint64_t);
+
+extern void *
+crown_store_remove(crown_store_t *, mmm_thread_t *, crown_t *, hatrack_hash_t, bool *, uint64_t);

--- a/src/hatrack/hash/duncecap.c
+++ b/src/hatrack/hash/duncecap.c
@@ -36,6 +36,8 @@
 
 #include <stdlib.h>
 
+#ifndef HATRACK_NO_PTHREAD
+
 // clang-format off
 static duncecap_store_t *duncecap_store_new    (uint64_t);
 static void             *duncecap_store_get    (duncecap_store_t *,
@@ -876,3 +878,5 @@ duncecap_migrate(duncecap_t *self)
 
     return;
 }
+
+#endif

--- a/src/hatrack/hash/duncecap.c
+++ b/src/hatrack/hash/duncecap.c
@@ -272,6 +272,12 @@ duncecap_get(duncecap_t *self, hatrack_hash_t hv, bool *found)
     return ret;
 }
 
+void *
+duncecap_get_mmm(duncecap_t *self, mmm_thread_t *thread, hatrack_hash_t hv, bool *found)
+{
+    return duncecap_get(self, hv, found);
+}
+
 /* duncecap_put()
  *
  * Lock the hash table for writing, and when we get ownership of the
@@ -305,6 +311,12 @@ duncecap_put(duncecap_t *self, hatrack_hash_t hv, void *item, bool *found)
     }
 
     return ret;
+}
+
+void *
+duncecap_put_mmm(duncecap_t *self, mmm_thread_t *thread, hatrack_hash_t hv, void *item, bool *found)
+{
+    return duncecap_put(self, hv, item, found);
 }
 
 /* duncecap_replace()
@@ -344,6 +356,12 @@ duncecap_replace(duncecap_t *self, hatrack_hash_t hv, void *item, bool *found)
     return ret;
 }
 
+void *
+duncecap_replace_mmm(duncecap_t *self, mmm_thread_t *thread, hatrack_hash_t hv, void *item, bool *found)
+{
+    return duncecap_replace(self, hv, item, found);
+}
+
 /* duncecap_add()
  *
  * Lock the hash table for writing, and when we get ownership of the
@@ -376,6 +394,12 @@ duncecap_add(duncecap_t *self, hatrack_hash_t hv, void *item)
     }
 
     return ret;
+}
+
+bool
+duncecap_add_mmm(duncecap_t *self, mmm_thread_t *thread, hatrack_hash_t hv, void *item)
+{
+    return duncecap_add(self, hv, item);
 }
 
 /* duncecap_remove()
@@ -418,6 +442,12 @@ duncecap_remove(duncecap_t *self, hatrack_hash_t hv, bool *found)
     return ret;
 }
 
+void *
+duncecap_remove_mmm(duncecap_t *self, mmm_thread_t *thread, hatrack_hash_t hv, bool *found)
+{
+    return duncecap_remove(self, hv, found);
+}
+
 /* duncecap_len()
  *
  * Returns the approximate number of items currently in the
@@ -430,6 +460,12 @@ uint64_t
 duncecap_len(duncecap_t *self)
 {
     return self->item_count;
+}
+
+uint64_t
+duncecap_len_mmm(duncecap_t *self, mmm_thread_t *thread)
+{
+    return duncecap_len(self);
 }
 
 /* duncecap_view()
@@ -497,6 +533,12 @@ duncecap_view(duncecap_t *self, uint64_t *num, bool sort)
 
     duncecap_viewer_exit(self, store);
     return view;
+}
+
+hatrack_view_t *
+duncecap_view_mmm(duncecap_t *self, mmm_thread_t *thread, uint64_t *num, bool sort)
+{
+    return duncecap_view(self, num, sort);
 }
 
 // clang-format off

--- a/src/hatrack/hash/hihat-a.c
+++ b/src/hatrack/hash/hihat-a.c
@@ -42,6 +42,7 @@
 #include "../hatrack-internal.h"
 
 #include <stdlib.h>
+#include <time.h>
 
 // clang-format off
 static hihat_store_t *hihat_a_store_new    (uint64_t);

--- a/src/hatrack/hash/newshat.c
+++ b/src/hatrack/hash/newshat.c
@@ -31,6 +31,8 @@
 
 #include <stdlib.h>
 
+#ifndef HATRACK_NO_PTHREAD
+
 // clang-format off
 
 // Not static, because tophat needs to call it, but nonetheless, don't
@@ -1002,3 +1004,5 @@ newshat_store_migrate(newshat_store_t *store, newshat_t *top)
 
     return new_store;
 }
+
+#endif

--- a/src/hatrack/hash/refhat.c
+++ b/src/hatrack/hash/refhat.c
@@ -214,6 +214,12 @@ refhat_get(refhat_t *self, hatrack_hash_t hv, bool *found)
     __builtin_unreachable();
 }
 
+void *
+refhat_get_mmm(refhat_t *self, mmm_thread_t *thread, hatrack_hash_t hv, bool *found)
+{
+    return refhat_get(self, hv, found);
+}
+
 /* refhat_put()
  *
  * This function will insert the item into the table, whether or not
@@ -288,6 +294,12 @@ refhat_put(refhat_t *self, hatrack_hash_t hv, void *item, bool *found)
     __builtin_unreachable();
 }
 
+void *
+refhat_put_mmm(refhat_t *self, mmm_thread_t *thread, hatrack_hash_t hv, void *item, bool *found)
+{
+    return refhat_put(self, hv, item, found);
+}
+
 /* refhat_replace()
  *
  * This function replaces an item in the hash table, returning the old
@@ -344,6 +356,12 @@ refhat_replace(refhat_t *self, hatrack_hash_t hv, void *item, bool *found)
         bix = (bix + 1) & self->last_slot;
     }
     __builtin_unreachable();
+}
+
+void *
+refhat_replace_mmm(refhat_t *self, mmm_thread_t *thread, hatrack_hash_t hv, void *item, bool *found)
+{
+    return refhat_replace(self, hv, item, found);
 }
 
 /* refhat_add()
@@ -405,6 +423,12 @@ refhat_add(refhat_t *self, hatrack_hash_t hv, void *item)
     __builtin_unreachable();
 }
 
+bool
+refhat_add_mmm(refhat_t *self, mmm_thread_t *thread, hatrack_hash_t hv, void *item)
+{
+    return refhat_add(self, hv, item);
+}
+
 /* refhat_remove()
  *
  * This function removes the item associated with the hash value from
@@ -458,6 +482,12 @@ refhat_remove(refhat_t *self, hatrack_hash_t hv, bool *found)
     __builtin_unreachable();
 }
 
+void *
+refhat_remove_mmm(refhat_t *self, mmm_thread_t *thread, hatrack_hash_t hv, bool *found)
+{
+    return refhat_remove(self, hv, found);
+}
+
 /* refhat_len()
  *
  * Returns the number of items currently in the table. Note that we
@@ -469,6 +499,12 @@ uint64_t
 refhat_len(refhat_t *self)
 {
     return self->item_count;
+}
+
+uint64_t
+refhat_len_mmm(refhat_t *self, mmm_thread_t *thread)
+{
+    return refhat_len(self);
 }
 
 /* refhat_view()
@@ -525,6 +561,12 @@ refhat_view(refhat_t *self, uint64_t *num, bool sort)
     }
 
     return view;
+}
+
+hatrack_view_t *
+refhat_view_mmm(refhat_t *self, mmm_thread_t *thread, uint64_t *num, bool sort)
+{
+    return refhat_view(self, num, sort);
 }
 
 /* refhat_migrate()

--- a/src/hatrack/hash/swimcap.c
+++ b/src/hatrack/hash/swimcap.c
@@ -46,18 +46,18 @@
 static swimcap_store_t *swimcap_store_new    (uint64_t);
 static void            *swimcap_store_get    (swimcap_store_t *,
 					      hatrack_hash_t, bool *);
-static void            *swimcap_store_put    (swimcap_store_t *,
+static void            *swimcap_store_put    (swimcap_store_t *, mmm_thread_t *,
 					      swimcap_t *, hatrack_hash_t,
 					      void *, bool *);
-static void            *swimcap_store_replace(swimcap_store_t *,
+static void            *swimcap_store_replace(swimcap_store_t *, mmm_thread_t *,
 					      hatrack_hash_t, void *, bool *);
-static bool             swimcap_store_add    (swimcap_store_t *,
+static bool             swimcap_store_add    (swimcap_store_t *, mmm_thread_t *,
 					      swimcap_t *, hatrack_hash_t,
 					      void *);
-static void            *swimcap_store_remove (swimcap_store_t *,
+static void            *swimcap_store_remove (swimcap_store_t *, mmm_thread_t *,
 					      swimcap_t *, hatrack_hash_t,
 					      bool *);
-static void             swimcap_migrate      (swimcap_t *);
+static void             swimcap_migrate      (swimcap_t *, mmm_thread_t *);
 // clang-format on
 
 /* swimcap_new()
@@ -145,7 +145,7 @@ void
 swimcap_cleanup(swimcap_t *self)
 {
     pthread_mutex_destroy(&self->write_mutex);
-    mmm_retire(self->store_current);
+    mmm_retire_unused(self->store_current);
 
     return;
 }
@@ -221,17 +221,23 @@ swimcap_delete(swimcap_t *self)
  * swimcap.c for more details if needed.
  */
 void *
-swimcap_get(swimcap_t *self, hatrack_hash_t hv, bool *found)
+swimcap_get_mmm(swimcap_t *self, mmm_thread_t *thread, hatrack_hash_t hv, bool *found)
 {
     void *ret;
 
-    mmm_start_basic_op();
+    mmm_start_basic_op(thread);
 
     ret = swimcap_store_get(self->store_current, hv, found);
 
-    mmm_end_op();
+    mmm_end_op(thread);
 
     return ret;
+}
+
+void *
+swimcap_get(swimcap_t *self, hatrack_hash_t hv, bool *found)
+{
+    return swimcap_get_mmm(self, mmm_thread_acquire(), hv, found);
 }
 
 /* swimcap_put()
@@ -260,7 +266,7 @@ swimcap_get(swimcap_t *self, hatrack_hash_t hv, bool *found)
  * in a single object in the item parameter.
  */
 void *
-swimcap_put(swimcap_t *self, hatrack_hash_t hv, void *item, bool *found)
+swimcap_put_mmm(swimcap_t *self, mmm_thread_t *thread, hatrack_hash_t hv, void *item, bool *found)
 {
     void *ret;
 
@@ -268,13 +274,19 @@ swimcap_put(swimcap_t *self, hatrack_hash_t hv, void *item, bool *found)
         abort();
     }
 
-    ret = swimcap_store_put(self->store_current, self, hv, item, found);
+    ret = swimcap_store_put(self->store_current, thread, self, hv, item, found);
 
     if (pthread_mutex_unlock(&self->write_mutex)) {
         abort();
     }
 
     return ret;
+}
+
+void *
+swimcap_put(swimcap_t *self, hatrack_hash_t hv, void *item, bool *found)
+{
+    return swimcap_put_mmm(self, mmm_thread_acquire(), hv, item, found);
 }
 
 /* swimcap_replace()
@@ -296,7 +308,7 @@ swimcap_put(swimcap_t *self, hatrack_hash_t hv, void *item, bool *found)
  * in a single object in the item parameter.
  */
 void *
-swimcap_replace(swimcap_t *self, hatrack_hash_t hv, void *item, bool *found)
+swimcap_replace_mmm(swimcap_t *self, mmm_thread_t *thread, hatrack_hash_t hv, void *item, bool *found)
 {
     void *ret;
 
@@ -304,13 +316,19 @@ swimcap_replace(swimcap_t *self, hatrack_hash_t hv, void *item, bool *found)
         abort();
     }
 
-    ret = swimcap_store_replace(self->store_current, hv, item, found);
+    ret = swimcap_store_replace(self->store_current, thread, hv, item, found);
 
     if (pthread_mutex_unlock(&self->write_mutex)) {
         abort();
     }
 
     return ret;
+}
+
+void *
+swimcap_replace(swimcap_t *self, hatrack_hash_t hv, void *item, bool *found)
+{
+    return swimcap_replace_mmm(self, mmm_thread_acquire(), hv, item, found);
 }
 
 /* swimcap_add()
@@ -329,7 +347,7 @@ swimcap_replace(swimcap_t *self, hatrack_hash_t hv, void *item, bool *found)
  * Returns true if the insertion is succesful, and false otherwise.
  */
 bool
-swimcap_add(swimcap_t *self, hatrack_hash_t hv, void *item)
+swimcap_add_mmm(swimcap_t *self, mmm_thread_t *thread, hatrack_hash_t hv, void *item)
 {
     bool ret;
 
@@ -337,13 +355,19 @@ swimcap_add(swimcap_t *self, hatrack_hash_t hv, void *item)
         abort();
     }
 
-    ret = swimcap_store_add(self->store_current, self, hv, item);
+    ret = swimcap_store_add(self->store_current, thread, self, hv, item);
 
     if (pthread_mutex_unlock(&self->write_mutex)) {
         abort();
     }
 
     return ret;
+}
+
+bool
+swimcap_add(swimcap_t *self, hatrack_hash_t hv, void *item)
+{
+    return swimcap_add_mmm(self, mmm_thread_acquire(), hv, item);
 }
 
 /*
@@ -368,7 +392,7 @@ swimcap_add(swimcap_t *self, hatrack_hash_t hv, void *item)
  * behavior is the same as if the item was never in the table.
  */
 void *
-swimcap_remove(swimcap_t *self, hatrack_hash_t hv, bool *found)
+swimcap_remove_mmm(swimcap_t *self, mmm_thread_t *thread, hatrack_hash_t hv, bool *found)
 {
     void *ret;
 
@@ -376,13 +400,19 @@ swimcap_remove(swimcap_t *self, hatrack_hash_t hv, bool *found)
         abort();
     }
 
-    ret = swimcap_store_remove(self->store_current, self, hv, found);
+    ret = swimcap_store_remove(self->store_current, thread, self, hv, found);
 
     if (pthread_mutex_unlock(&self->write_mutex)) {
         abort();
     }
 
     return ret;
+}
+
+void *
+swimcap_remove(swimcap_t *self, hatrack_hash_t hv, bool *found)
+{
+    return swimcap_remove_mmm(self, mmm_thread_acquire(), hv, found);
 }
 
 /* swimcap_len()
@@ -395,10 +425,17 @@ swimcap_remove(swimcap_t *self, hatrack_hash_t hv, bool *found)
  * the time of check could be dramatically different by the time of
  * use.
  */
+
 uint64_t
 swimcap_len(swimcap_t *self)
 {
     return self->item_count;
+}
+
+uint64_t
+swimcap_len_mmm(swimcap_t *self, mmm_thread_t *thread)
+{
+    return swimcap_len(self);
 }
 
 /* swimcap_view()
@@ -417,7 +454,7 @@ swimcap_len(swimcap_t *self)
  * write lock, just as we did with swimcap.
  */
 hatrack_view_t *
-swimcap_view(swimcap_t *self, uint64_t *num, bool sort)
+swimcap_view_mmm(swimcap_t *self, mmm_thread_t *thread, uint64_t *num, bool sort)
 {
     hatrack_view_t   *view;
     swimcap_store_t  *store;
@@ -434,7 +471,7 @@ swimcap_view(swimcap_t *self, uint64_t *num, bool sort)
         abort();
     }
 #else
-    mmm_start_basic_op();
+    mmm_start_basic_op(thread);
 #endif
 
     store     = self->store_current;
@@ -472,7 +509,7 @@ swimcap_view(swimcap_t *self, uint64_t *num, bool sort)
             abort();
         }
 #else
-        mmm_end_op();
+        mmm_end_op(thread);
 #endif
 
         return NULL;
@@ -489,10 +526,16 @@ swimcap_view(swimcap_t *self, uint64_t *num, bool sort)
         abort();
     }
 #else
-    mmm_end_op();
+    mmm_end_op(thread);
 #endif
 
     return view;
+}
+
+hatrack_view_t *
+swimcap_view(swimcap_t *self, uint64_t *num, bool sort)
+{
+    return swimcap_view_mmm(self, mmm_thread_acquire(), num, sort);
 }
 
 /*
@@ -572,6 +615,7 @@ swimcap_store_get(swimcap_store_t *self, hatrack_hash_t hv, bool *found)
 
 static void *
 swimcap_store_put(swimcap_store_t *self,
+                  mmm_thread_t    *thread,
                   swimcap_t       *top,
                   hatrack_hash_t   hv,
                   void            *item,
@@ -623,9 +667,10 @@ swimcap_store_put(swimcap_store_t *self,
 
         if (hatrack_bucket_unreserved(cur->hv)) {
             if (self->used_count + 1 == self->threshold) {
-                swimcap_migrate(top);
+                swimcap_migrate(top, thread);
 
                 return swimcap_store_put(top->store_current,
+                                         thread,
                                          top,
                                          hv,
                                          item,
@@ -655,6 +700,7 @@ swimcap_store_put(swimcap_store_t *self,
 
 static void *
 swimcap_store_replace(swimcap_store_t *self,
+                      mmm_thread_t    *thread,
                       hatrack_hash_t   hv,
                       void            *item,
                       bool            *found)
@@ -710,6 +756,7 @@ swimcap_store_replace(swimcap_store_t *self,
 
 static bool
 swimcap_store_add(swimcap_store_t *self,
+                  mmm_thread_t    *thread,
                   swimcap_t       *top,
                   hatrack_hash_t   hv,
                   void            *item)
@@ -747,9 +794,9 @@ swimcap_store_add(swimcap_store_t *self,
         // time of the operation, and we should add.
         if (hatrack_bucket_unreserved(cur->hv)) {
             if (self->used_count + 1 == self->threshold) {
-                swimcap_migrate(top);
+                swimcap_migrate(top, thread);
 
-                return swimcap_store_add(top->store_current, top, hv, item);
+                return swimcap_store_add(top->store_current, thread, top, hv, item);
             }
 
             self->used_count++;
@@ -770,6 +817,7 @@ swimcap_store_add(swimcap_store_t *self,
 
 void *
 swimcap_store_remove(swimcap_store_t *self,
+                     mmm_thread_t    *thread,
                      swimcap_t       *top,
                      hatrack_hash_t   hv,
                      bool            *found)
@@ -825,7 +873,7 @@ swimcap_store_remove(swimcap_store_t *self,
 }
 
 static void
-swimcap_migrate(swimcap_t *self)
+swimcap_migrate(swimcap_t *self, mmm_thread_t *thread)
 {
     swimcap_store_t  *cur_store;
     swimcap_store_t  *new_store;
@@ -839,7 +887,7 @@ swimcap_migrate(swimcap_t *self)
 
     cur_store     = self->store_current;
     cur_last_slot = cur_store->last_slot;
-    new_size      = hatrack_new_size(cur_last_slot, swimcap_len(self) + 1);
+    new_size      = hatrack_new_size(cur_last_slot, swimcap_len_mmm(self, thread) + 1);
     new_last_slot = new_size - 1;
     new_store     = swimcap_store_new(new_size);
 
@@ -884,7 +932,7 @@ swimcap_migrate(swimcap_t *self)
      * after the retirement epoch, which would constitute a
      * use-after-free bug.
      */
-    mmm_retire(cur_store);
+    mmm_retire(thread, cur_store);
 
     return;
 }

--- a/src/hatrack/hash/swimcap.c
+++ b/src/hatrack/hash/swimcap.c
@@ -40,6 +40,8 @@
 
 #include <stdlib.h>
 
+#ifndef HATRACK_NO_PTHREAD
+
 // clang-format off
 static swimcap_store_t *swimcap_store_new    (uint64_t);
 static void            *swimcap_store_get    (swimcap_store_t *,
@@ -886,3 +888,5 @@ swimcap_migrate(swimcap_t *self)
 
     return;
 }
+
+#endif

--- a/src/hatrack/hash/tophat.c
+++ b/src/hatrack/hash/tophat.c
@@ -1346,8 +1346,9 @@ tophat_migrate_to_woolhat(tophat_t *self)
 
     new_table->store_current->used_count = ctx->item_count;
 
-    if (mmm_epoch < ctx->next_epoch) {
-	atomic_store(&mmm_epoch, ctx->next_epoch);
+    uint64_t epoch = atomic_load(&mmm_epoch);
+    while (epoch < ctx->next_epoch) {
+        CAS(&mmm_epoch, &epoch, ctx->next_epoch);
     }
 
     atomic_store(&self->mt_table, new_table);

--- a/src/hatrack/hash/tophat.c
+++ b/src/hatrack/hash/tophat.c
@@ -38,6 +38,8 @@
 
 #include <stdlib.h>
 
+#ifndef HATRACK_NO_PTHREAD
+
 // clang-format off
 static void             tophat_init_base     (tophat_t *, char);
 static void		tophat_st_migrate    (tophat_st_ctx_t *);
@@ -1356,3 +1358,5 @@ tophat_migrate_to_woolhat(tophat_t *self)
 
     return (void *)new_table;
 }
+
+#endif

--- a/src/hatrack/hash/witchhat-internal.h
+++ b/src/hatrack/hash/witchhat-internal.h
@@ -15,9 +15,24 @@ enum64(witchhat_flag_t,
  * I'm going to explicitly leave these here, instead of going back to
  * making them static.
  */
-witchhat_store_t *witchhat_store_new(uint64_t);
-void             *witchhat_store_get(witchhat_store_t *, hatrack_hash_t, bool *);
-void             *witchhat_store_put(witchhat_store_t *, witchhat_t *, hatrack_hash_t, void *, bool *, uint64_t);
-void             *witchhat_store_replace(witchhat_store_t *, witchhat_t *, hatrack_hash_t, void *, bool *, uint64_t);
-bool              witchhat_store_add(witchhat_store_t *, witchhat_t *, hatrack_hash_t, void *, uint64_t);
-void             *witchhat_store_remove(witchhat_store_t *, witchhat_t *, hatrack_hash_t, bool *, uint64_t);
+
+extern hatrack_view_t *
+witchhat_view_no_mmm(witchhat_t *, uint64_t *, bool);
+
+extern witchhat_store_t *
+witchhat_store_new(uint64_t size);
+
+extern void *
+witchhat_store_get(witchhat_store_t *, hatrack_hash_t, bool *);
+
+extern void *
+witchhat_store_put(witchhat_store_t *, mmm_thread_t *, witchhat_t *, hatrack_hash_t, void *, bool *, uint64_t);
+
+extern void *
+witchhat_store_replace(witchhat_store_t *, mmm_thread_t *, witchhat_t *, hatrack_hash_t, void *, bool *, uint64_t);
+
+extern bool
+witchhat_store_add(witchhat_store_t *, mmm_thread_t *, witchhat_t *, hatrack_hash_t, void *, uint64_t);
+
+extern void *
+witchhat_store_remove(witchhat_store_t *, mmm_thread_t *, witchhat_t *, hatrack_hash_t, bool *, uint64_t);

--- a/src/hatrack/hatrack-internal.h
+++ b/src/hatrack/hatrack-internal.h
@@ -192,16 +192,16 @@ hatrack_not_found(bool *found)
 }
 
 static inline void *
-hatrack_found_w_mmm(bool *found, void *ret)
+hatrack_found_w_mmm(mmm_thread_t *thread, bool *found, void *ret)
 {
-    mmm_end_op();
+    mmm_end_op(thread);
     return hatrack_found(found, ret);
 }
 
 static inline void *
-hatrack_not_found_w_mmm(bool *found)
+hatrack_not_found_w_mmm(mmm_thread_t *thread, bool *found)
 {
-    mmm_end_op();
+    mmm_end_op(thread);
     return hatrack_not_found(found);
 }
 

--- a/src/hatrack/queue/debug.c
+++ b/src/hatrack/queue/debug.c
@@ -92,7 +92,7 @@ debug_dump(uint64_t max_msgs)
 void
 debug_thread(void)
 {
-    debug_other_thread(mmm_mytid);
+    debug_other_thread(mmm_thread->tid);
 
     return;
 }

--- a/src/hatrack/queue/debug.c
+++ b/src/hatrack/queue/debug.c
@@ -92,7 +92,7 @@ debug_dump(uint64_t max_msgs)
 void
 debug_thread(void)
 {
-    debug_other_thread(mmm_thread->tid);
+    debug_other_thread(mmm_thread_acquire()->tid);
 
     return;
 }

--- a/src/hatrack/queue/debug.c
+++ b/src/hatrack/queue/debug.c
@@ -19,7 +19,6 @@
  *
  *  Author:         John Viega, john@zork.org
  */
-
 #include "hatrack/debug.h"
 
 #ifdef HATRACK_DEBUG

--- a/src/hatrack/queue/hatring.c
+++ b/src/hatrack/queue/hatring.c
@@ -27,6 +27,7 @@
 #include "hatrack/hatrack_common.h"
 
 #include <string.h>
+#include <time.h>
 
 #include "hatring-internal.h"
 #include "../hatrack-internal.h"

--- a/src/hatrack/support/mmm.c
+++ b/src/hatrack/support/mmm.c
@@ -27,8 +27,13 @@
 #include "hatrack/hatomic.h"
 
 #include <stdlib.h>
+#ifdef HATRACK_NO_PTHREAD
+#include <stdio.h>
+#else
+#include <pthread.h>
+#endif
 
-#ifdef HATRACK_DEBUG
+#ifdef HATRACK_MMM_DEBUG
 #include "hatrack/debug.h"
 #include <string.h>
 #endif
@@ -39,16 +44,15 @@ struct mmm_free_tids_st {
     uint64_t         tid;
 };
 
-__thread mmm_thread_t *mmm_thread;
-_Atomic uint64_t       mmm_nexttid;
+static _Atomic uint64_t mmm_nexttid;
 
 _Atomic uint64_t mmm_epoch = HATRACK_EPOCH_FIRST;
 
 static uint64_t mmm_reservations[HATRACK_THREADS_MAX];
 
-static void mmm_empty(void);
+static void mmm_empty(mmm_thread_t *thread);
 
-#ifdef HATRACK_DEBUG
+#ifdef HATRACK_MMM_DEBUG
 __attribute__((unused)) static void
 hatrack_debug_mmm(void *addr, char *msg);
 
@@ -73,6 +77,11 @@ hatrack_debug_mmm(void *addr, char *msg);
 #define HATRACK_RETIRE_UNUSED_CTR() HATRACK_CTR(HATRACK_CTR_RETIRE_UNUSED)
 #endif
 
+static mmm_thread_t *mmm_thread_acquire_default(void *aux, size_t size);
+
+static void                   *mmm_thread_aux;
+static mmm_thread_acquire_func mmm_thread_acquire_fn = mmm_thread_acquire_default;
+
 /*
  * We want to avoid overrunning the reservations array that our memory
  * management system uses.
@@ -89,64 +98,20 @@ hatrack_debug_mmm(void *addr, char *msg);
 
 static _Atomic(mmm_free_tids_t *) mmm_free_tids;
 
-/* This grabs an mmm-specific threadid and stashes it in the
- * thread-local variable mmm_thread->tid.
- *
- * We have a fixed number of TIDS to give out though (controlled by
- * the preprocessor variable, HATRACK_THREADS_MAX).  We give them out
- * sequentially till they're done, and then we give out ones that have
- * been "given back", which are stored on a stack (mmm_free_tids).
- *
- * If we finally run out, we abort.
- */
-void
-mmm_register_thread(void)
-{
-    mmm_free_tids_t *head;
-
-    if (NULL == mmm_thread) {
-        return;
-    }
-    mmm_thread      = hatrack_malloc(sizeof(mmm_thread_t));
-    mmm_thread->tid = atomic_fetch_add(&mmm_nexttid, 1);
-
-    if (mmm_thread->tid >= HATRACK_THREADS_MAX) {
-        head = atomic_load(&mmm_free_tids);
-
-        do {
-            if (!head) {
-                abort();
-            }
-        } while (!CAS(&mmm_free_tids, &head, head->next));
-
-        mmm_thread->tid = head->tid;
-        mmm_retire(head);
-    }
-
-    mmm_reservations[mmm_thread->tid] = HATRACK_EPOCH_UNRESERVED;
-
-    return;
-}
-
 // Call when a thread exits to add to the free TID stack.
 static void
-mmm_tid_giveback(void)
+mmm_tid_giveback(mmm_thread_t *thread)
 {
     mmm_free_tids_t *new_head;
     mmm_free_tids_t *old_head;
 
     new_head      = mmm_alloc(sizeof(mmm_free_tids_t));
-    new_head->tid = mmm_thread->tid;
+    new_head->tid = thread->tid;
     old_head      = atomic_load(&mmm_free_tids);
 
     do {
         new_head->next = old_head;
     } while (!CAS(&mmm_free_tids, &old_head, new_head));
-
-    hatrack_free(mmm_thread, sizeof(mmm_thread_t));
-    mmm_thread = NULL;
-
-    return;
 }
 
 // This is here for convenience of testing; generally this
@@ -155,8 +120,86 @@ void
 mmm_reset_tids(void)
 {
     atomic_store(&mmm_nexttid, 0);
+}
 
-    return;
+#ifndef HATRACK_NO_PTHREAD
+static pthread_key_t mmm_thread_pkey;
+
+struct mmm_pthread {
+    size_t size;
+    char   data[];
+};
+
+static void
+mmm_thread_release_pthread(void *arg)
+{
+    pthread_setspecific(mmm_thread_pkey, NULL);
+
+    struct mmm_pthread *pt = arg;
+    mmm_thread_release((mmm_thread_t *)pt->data);
+    hatrack_free(arg, pt->size);
+}
+
+static void
+mmm_thread_acquire_init_pthread(void)
+{
+    pthread_key_create(&mmm_thread_pkey, mmm_thread_release_pthread);
+}
+#endif
+
+static mmm_thread_t *
+mmm_thread_acquire_default(void *aux, size_t size)
+{
+#ifdef HATRACK_NO_PTHREAD
+    fprintf(stderr, "No implementation for mmm_thread_acquire defined\n");
+    abort();
+#else
+    static pthread_once_t init = PTHREAD_ONCE_INIT;
+    pthread_once(&init, mmm_thread_acquire_init_pthread);
+
+    struct mmm_pthread *pt = pthread_getspecific(mmm_thread_pkey);
+    if (NULL == pt) {
+        pt       = hatrack_zalloc(sizeof(struct mmm_pthread) + size);
+        pt->size = size;
+        pthread_setspecific(mmm_thread_pkey, pt);
+    }
+    return (mmm_thread_t *)pt->data;
+#endif
+}
+
+mmm_thread_t *
+mmm_thread_acquire(void)
+{
+    mmm_thread_t *thread = mmm_thread_acquire_fn(mmm_thread_aux,
+                                                 sizeof(mmm_thread_t));
+
+    if (!thread->initialized) {
+        thread->initialized = true;
+
+        /* We have a fixed number of TIDS to give out though (controlled by
+         * the preprocessor variable, HATRACK_THREADS_MAX).  We give them out
+         * sequentially till they're done, and then we give out ones that have
+         * been "given back", which are stored on a stack (mmm_free_tids).
+         *
+         * If we finally run out, we abort.
+         */
+        thread->tid = atomic_fetch_add(&mmm_nexttid, 1);
+        if (thread->tid >= HATRACK_THREADS_MAX) {
+            mmm_free_tids_t *head = atomic_load(&mmm_free_tids);
+            do {
+                if (!head) {
+                    abort();
+                }
+            } while (!CAS(&mmm_free_tids, &head, head->next));
+
+            thread->tid = head->tid;
+            mmm_retire(head);
+        }
+
+        mmm_reservations[thread->tid] = HATRACK_EPOCH_UNRESERVED;
+    }
+
+    return thread;
 }
 
 /* For now, our cleanup function spins until it is able to retire
@@ -165,21 +208,24 @@ mmm_reset_tids(void)
  * contents to an "ophan" list.
  */
 void
-mmm_clean_up_before_exit(void)
+mmm_thread_release(mmm_thread_t *thread)
 {
-    if (NULL == mmm_thread) {
-        return;
-    }
-
     mmm_end_op();
 
-    while (mmm_thread->retire_list) {
-        mmm_empty();
+    while (thread->retire_list) {
+        mmm_empty(thread);
     }
 
-    mmm_tid_giveback();
+    mmm_tid_giveback(thread);
 
     return;
+}
+
+void
+mmm_setthreadfns(mmm_thread_acquire_func acquirefn, void *aux)
+{
+    mmm_thread_acquire_fn = acquirefn != NULL ? acquirefn : mmm_thread_acquire_default;
+    mmm_thread_aux        = aux;
 }
 
 /* Sets the retirement epoch on the pointer, and adds it to the
@@ -193,6 +239,7 @@ mmm_clean_up_before_exit(void)
 void
 mmm_retire(void *ptr)
 {
+    mmm_thread_t *thread = mmm_thread_acquire();
     mmm_header_t *cell;
 
     cell = mmm_get_header(ptr);
@@ -224,15 +271,15 @@ mmm_retire(void *ptr)
     }
 #endif
 
-    cell->retire_epoch      = atomic_load(&mmm_epoch);
-    cell->next              = mmm_thread->retire_list;
-    mmm_thread->retire_list = cell;
+    cell->retire_epoch  = atomic_load(&mmm_epoch);
+    cell->next          = thread->retire_list;
+    thread->retire_list = cell;
 
     DEBUG_MMM_INTERNAL(cell->data, "mmm_retire");
 
-    if (++mmm_thread->retire_ctr & HATRACK_RETIRE_FREQ) {
-        mmm_thread->retire_ctr = 0;
-        mmm_empty();
+    if (++thread->retire_ctr & HATRACK_RETIRE_FREQ) {
+        thread->retire_ctr = 0;
+        mmm_empty(thread);
     }
 
     return;
@@ -249,7 +296,7 @@ mmm_retire(void *ptr)
  * and free everything else.
  */
 static void
-mmm_empty(void)
+mmm_empty(mmm_thread_t *thread)
 {
     mmm_header_t *tmp;
     mmm_header_t *cell;
@@ -296,12 +343,12 @@ mmm_empty(void)
      * something on the retire list, so cell will never start out
      * empty.
      */
-    cell = mmm_thread->retire_list;
+    cell = thread->retire_list;
 
     // Special-case this, in case we have to delete the head cell,
     // to make sure we reinitialize the linked list right.
-    if (mmm_thread->retire_list->retire_epoch < lowest) {
-        mmm_thread->retire_list = NULL;
+    if (thread->retire_list->retire_epoch < lowest) {
+        thread->retire_list = NULL;
     }
     else {
         while (true) {
@@ -344,8 +391,9 @@ mmm_empty(void)
 void
 mmm_start_basic_op(void)
 {
-    mmm_register_thread();
-    mmm_reservations[mmm_thread->tid] = atomic_load(&mmm_epoch);
+    mmm_thread_t *thread = mmm_thread_acquire();
+
+    mmm_reservations[thread->tid] = atomic_load(&mmm_epoch);
 
     return;
 }
@@ -353,11 +401,12 @@ mmm_start_basic_op(void)
 uint64_t
 mmm_start_linearized_op(void)
 {
+    mmm_thread_t *thread = mmm_thread_acquire();
+
     uint64_t read_epoch;
 
-    mmm_register_thread();
-    mmm_reservations[mmm_thread->tid] = atomic_load(&mmm_epoch);
-    read_epoch                        = atomic_load(&mmm_epoch);
+    mmm_reservations[thread->tid] = atomic_load(&mmm_epoch);
+    read_epoch                    = atomic_load(&mmm_epoch);
 
     HATRACK_YN_CTR_NORET(read_epoch == mmm_reservations[mmm_thread->tid],
                          HATRACK_CTR_LINEAR_EPOCH_EQ);
@@ -368,8 +417,10 @@ mmm_start_linearized_op(void)
 void
 mmm_end_op(void)
 {
+    mmm_thread_t *thread = mmm_thread_acquire();
+
     atomic_signal_fence(memory_order_seq_cst);
-    mmm_reservations[mmm_thread->tid] = HATRACK_EPOCH_UNRESERVED;
+    mmm_reservations[thread->tid] = HATRACK_EPOCH_UNRESERVED;
 
     return;
 }
@@ -474,17 +525,18 @@ mmm_retire_unused(void *ptr)
 void
 mmm_retire_fast(void *ptr)
 {
+    mmm_thread_t *thread = mmm_thread_acquire();
     mmm_header_t *cell;
 
-    cell                    = mmm_get_header(ptr);
-    cell->retire_epoch      = atomic_load(&mmm_epoch);
-    cell->next              = mmm_thread->retire_list;
-    mmm_thread->retire_list = cell;
+    cell                = mmm_get_header(ptr);
+    cell->retire_epoch  = atomic_load(&mmm_epoch);
+    cell->next          = thread->retire_list;
+    thread->retire_list = cell;
 
     return;
 }
 
-#ifdef HATRACK_DEBUG
+#ifdef HATRACK_MMM_DEBUG
 /* Conceptually, this might belong in the debug subsystem. However,
  * this is a specific debug interface for outputting the epoch info
  * associated with an MMM allocation, and as such should live

--- a/src/hatrack/support/mmm.c
+++ b/src/hatrack/support/mmm.c
@@ -35,14 +35,13 @@ struct mmm_free_tids_st {
 };
 
 // clang-format off
-__thread mmm_header_t  *mmm_retire_list  = NULL;
-__thread pthread_once_t mmm_inited       = PTHREAD_ONCE_INIT;
-_Atomic  uint64_t       mmm_epoch        = HATRACK_EPOCH_FIRST;
-_Atomic  uint64_t       mmm_nexttid      = 0;
-__thread int64_t        mmm_mytid        = -1;
-__thread uint64_t       mmm_retire_ctr   = 0;
+__thread mmm_header_t *mmm_retire_list  = NULL;
+_Atomic  uint64_t      mmm_epoch        = HATRACK_EPOCH_FIRST;
+_Atomic  uint64_t      mmm_nexttid      = 0;
+__thread int64_t       mmm_mytid        = -1;
+__thread uint64_t      mmm_retire_ctr   = 0;
 
-         uint64_t       mmm_reservations[HATRACK_THREADS_MAX] = { 0, };
+         uint64_t      mmm_reservations[HATRACK_THREADS_MAX] = { 0, };
 
 // clang-format on
 
@@ -339,7 +338,7 @@ mmm_empty(void)
 void
 mmm_start_basic_op(void)
 {
-    pthread_once(&mmm_inited, mmm_register_thread);
+    mmm_register_thread();
     mmm_reservations[mmm_mytid] = atomic_load(&mmm_epoch);
 
     return;
@@ -350,8 +349,7 @@ mmm_start_linearized_op(void)
 {
     uint64_t read_epoch;
 
-    pthread_once(&mmm_inited, mmm_register_thread);
-
+    mmm_register_thread();
     mmm_reservations[mmm_mytid] = atomic_load(&mmm_epoch);
     read_epoch                  = atomic_load(&mmm_epoch);
 

--- a/src/tests/hash/functional.c
+++ b/src/tests/hash/functional.c
@@ -37,14 +37,12 @@ start_one_functest_thread(void *info)
     test_func_t func;
     bool        ret;
 
-    mmm_register_thread();
+    (void)mmm_thread_acquire();
 
     while (!(func = atomic_load(&test_func)))
         ;
 
     ret = (*test_func)(info);
-
-    mmm_clean_up_before_exit();
 
     return (void *)(int64_t)ret;
 }
@@ -63,7 +61,9 @@ functionality_test(test_func_t func,
     testhat_t       *dict;
 
     atomic_store(&test_func, NULL);
-    atomic_store(&mmm_nexttid, 0); // Reset thread ids.
+
+    extern void mmm_reset_tids(void);
+    mmm_reset_tids();
 
     dict = testhat_new(type);
 

--- a/src/tests/hash/functional.c
+++ b/src/tests/hash/functional.c
@@ -13,7 +13,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
+#include <pthread.h>
 
 typedef struct {
     uint32_t   tid;
@@ -25,13 +25,11 @@ typedef struct {
 
 typedef bool (*test_func_t)(func_test_info_t *);
 
-// clang-format off
 uint32_t            one_thread[]       = {1, 0};
 uint32_t            multiple_threads[] = {2, 4, 8, 20, 100, 0};
 uint32_t            basic_sizes[]      = {10, 100, 1000, 10000, 0};
 uint32_t            shrug_sizes[]      = {1, 0};
 _Atomic test_func_t test_func;
-//  clang-format on
 
 static void *
 start_one_functest_thread(void *info)
@@ -50,7 +48,6 @@ start_one_functest_thread(void *info)
 
     return (void *)(int64_t)ret;
 }
-
 
 static bool
 functionality_test(test_func_t func,
@@ -75,7 +72,7 @@ functionality_test(test_func_t func,
      * do range * 2, just to give us some headroom for other potential
      * functional tests.
      */
-    precompute_hashes(range*2);
+    precompute_hashes(range * 2);
 
     for (i = 0; i < num_threads; i++) {
         info[i].tid   = i;
@@ -101,7 +98,6 @@ functionality_test(test_func_t func,
 
     return true;
 }
-
 
 static void
 run_one_func_test(test_func_t func,
@@ -149,36 +145,36 @@ run_func_test(char       *name,
     fprintf(stderr, "[[ Test: %s ]]\n", name);
     tcount_ix = 0;
     while (tcounts[tcount_ix]) {
-	range_ix = 0;
-	while (ranges[range_ix]) {
-	    fprintf(stderr,
-		    "[%10s] -- Parameters: threads=%4d, "
-		    "iters=%7d, range=%6d\n",
-		    name,
-		    tcounts[tcount_ix],
-		    iters,
-		    ranges[range_ix]);
-	    dict_ix = 0;
-	    while (types[dict_ix]) {
-		info = algorithm_info(types[dict_ix]);
-		if (info->hashbytes != 16) {
-		    dict_ix++;
-		    continue;
-		}
-		if (tcounts[tcount_ix] != 1 && !info->threadsafe) {
-		    dict_ix++;
-		    continue;
-		}
-		run_one_func_test(func,
-				  iters,
-				  types[dict_ix],
-				  ranges[range_ix],
-				  tcounts[tcount_ix]);
-		dict_ix++;
-	    }
-	    range_ix++;
-	}
-	tcount_ix++;
+        range_ix = 0;
+        while (ranges[range_ix]) {
+            fprintf(stderr,
+                    "[%10s] -- Parameters: threads=%4d, "
+                    "iters=%7d, range=%6d\n",
+                    name,
+                    tcounts[tcount_ix],
+                    iters,
+                    ranges[range_ix]);
+            dict_ix = 0;
+            while (types[dict_ix]) {
+                info = algorithm_info(types[dict_ix]);
+                if (info->hashbytes != 16) {
+                    dict_ix++;
+                    continue;
+                }
+                if (tcounts[tcount_ix] != 1 && !info->threadsafe) {
+                    dict_ix++;
+                    continue;
+                }
+                run_one_func_test(func,
+                                  iters,
+                                  types[dict_ix],
+                                  ranges[range_ix],
+                                  tcounts[tcount_ix]);
+                dict_ix++;
+            }
+            range_ix++;
+        }
+        tcount_ix++;
     }
 
     return;
@@ -269,15 +265,15 @@ test_ordering(func_test_info_t *info)
         k = (uint32_t)(((uint64_t)view[i].item) >> 32);
         v = (uint32_t)(((uint64_t)view[i].item) & 0xffffffff);
         if (k != v) {
-	    printf("k(%d) != v(%d)\n", k, v);
+            printf("k(%d) != v(%d)\n", k, v);
             hatrack_view_delete(view, n);
             return false;
         }
 
         if (((i + (info->range / 2) + 1) % info->range) != (k % info->range)) {
-	    printf("%d != %d\n",
-		   (i + (info->range / 2) + 1) % info->range,
-		   k % info->range);
+            printf("%d != %d\n",
+                   (i + (info->range / 2) + 1) % info->range,
+                   k % info->range);
             hatrack_view_delete(view, n);
             return false;
         }
@@ -429,43 +425,43 @@ run_functional_tests(config_info_t *config)
     run_func_test("basic",
                   test_basic,
                   1,
-		  hat_list,
-		  basic_sizes,
+                  hat_list,
+                  basic_sizes,
                   one_thread);
     counters_output_delta();
     run_func_test("ordering",
                   test_ordering,
                   1,
-		  hat_list,
-		  basic_sizes,
+                  hat_list,
+                  basic_sizes,
                   one_thread);
     counters_output_delta();
     run_func_test("shrinking",
-		  test_shrinking,
-		  1,
-		  hat_list,
-		  shrug_sizes,
-		  one_thread);
+                  test_shrinking,
+                  1,
+                  hat_list,
+                  shrug_sizes,
+                  one_thread);
     counters_output_delta();
     run_func_test("replace",
-		  test_replace_op,
-		  1,
-		  hat_list,
-		  shrug_sizes,
-		  one_thread);
+                  test_replace_op,
+                  1,
+                  hat_list,
+                  shrug_sizes,
+                  one_thread);
     counters_output_delta();
     run_func_test("condput",
-		  test_condput,
-		  1,
-		  hat_list,
-		  shrug_sizes,
-		  one_thread);
+                  test_condput,
+                  1,
+                  hat_list,
+                  shrug_sizes,
+                  one_thread);
     counters_output_delta();
     run_func_test("parallel",
                   test_parallel,
                   10,
-		  hat_list,
-		  basic_sizes,
+                  hat_list,
+                  basic_sizes,
                   multiple_threads);
     counters_output_delta();
 

--- a/src/tests/hash/performance.c
+++ b/src/tests/hash/performance.c
@@ -16,12 +16,11 @@
 
 #include <test/testhat.h>
 #include <hatrack/gate.h>
-#include <stdlib.h>
 #include <unistd.h>
 #include <sys/utsname.h>
 #include <sys/ioctl.h>
 #include <stdio.h>
-#include <string.h>
+#include <pthread.h>
 
 #ifdef __MACH__
 _Bool        clock_service_inited = false;

--- a/src/tests/hash/performance.c
+++ b/src/tests/hash/performance.c
@@ -271,26 +271,26 @@ shuffle_thread_run(void *v)
         for (j = 0; j < 100; j++) {
             switch (thread_mix[j]) {
             case OP_READ:
-                test_get(table, next_key);
+                test_get(table, thread, next_key);
                 break;
             case OP_PUT:
-                test_put(table, next_key, 0);
+                test_put(table, thread, next_key, 0);
                 break;
             case OP_ADD:
-                test_add(table, next_key, 0);
+                test_add(table, thread, next_key, 0);
                 break;
             case OP_REPLACE:
-                test_replace(table, next_key, 0);
+                test_replace(table, thread, next_key, 0);
                 break;
             case OP_REMOVE:
-                test_remove(table, next_key);
+                test_remove(table, thread, next_key);
                 break;
             case OP_VIEW:
-                view = test_view(table, &num_items, false);
+                view = test_view(table, thread, &num_items, false);
                 hatrack_view_delete(view, num_items);
                 break;
             case OP_ORDERED_VIEW:
-                view = test_view(table, &num_items, true);
+                view = test_view(table, thread, &num_items, true);
                 hatrack_view_delete(view, num_items);
                 break;
             }
@@ -301,26 +301,26 @@ shuffle_thread_run(void *v)
     for (j = 0; j < remaining_ops; j++) {
         switch (thread_mix[j]) {
         case OP_READ:
-            test_get(table, next_key);
+            test_get(table, thread, next_key);
             break;
         case OP_PUT:
-            test_put(table, next_key, 0);
+            test_put(table, thread, next_key, 0);
             break;
         case OP_ADD:
-            test_add(table, next_key, 0);
+            test_add(table, thread, next_key, 0);
             break;
         case OP_REPLACE:
-            test_replace(table, next_key, 0);
+            test_replace(table, thread, next_key, 0);
             break;
         case OP_REMOVE:
-            test_remove(table, next_key);
+            test_remove(table, thread, next_key);
             break;
         case OP_VIEW:
-            view = test_view(table, &num_items, false);
+            view = test_view(table, thread, &num_items, false);
             hatrack_view_delete(view, num_items);
             break;
         case OP_ORDERED_VIEW:
-            view = test_view(table, &num_items, true);
+            view = test_view(table, thread, &num_items, true);
             hatrack_view_delete(view, num_items);
             break;
         }
@@ -358,26 +358,26 @@ shuffle_thread_run64(void *v)
         for (j = 0; j < 100; j++) {
             switch (thread_mix[j]) {
             case OP_READ:
-                test_get64(table, next_key);
+                test_get64(table, thread, next_key);
                 break;
             case OP_PUT:
-                test_put64(table, next_key, 0xff);
+                test_put64(table, thread, next_key, 0xff);
                 break;
             case OP_ADD:
-                test_add64(table, next_key, 0xff);
+                test_add64(table, thread, next_key, 0xff);
                 break;
             case OP_REPLACE:
-                test_replace64(table, next_key, 0xff);
+                test_replace64(table, thread, next_key, 0xff);
                 break;
             case OP_REMOVE:
-                test_remove64(table, next_key);
+                test_remove64(table, thread, next_key);
                 break;
             case OP_VIEW:
-                view = test_view64(table, &num_items, false);
+                view = test_view64(table, thread, &num_items, false);
                 hatrack_view_delete(view, num_items);
                 break;
             case OP_ORDERED_VIEW:
-                view = test_view64(table, &num_items, true);
+                view = test_view64(table, thread, &num_items, true);
                 hatrack_view_delete(view, num_items);
                 break;
             }
@@ -388,26 +388,26 @@ shuffle_thread_run64(void *v)
     for (j = 0; j < remaining_ops; j++) {
         switch (thread_mix[j]) {
         case OP_READ:
-            test_get64(table, next_key);
+            test_get64(table, thread, next_key);
             break;
         case OP_PUT:
-            test_put64(table, next_key, 0xff);
+            test_put64(table, thread, next_key, 0xff);
             break;
         case OP_ADD:
-            test_add64(table, next_key, 0xff);
+            test_add64(table, thread, next_key, 0xff);
             break;
         case OP_REPLACE:
-            test_replace64(table, next_key, 0xff);
+            test_replace64(table, thread, next_key, 0xff);
             break;
         case OP_REMOVE:
-            test_remove64(table, next_key);
+            test_remove64(table, thread, next_key);
             break;
         case OP_VIEW:
-            view = test_view64(table, &num_items, false);
+            view = test_view64(table, thread, &num_items, false);
             hatrack_view_delete(view, num_items);
             break;
         case OP_ORDERED_VIEW:
-            test_view64(table, &num_items, true);
+            test_view64(table, thread, &num_items, true);
             hatrack_view_delete(view, num_items);
             break;
         }
@@ -440,26 +440,26 @@ rand_thread_run(void *v)
     for (i = 0; i < thread_total_ops; i++) {
         switch (op_distribution[n]) {
         case OP_READ:
-            test_get(table, test_rand() & key_mod_mask);
+            test_get(table, thread, test_rand() & key_mod_mask);
             break;
         case OP_PUT:
-            test_put(table, test_rand() & key_mod_mask, test_rand());
+            test_put(table, thread, test_rand() & key_mod_mask, test_rand());
             break;
         case OP_ADD:
-            test_add(table, test_rand() & key_mod_mask, test_rand());
+            test_add(table, thread, test_rand() & key_mod_mask, test_rand());
             break;
         case OP_REPLACE:
-            test_replace(table, test_rand() & key_mod_mask, test_rand());
+            test_replace(table, thread, test_rand() & key_mod_mask, test_rand());
             break;
         case OP_REMOVE:
-            test_remove(table, test_rand() & key_mod_mask);
+            test_remove(table, thread, test_rand() & key_mod_mask);
             break;
         case OP_VIEW:
-            view = test_view(table, &num_items, false);
+            view = test_view(table, thread, &num_items, false);
             hatrack_view_delete(view, num_items);
             break;
         case OP_ORDERED_VIEW:
-            view = test_view(table, &num_items, true);
+            view = test_view(table, thread, &num_items, true);
             hatrack_view_delete(view, num_items);
             break;
         }
@@ -489,26 +489,26 @@ rand_thread_run64(void *v)
     for (i = 0; i < thread_total_ops; i++) {
         switch (op_distribution[n]) {
         case OP_READ:
-            test_get64(table, (test_rand() & key_mod_mask));
+            test_get64(table, thread, (test_rand() & key_mod_mask));
             break;
         case OP_PUT:
-            test_put64(table, test_rand() & key_mod_mask, test_rand());
+            test_put64(table, thread, test_rand() & key_mod_mask, test_rand());
             break;
         case OP_ADD:
-            test_add64(table, test_rand() & key_mod_mask, test_rand());
+            test_add64(table, thread, test_rand() & key_mod_mask, test_rand());
             break;
         case OP_REPLACE:
-            test_replace64(table, test_rand() & key_mod_mask, test_rand());
+            test_replace64(table, thread, test_rand() & key_mod_mask, test_rand());
             break;
         case OP_REMOVE:
-            test_remove64(table, test_rand() & key_mod_mask);
+            test_remove64(table, thread, test_rand() & key_mod_mask);
             break;
         case OP_VIEW:
-            view = test_view64(table, &num_items, false);
+            view = test_view64(table, thread, &num_items, false);
             hatrack_view_delete(view, num_items);
             break;
         case OP_ORDERED_VIEW:
-            view = test_view64(table, &num_items, true);
+            view = test_view64(table, thread, &num_items, true);
             hatrack_view_delete(view, num_items);
             break;
         }
@@ -521,7 +521,7 @@ rand_thread_run64(void *v)
 }
 
 static void
-initialize_dictionary(benchmark_t *config, char *hat)
+initialize_dictionary(benchmark_t *config, mmm_thread_t *thread, char *hat)
 {
     int      i;
     uint32_t step;
@@ -534,7 +534,7 @@ initialize_dictionary(benchmark_t *config, char *hat)
     p     = get_prefill_amount(config);
 
     for (i = 0; i < p; i++) {
-        test_add(table, n, i);
+        test_add(table, thread, n, i);
         n = (n + step) & key_mod_mask;
     }
 
@@ -542,7 +542,7 @@ initialize_dictionary(benchmark_t *config, char *hat)
 }
 
 static void
-initialize_dictionary64(benchmark_t *config, char *hat)
+initialize_dictionary64(benchmark_t *config, mmm_thread_t *thread, char *hat)
 {
     int      i;
     uint32_t step;
@@ -555,7 +555,7 @@ initialize_dictionary64(benchmark_t *config, char *hat)
     p     = get_prefill_amount(config);
 
     for (i = 0; i < p; i++) {
-        test_add64(table, n, i + 8);
+        test_add64(table, thread, n, i + 8);
         n = (n + step) & key_mod_mask;
     }
 
@@ -642,6 +642,8 @@ run_performance_test(benchmark_t *config)
         remaining_ops      = ops_per_thread % 100;
     }
 
+    mmm_thread_t *thread = mmm_thread_acquire();
+
     while (config->hat_list[i]) {
         alg_info = algorithm_info(config->hat_list[i]);
 
@@ -651,10 +653,10 @@ run_performance_test(benchmark_t *config)
         }
 
         if (alg_info->hashbytes == HB_DEFAULT) {
-            initialize_dictionary(config, config->hat_list[i]);
+            initialize_dictionary(config, thread, config->hat_list[i]);
         }
         else {
-            initialize_dictionary64(config, config->hat_list[i]);
+            initialize_dictionary64(config, thread, config->hat_list[i]);
         }
         clear_timestamps();
         basic_gate_init(&starting_gate);

--- a/src/tests/hash/performance.c
+++ b/src/tests/hash/performance.c
@@ -327,7 +327,7 @@ shuffle_thread_run(void *v)
         next_key = (next_key + thread_step) & key_mod_mask;
     }
 
-    get_timestamp(&stop_times[mmm_mytid]);
+    get_timestamp(&stop_times[mmm_thread->tid]);
     mmm_clean_up_before_exit();
 
     return NULL;
@@ -415,7 +415,7 @@ shuffle_thread_run64(void *v)
         next_key = (next_key + thread_step) & key_mod_mask;
     }
 
-    get_timestamp(&stop_times[mmm_mytid]);
+    get_timestamp(&stop_times[mmm_thread->tid]);
     mmm_clean_up_before_exit();
 
     return NULL;
@@ -468,7 +468,7 @@ rand_thread_run(void *v)
         n = test_rand() % 100;
     }
 
-    get_timestamp(&stop_times[mmm_mytid]);
+    get_timestamp(&stop_times[mmm_thread->tid]);
     mmm_clean_up_before_exit();
 
     return NULL;
@@ -518,7 +518,7 @@ rand_thread_run64(void *v)
         n = test_rand() % 100;
     }
 
-    get_timestamp(&stop_times[mmm_mytid]);
+    get_timestamp(&stop_times[mmm_thread->tid]);
     mmm_clean_up_before_exit();
 
     return NULL;

--- a/src/tests/hash/performance.c
+++ b/src/tests/hash/performance.c
@@ -262,7 +262,7 @@ shuffle_thread_run(void *v)
 
     memcpy(thread_mix, op_distribution, 100);
     test_shuffle_array(thread_mix, 100, sizeof(char));
-    mmm_register_thread();
+    mmm_thread_t *thread = mmm_thread_acquire();
     basic_gate_thread_ready(&starting_gate);
 
     for (i = 0; i < thread_full_cycles; i++) {
@@ -327,8 +327,7 @@ shuffle_thread_run(void *v)
         next_key = (next_key + thread_step) & key_mod_mask;
     }
 
-    get_timestamp(&stop_times[mmm_thread->tid]);
-    mmm_clean_up_before_exit();
+    get_timestamp(&stop_times[thread->tid]);
 
     return NULL;
 }
@@ -350,7 +349,7 @@ shuffle_thread_run64(void *v)
 
     memcpy(thread_mix, op_distribution, 100);
     test_shuffle_array(thread_mix, 100, sizeof(char));
-    mmm_register_thread();
+    mmm_thread_t *thread = mmm_thread_acquire();
     basic_gate_thread_ready(&starting_gate);
 
     for (i = 0; i < thread_full_cycles; i++) {
@@ -415,8 +414,7 @@ shuffle_thread_run64(void *v)
         next_key = (next_key + thread_step) & key_mod_mask;
     }
 
-    get_timestamp(&stop_times[mmm_thread->tid]);
-    mmm_clean_up_before_exit();
+    get_timestamp(&stop_times[thread->tid]);
 
     return NULL;
 }
@@ -436,7 +434,7 @@ rand_thread_run(void *v)
      */
     n                = test_rand() % 100;
 
-    mmm_register_thread();
+    mmm_thread_t *thread = mmm_thread_acquire();
     basic_gate_thread_ready(&starting_gate);
 
     for (i = 0; i < thread_total_ops; i++) {
@@ -468,8 +466,7 @@ rand_thread_run(void *v)
         n = test_rand() % 100;
     }
 
-    get_timestamp(&stop_times[mmm_thread->tid]);
-    mmm_clean_up_before_exit();
+    get_timestamp(&stop_times[thread->tid]);
 
     return NULL;
 }
@@ -486,7 +483,7 @@ rand_thread_run64(void *v)
     thread_total_ops = (uintptr_t)v;
     n                = test_rand() % 100;
 
-    mmm_register_thread();
+    mmm_thread_t *thread = mmm_thread_acquire();
     basic_gate_thread_ready(&starting_gate);
 
     for (i = 0; i < thread_total_ops; i++) {
@@ -518,8 +515,7 @@ rand_thread_run64(void *v)
         n = test_rand() % 100;
     }
 
-    get_timestamp(&stop_times[mmm_thread->tid]);
-    mmm_clean_up_before_exit();
+    get_timestamp(&stop_times[thread->tid]);
 
     return NULL;
 }
@@ -635,7 +631,9 @@ run_performance_test(benchmark_t *config)
     test_init_rand(config->seed);
     prepare_operational_mix(config);
     precompute_hashes(calculate_num_test_keys(config->key_range));
-    atomic_store(&mmm_nexttid, 0); // Reset thread ids.
+
+    extern void mmm_reset_tids(void);
+    mmm_reset_tids();
 
     ops_per_thread = config->total_ops / config->num_threads;
 

--- a/src/tests/hash/test.c
+++ b/src/tests/hash/test.c
@@ -71,7 +71,7 @@ main(int argc, char *argv[])
 
     config = parse_args(argc, argv);
 
-    mmm_register_thread();
+    (void)mmm_thread_acquire();
 
     if (config->run_custom_test) {
         run_performance_test(&config->custom);

--- a/src/tests/hash/test.c
+++ b/src/tests/hash/test.c
@@ -64,14 +64,49 @@ precompute_hashes(uint64_t max_range)
     return;
 }
 
+#ifdef HATRACK_NO_PTHREAD
+static pthread_key_t thread_pkey;
+
+struct thread_data {
+    size_t size;
+    char   data[];
+};
+
+static void
+thread_release_pthread(void *arg)
+{
+    pthread_setspecific(thread_pkey, NULL);
+
+    struct thread_data *pt = arg;
+    mmm_thread_release((mmm_thread_t *)pt->data);
+    hatrack_free(arg, pt->size);
+}
+
+static mmm_thread_t *
+thread_acquire_data(void *aux, size_t size)
+{
+    struct thread_data *pt = pthread_getspecific(thread_pkey);
+    if (NULL == pt) {
+        pt       = hatrack_zalloc(sizeof(struct thread_data) + size);
+        pt->size = size;
+        pthread_setspecific(thread_pkey, pt);
+    }
+    return (mmm_thread_t *)pt->data;
+}
+
+#endif
+
 int
 main(int argc, char *argv[])
 {
+#ifdef HATRACK_NO_PTHREAD
+    pthread_key_create(&thread_pkey, thread_release_pthread);
+    mmm_setthreadfns(thread_acquire_data, NULL);
+#endif
+
     config_info_t *config;
 
     config = parse_args(argc, argv);
-
-    (void)mmm_thread_acquire();
 
     if (config->run_custom_test) {
         run_performance_test(&config->custom);

--- a/src/tests/hash/testhat.c
+++ b/src/tests/hash/testhat.c
@@ -168,6 +168,8 @@ hatrack_vtable_t refhat_vtable = {
     .view    = (hatrack_view_func)refhat_view
 };
 
+#ifndef HATRACK_NO_PTHREAD
+
 hatrack_vtable_t dcap_vtable = {
     .init    = (hatrack_init_func)duncecap_init,
     .init_sz = (hatrack_init_sz_func)duncecap_init_size,
@@ -219,6 +221,8 @@ hatrack_vtable_t ballcap_vtable = {
     .len     = (hatrack_len_func)ballcap_len,
     .view    = (hatrack_view_func)ballcap_view
 };
+
+#endif
 
 hatrack_vtable_t hihat_vtable = {
     .init    = (hatrack_init_func)hihat_init,
@@ -311,6 +315,8 @@ hatrack_vtable_t oldhat_vtable = {
     .view    = (hatrack_view_func)oldhat_view
 };
 
+#ifndef HATRACK_NO_PTHREAD
+
 hatrack_vtable_t thfmx_vtable = {
     .init    = (hatrack_init_func)tophat_init_fast_mx,
     .init_sz = (hatrack_init_sz_func)tophat_init_fast_mx_size,
@@ -363,6 +369,8 @@ hatrack_vtable_t thcwf_vtable = {
     .view    = (hatrack_view_func)tophat_view
 };
 
+#endif
+
 hatrack_vtable_t crown_vtable = {
     .init    = (hatrack_init_func)crown_init,
     .init_sz = (hatrack_init_sz_func)crown_init_size,
@@ -395,10 +403,12 @@ static void
 testhat_init_default_algorithms(void)
 {
     algorithm_register("refhat", &refhat_vtable, sizeof(refhat_t), 16, false);
+#ifndef HATRACK_NO_PTHREAD
     algorithm_register("duncecap", &dcap_vtable, sizeof(duncecap_t), 16, true);
     algorithm_register("swimcap", &swimcap_vtable, sizeof(swimcap_t), 16, true);
     algorithm_register("newshat", &newshat_vtable, sizeof(newshat_t), 16, true);
     algorithm_register("ballcap", &ballcap_vtable, sizeof(ballcap_t), 16, true);
+#endif
     algorithm_register("hihat", &hihat_vtable, sizeof(hihat_t), 16, true);
     algorithm_register("hihat-a", &hihat_a_vtable, sizeof(hihat_t), 16, true);
     algorithm_register("witchhat", &witch_vtable, sizeof(witchhat_t), 16, true);
@@ -407,10 +417,12 @@ testhat_init_default_algorithms(void)
     algorithm_register("lohat", &lohat_vtable, sizeof(lohat_t), 16, true);
     algorithm_register("lohat-a", &lohat_a_vtable, sizeof(lohat_a_t), 16, true);
     algorithm_register("woolhat", &woolhat_vtable, sizeof(woolhat_t), 16, true);
+#ifndef HATRACK_NO_PTHREAD
     algorithm_register("tophat-fmx", &thfmx_vtable, sizeof(tophat_t), 16, true);
     algorithm_register("tophat-fwf", &thfwf_vtable, sizeof(tophat_t), 16, true);
     algorithm_register("tophat-cmx", &thcmx_vtable, sizeof(tophat_t), 16, true);
     algorithm_register("tophat-cwf", &thcwf_vtable, sizeof(tophat_t), 16, true);
+#endif
     algorithm_register("tiara", &tiara_vtable, sizeof(tiara_t), 8, true);
     return;
 }

--- a/src/tests/hash/testhat.c
+++ b/src/tests/hash/testhat.c
@@ -158,14 +158,14 @@ testhat_new_size(char *name, char sz)
 hatrack_vtable_t refhat_vtable = {
     .init    = (hatrack_init_func)refhat_init,
     .init_sz = (hatrack_init_sz_func)refhat_init_size,
-    .get     = (hatrack_get_func)refhat_get,
-    .put     = (hatrack_put_func)refhat_put,
-    .replace = (hatrack_replace_func)refhat_replace,
-    .add     = (hatrack_add_func)refhat_add,
-    .remove  = (hatrack_remove_func)refhat_remove,
+    .get     = (hatrack_get_func)refhat_get_mmm,
+    .put     = (hatrack_put_func)refhat_put_mmm,
+    .replace = (hatrack_replace_func)refhat_replace_mmm,
+    .add     = (hatrack_add_func)refhat_add_mmm,
+    .remove  = (hatrack_remove_func)refhat_remove_mmm,
     .delete  = (hatrack_delete_func)refhat_delete,
-    .len     = (hatrack_len_func)refhat_len,
-    .view    = (hatrack_view_func)refhat_view
+    .len     = (hatrack_len_func)refhat_len_mmm,
+    .view    = (hatrack_view_func)refhat_view_mmm
 };
 
 #ifndef HATRACK_NO_PTHREAD
@@ -173,53 +173,53 @@ hatrack_vtable_t refhat_vtable = {
 hatrack_vtable_t dcap_vtable = {
     .init    = (hatrack_init_func)duncecap_init,
     .init_sz = (hatrack_init_sz_func)duncecap_init_size,
-    .get     = (hatrack_get_func)duncecap_get,
-    .put     = (hatrack_put_func)duncecap_put,
-    .replace = (hatrack_replace_func)duncecap_replace,
-    .add     = (hatrack_add_func)duncecap_add,
-    .remove  = (hatrack_remove_func)duncecap_remove,
+    .get     = (hatrack_get_func)duncecap_get_mmm,
+    .put     = (hatrack_put_func)duncecap_put_mmm,
+    .replace = (hatrack_replace_func)duncecap_replace_mmm,
+    .add     = (hatrack_add_func)duncecap_add_mmm,
+    .remove  = (hatrack_remove_func)duncecap_remove_mmm,
     .delete  = (hatrack_delete_func)duncecap_delete,
-    .len     = (hatrack_len_func)duncecap_len,
-    .view    = (hatrack_view_func)duncecap_view
+    .len     = (hatrack_len_func)duncecap_len_mmm,
+    .view    = (hatrack_view_func)duncecap_view_mmm
 };
 
 hatrack_vtable_t swimcap_vtable = {
     .init    = (hatrack_init_func)swimcap_init,
     .init_sz = (hatrack_init_sz_func)swimcap_init_size,
-    .get     = (hatrack_get_func)swimcap_get,
-    .put     = (hatrack_put_func)swimcap_put,
-    .replace = (hatrack_replace_func)swimcap_replace,
-    .add     = (hatrack_add_func)swimcap_add,
-    .remove  = (hatrack_remove_func)swimcap_remove,
+    .get     = (hatrack_get_func)swimcap_get_mmm,
+    .put     = (hatrack_put_func)swimcap_put_mmm,
+    .replace = (hatrack_replace_func)swimcap_replace_mmm,
+    .add     = (hatrack_add_func)swimcap_add_mmm,
+    .remove  = (hatrack_remove_func)swimcap_remove_mmm,
     .delete  = (hatrack_delete_func)swimcap_delete,
-    .len     = (hatrack_len_func)swimcap_len,
-    .view    = (hatrack_view_func)swimcap_view
+    .len     = (hatrack_len_func)swimcap_len_mmm,
+    .view    = (hatrack_view_func)swimcap_view_mmm
 };
 
 hatrack_vtable_t newshat_vtable = {
     .init    = (hatrack_init_func)newshat_init,
     .init_sz = (hatrack_init_sz_func)newshat_init_size,
-    .get     = (hatrack_get_func)newshat_get,
-    .put     = (hatrack_put_func)newshat_put,
-    .replace = (hatrack_replace_func)newshat_replace,
-    .add     = (hatrack_add_func)newshat_add,
-    .remove  = (hatrack_remove_func)newshat_remove,
+    .get     = (hatrack_get_func)newshat_get_mmm,
+    .put     = (hatrack_put_func)newshat_put_mmm,
+    .replace = (hatrack_replace_func)newshat_replace_mmm,
+    .add     = (hatrack_add_func)newshat_add_mmm,
+    .remove  = (hatrack_remove_func)newshat_remove_mmm,
     .delete  = (hatrack_delete_func)newshat_delete,
-    .len     = (hatrack_len_func)newshat_len,
-    .view    = (hatrack_view_func)newshat_view
+    .len     = (hatrack_len_func)newshat_len_mmm,
+    .view    = (hatrack_view_func)newshat_view_mmm
 };
 
 hatrack_vtable_t ballcap_vtable = {
     .init    = (hatrack_init_func)ballcap_init,
     .init_sz = (hatrack_init_sz_func)ballcap_init_size,
-    .get     = (hatrack_get_func)ballcap_get,
-    .put     = (hatrack_put_func)ballcap_put,
-    .replace = (hatrack_replace_func)ballcap_replace,
-    .add     = (hatrack_add_func)ballcap_add,
-    .remove  = (hatrack_remove_func)ballcap_remove,
+    .get     = (hatrack_get_func)ballcap_get_mmm,
+    .put     = (hatrack_put_func)ballcap_put_mmm,
+    .replace = (hatrack_replace_func)ballcap_replace_mmm,
+    .add     = (hatrack_add_func)ballcap_add_mmm,
+    .remove  = (hatrack_remove_func)ballcap_remove_mmm,
     .delete  = (hatrack_delete_func)ballcap_delete,
-    .len     = (hatrack_len_func)ballcap_len,
-    .view    = (hatrack_view_func)ballcap_view
+    .len     = (hatrack_len_func)ballcap_len_mmm,
+    .view    = (hatrack_view_func)ballcap_view_mmm
 };
 
 #endif
@@ -227,92 +227,92 @@ hatrack_vtable_t ballcap_vtable = {
 hatrack_vtable_t hihat_vtable = {
     .init    = (hatrack_init_func)hihat_init,
     .init_sz = (hatrack_init_sz_func)hihat_init_size,
-    .get     = (hatrack_get_func)hihat_get,
-    .put     = (hatrack_put_func)hihat_put,
-    .replace = (hatrack_replace_func)hihat_replace,
-    .add     = (hatrack_add_func)hihat_add,
-    .remove  = (hatrack_remove_func)hihat_remove,
+    .get     = (hatrack_get_func)hihat_get_mmm,
+    .put     = (hatrack_put_func)hihat_put_mmm,
+    .replace = (hatrack_replace_func)hihat_replace_mmm,
+    .add     = (hatrack_add_func)hihat_add_mmm,
+    .remove  = (hatrack_remove_func)hihat_remove_mmm,
     .delete  = (hatrack_delete_func)hihat_delete,
-    .len     = (hatrack_len_func)hihat_len,
-    .view    = (hatrack_view_func)hihat_view
+    .len     = (hatrack_len_func)hihat_len_mmm,
+    .view    = (hatrack_view_func)hihat_view_mmm
 };
 
 hatrack_vtable_t hihat_a_vtable = {
     .init    = (hatrack_init_func)hihat_a_init,
     .init_sz = (hatrack_init_sz_func)hihat_a_init_size,
-    .get     = (hatrack_get_func)hihat_a_get,
-    .put     = (hatrack_put_func)hihat_a_put,
-    .replace = (hatrack_replace_func)hihat_a_replace,
-    .add     = (hatrack_add_func)hihat_a_add,
-    .remove  = (hatrack_remove_func)hihat_a_remove,
+    .get     = (hatrack_get_func)hihat_a_get_mmm,
+    .put     = (hatrack_put_func)hihat_a_put_mmm,
+    .replace = (hatrack_replace_func)hihat_a_replace_mmm,
+    .add     = (hatrack_add_func)hihat_a_add_mmm,
+    .remove  = (hatrack_remove_func)hihat_a_remove_mmm,
     .delete  = (hatrack_delete_func)hihat_a_delete,
-    .len     = (hatrack_len_func)hihat_a_len,
-    .view    = (hatrack_view_func)hihat_a_view
+    .len     = (hatrack_len_func)hihat_a_len_mmm,
+    .view    = (hatrack_view_func)hihat_a_view_mmm
 };
 
 hatrack_vtable_t lohat_vtable = {
     .init    = (hatrack_init_func)lohat_init,
     .init_sz = (hatrack_init_sz_func)lohat_init_size,
-    .get     = (hatrack_get_func)lohat_get,
-    .put     = (hatrack_put_func)lohat_put,
-    .replace = (hatrack_replace_func)lohat_replace,
-    .add     = (hatrack_add_func)lohat_add,
-    .remove  = (hatrack_remove_func)lohat_remove,
+    .get     = (hatrack_get_func)lohat_get_mmm,
+    .put     = (hatrack_put_func)lohat_put_mmm,
+    .replace = (hatrack_replace_func)lohat_replace_mmm,
+    .add     = (hatrack_add_func)lohat_add_mmm,
+    .remove  = (hatrack_remove_func)lohat_remove_mmm,
     .delete  = (hatrack_delete_func)lohat_delete,
-    .len     = (hatrack_len_func)lohat_len,
-    .view    = (hatrack_view_func)lohat_view
+    .len     = (hatrack_len_func)lohat_len_mmm,
+    .view    = (hatrack_view_func)lohat_view_mmm
 };
 
 hatrack_vtable_t lohat_a_vtable = {
     .init    = (hatrack_init_func)lohat_a_init,
     .init_sz = (hatrack_init_sz_func)lohat_a_init_size,
-    .get     = (hatrack_get_func)lohat_a_get,
-    .put     = (hatrack_put_func)lohat_a_put,
-    .replace = (hatrack_replace_func)lohat_a_replace,
-    .add     = (hatrack_add_func)lohat_a_add,
-    .remove  = (hatrack_remove_func)lohat_a_remove,
+    .get     = (hatrack_get_func)lohat_a_get_mmm,
+    .put     = (hatrack_put_func)lohat_a_put_mmm,
+    .replace = (hatrack_replace_func)lohat_a_replace_mmm,
+    .add     = (hatrack_add_func)lohat_a_add_mmm,
+    .remove  = (hatrack_remove_func)lohat_a_remove_mmm,
     .delete  = (hatrack_delete_func)lohat_a_delete,
-    .len     = (hatrack_len_func)lohat_a_len,
-    .view    = (hatrack_view_func)lohat_a_view
+    .len     = (hatrack_len_func)lohat_a_len_mmm,
+    .view    = (hatrack_view_func)lohat_a_view_mmm
 };
 
 hatrack_vtable_t witch_vtable = {
     .init    = (hatrack_init_func)witchhat_init,
     .init_sz = (hatrack_init_sz_func)witchhat_init_size,
-    .get     = (hatrack_get_func)witchhat_get,
-    .put     = (hatrack_put_func)witchhat_put,
-    .replace = (hatrack_replace_func)witchhat_replace,
-    .add     = (hatrack_add_func)witchhat_add,
-    .remove  = (hatrack_remove_func)witchhat_remove,
+    .get     = (hatrack_get_func)witchhat_get_mmm,
+    .put     = (hatrack_put_func)witchhat_put_mmm,
+    .replace = (hatrack_replace_func)witchhat_replace_mmm,
+    .add     = (hatrack_add_func)witchhat_add_mmm,
+    .remove  = (hatrack_remove_func)witchhat_remove_mmm,
     .delete  = (hatrack_delete_func)witchhat_delete,
-    .len     = (hatrack_len_func)witchhat_len,
-    .view    = (hatrack_view_func)witchhat_view
+    .len     = (hatrack_len_func)witchhat_len_mmm,
+    .view    = (hatrack_view_func)witchhat_view_mmm
 };
 
 hatrack_vtable_t woolhat_vtable = {
     .init    = (hatrack_init_func)woolhat_init,
     .init_sz = (hatrack_init_sz_func)woolhat_init_size,
-    .get     = (hatrack_get_func)woolhat_get,
-    .put     = (hatrack_put_func)woolhat_put,
-    .replace = (hatrack_replace_func)woolhat_replace,
-    .add     = (hatrack_add_func)woolhat_add,
-    .remove  = (hatrack_remove_func)woolhat_remove,
+    .get     = (hatrack_get_func)woolhat_get_mmm,
+    .put     = (hatrack_put_func)woolhat_put_mmm,
+    .replace = (hatrack_replace_func)woolhat_replace_mmm,
+    .add     = (hatrack_add_func)woolhat_add_mmm,
+    .remove  = (hatrack_remove_func)woolhat_remove_mmm,
     .delete  = (hatrack_delete_func)woolhat_delete,
-    .len     = (hatrack_len_func)woolhat_len,
-    .view    = (hatrack_view_func)woolhat_view
+    .len     = (hatrack_len_func)woolhat_len_mmm,
+    .view    = (hatrack_view_func)woolhat_view_mmm
 };
 
 hatrack_vtable_t oldhat_vtable = {
     .init    = (hatrack_init_func)oldhat_init,
     .init_sz = (hatrack_init_sz_func)oldhat_init_size,
-    .get     = (hatrack_get_func)oldhat_get,
-    .put     = (hatrack_put_func)oldhat_put,
-    .replace = (hatrack_replace_func)oldhat_replace,
-    .add     = (hatrack_add_func)oldhat_add,
-    .remove  = (hatrack_remove_func)oldhat_remove,
+    .get     = (hatrack_get_func)oldhat_get_mmm,
+    .put     = (hatrack_put_func)oldhat_put_mmm,
+    .replace = (hatrack_replace_func)oldhat_replace_mmm,
+    .add     = (hatrack_add_func)oldhat_add_mmm,
+    .remove  = (hatrack_remove_func)oldhat_remove_mmm,
     .delete  = (hatrack_delete_func)oldhat_delete,
-    .len     = (hatrack_len_func)oldhat_len,
-    .view    = (hatrack_view_func)oldhat_view
+    .len     = (hatrack_len_func)oldhat_len_mmm,
+    .view    = (hatrack_view_func)oldhat_view_mmm
 };
 
 #ifndef HATRACK_NO_PTHREAD
@@ -320,53 +320,53 @@ hatrack_vtable_t oldhat_vtable = {
 hatrack_vtable_t thfmx_vtable = {
     .init    = (hatrack_init_func)tophat_init_fast_mx,
     .init_sz = (hatrack_init_sz_func)tophat_init_fast_mx_size,
-    .get     = (hatrack_get_func)tophat_get,
-    .put     = (hatrack_put_func)tophat_put,
-    .replace = (hatrack_replace_func)tophat_replace,
-    .add     = (hatrack_add_func)tophat_add,
-    .remove  = (hatrack_remove_func)tophat_remove,
+    .get     = (hatrack_get_func)tophat_get_mmm,
+    .put     = (hatrack_put_func)tophat_put_mmm,
+    .replace = (hatrack_replace_func)tophat_replace_mmm,
+    .add     = (hatrack_add_func)tophat_add_mmm,
+    .remove  = (hatrack_remove_func)tophat_remove_mmm,
     .delete  = (hatrack_delete_func)tophat_delete,
-    .len     = (hatrack_len_func)tophat_len,
-    .view    = (hatrack_view_func)tophat_view
+    .len     = (hatrack_len_func)tophat_len_mmm,
+    .view    = (hatrack_view_func)tophat_view_mmm
 };
 
 hatrack_vtable_t thfwf_vtable = {
     .init    = (hatrack_init_func)tophat_init_fast_wf,
     .init_sz = (hatrack_init_sz_func)tophat_init_fast_wf_size,
-    .get     = (hatrack_get_func)tophat_get,
-    .put     = (hatrack_put_func)tophat_put,
-    .replace = (hatrack_replace_func)tophat_replace,
-    .add     = (hatrack_add_func)tophat_add,
-    .remove  = (hatrack_remove_func)tophat_remove,
+    .get     = (hatrack_get_func)tophat_get_mmm,
+    .put     = (hatrack_put_func)tophat_put_mmm,
+    .replace = (hatrack_replace_func)tophat_replace_mmm,
+    .add     = (hatrack_add_func)tophat_add_mmm,
+    .remove  = (hatrack_remove_func)tophat_remove_mmm,
     .delete  = (hatrack_delete_func)tophat_delete,
-    .len     = (hatrack_len_func)tophat_len,
-    .view    = (hatrack_view_func)tophat_view
+    .len     = (hatrack_len_func)tophat_len_mmm,
+    .view    = (hatrack_view_func)tophat_view_mmm
 };
 
 hatrack_vtable_t thcmx_vtable = {
     .init    = (hatrack_init_func)tophat_init_cst_mx,
     .init_sz = (hatrack_init_sz_func)tophat_init_cst_mx_size,
-    .get     = (hatrack_get_func)tophat_get,
-    .put     = (hatrack_put_func)tophat_put,
-    .replace = (hatrack_replace_func)tophat_replace,
-    .add     = (hatrack_add_func)tophat_add,
-    .remove  = (hatrack_remove_func)tophat_remove,
+    .get     = (hatrack_get_func)tophat_get_mmm,
+    .put     = (hatrack_put_func)tophat_put_mmm,
+    .replace = (hatrack_replace_func)tophat_replace_mmm,
+    .add     = (hatrack_add_func)tophat_add_mmm,
+    .remove  = (hatrack_remove_func)tophat_remove_mmm,
     .delete  = (hatrack_delete_func)tophat_delete,
-    .len     = (hatrack_len_func)tophat_len,
-    .view    = (hatrack_view_func)tophat_view
+    .len     = (hatrack_len_func)tophat_len_mmm,
+    .view    = (hatrack_view_func)tophat_view_mmm
 };
 
 hatrack_vtable_t thcwf_vtable = {
     .init    = (hatrack_init_func)tophat_init_cst_wf,
     .init_sz = (hatrack_init_sz_func)tophat_init_cst_wf_size,
-    .get     = (hatrack_get_func)tophat_get,
-    .put     = (hatrack_put_func)tophat_put,
-    .replace = (hatrack_replace_func)tophat_replace,
-    .add     = (hatrack_add_func)tophat_add,
-    .remove  = (hatrack_remove_func)tophat_remove,
+    .get     = (hatrack_get_func)tophat_get_mmm,
+    .put     = (hatrack_put_func)tophat_put_mmm,
+    .replace = (hatrack_replace_func)tophat_replace_mmm,
+    .add     = (hatrack_add_func)tophat_add_mmm,
+    .remove  = (hatrack_remove_func)tophat_remove_mmm,
     .delete  = (hatrack_delete_func)tophat_delete,
-    .len     = (hatrack_len_func)tophat_len,
-    .view    = (hatrack_view_func)tophat_view
+    .len     = (hatrack_len_func)tophat_len_mmm,
+    .view    = (hatrack_view_func)tophat_view_mmm
 };
 
 #endif
@@ -374,27 +374,27 @@ hatrack_vtable_t thcwf_vtable = {
 hatrack_vtable_t crown_vtable = {
     .init    = (hatrack_init_func)crown_init,
     .init_sz = (hatrack_init_sz_func)crown_init_size,
-    .get     = (hatrack_get_func)crown_get,
-    .put     = (hatrack_put_func)crown_put,
-    .replace = (hatrack_replace_func)crown_replace,
-    .add     = (hatrack_add_func)crown_add,
-    .remove  = (hatrack_remove_func)crown_remove,
+    .get     = (hatrack_get_func)crown_get_mmm,
+    .put     = (hatrack_put_func)crown_put_mmm,
+    .replace = (hatrack_replace_func)crown_replace_mmm,
+    .add     = (hatrack_add_func)crown_add_mmm,
+    .remove  = (hatrack_remove_func)crown_remove_mmm,
     .delete  = (hatrack_delete_func)crown_delete,
-    .len     = (hatrack_len_func)crown_len,
-    .view    = (hatrack_view_func)crown_view
+    .len     = (hatrack_len_func)crown_len_mmm,
+    .view    = (hatrack_view_func)crown_view_mmm
 };
 
 hatrack_vtable_t tiara_vtable = {
     .init    = (hatrack_init_func)tiara_init,
     .init_sz = (hatrack_init_sz_func)tiara_init_size,
-    .get     = (hatrack_get_func)tiara_get,
-    .put     = (hatrack_put_func)tiara_put,
-    .replace = (hatrack_replace_func)tiara_replace,
-    .add     = (hatrack_add_func)tiara_add,
-    .remove  = (hatrack_remove_func)tiara_remove,
+    .get     = (hatrack_get_func)tiara_get_mmm,
+    .put     = (hatrack_put_func)tiara_put_mmm,
+    .replace = (hatrack_replace_func)tiara_replace_mmm,
+    .add     = (hatrack_add_func)tiara_add_mmm,
+    .remove  = (hatrack_remove_func)tiara_remove_mmm,
     .delete  = (hatrack_delete_func)tiara_delete,
-    .len     = (hatrack_len_func)tiara_len,
-    .view    = (hatrack_view_func)tiara_view
+    .len     = (hatrack_len_func)tiara_len_mmm,
+    .view    = (hatrack_view_func)tiara_view_mmm
 };
 
 // clang-format on


### PR DESCRIPTION
The work here is mainly to remove the dependency on `__thread` in Hatrack. Dependencies in con4m itself remain, but will be addressed later. However, there are other, smaller related threading changes here as well. Overall, the goal is to be more friendly to many environments, including embedded environments that may not have pthreads or `__thread` support available.

There is a new config option to disable all pthread support. The core of Hatrack does not require it, but a handful of algorithms do use it. They'll be skipped if `HATRACK_NO_PTHREAD` is defined. If this is defined, the host must either define a tis access function, or not use the implicit tis APIs. The tis access function is new, as is the distinction between implicit and explicit tis APIs.

Mainly the work here is to split most of the public APIs into explicit / implicit versions. This means that the explicit versions are passed a thread-local struct as a parameter, while the implicit versions are not. The implicit versions use a tis access function that can be defined by the host to get the needed thread-local struct. The implicit versions are the same functions that always existed. It's the explicit functions that are new, and they all are named the same as the corresponding implicit function, but with a `_mmm` suffix.

For the explicit functions with the added `mmm_thread_t *` parameter, there's no great place to put the parameter that feels right for all cases. I've chosen to make it the second parameter in all cases. The rationale for this is that it's a fixed parameter, present for all functions, like the primary object being operated on. The primary object being operated on should always be the first parameter, so it follows that the second parameter should be the tis pointer. Everything after that is highly variable, dependent on the function.

By default, there is a tis acquisition function defined if pthread support is enabled (the default). This implementation uses the pthread API for thread-specific data and takes care of its own cleanup when threads exit.

Most users of the Hatrack API will use the implicit API with the default tis acquisition function, and so they need to do nothing special, nor concern themselves with any of this. Most of what's been done here is for atypical use cases.
