### PR TITLE
Formatting cleanups, mostly whitespace

### DIFF
--- a/include/test/testhat.h
+++ b/include/test/testhat.h
@@ -201,37 +201,35 @@ typedef struct {
 extern _Atomic uint64_t mmm_nexttid;
 extern hatrack_hash_t  *precomputed_hashes;
 
-// clang-format off
 // from rand.c
-void           test_init_rand        (__int128_t);
-uint32_t       test_rand             (void);
-void           test_shuffle_array    (void *, uint32_t, uint32_t);
+void     test_init_rand(__int128_t);
+uint32_t test_rand(void);
+void     test_shuffle_array(void *, uint32_t, uint32_t);
 
 // from testhat.c: basic algorithm registering / info / instantiation.
-uint32_t       algorithm_register    (char *, hatrack_vtable_t *, size_t, int,
-				      bool);
-uint32_t       get_num_algorithms    (void);
-alg_info_t    *get_all_algorithm_info(void);
-int32_t        algorithm_id_by_name  (char *);
-alg_info_t    *algorithm_info        (char *);
-testhat_t     *testhat_new           (char *);
-testhat_t     *testhat_new_size      (char *, char);
+uint32_t    algorithm_register(char *, hatrack_vtable_t *, size_t, int, bool);
+uint32_t    get_num_algorithms(void);
+alg_info_t *get_all_algorithm_info(void);
+int32_t     algorithm_id_by_name(char *);
+alg_info_t *algorithm_info(char *);
+testhat_t  *testhat_new(char *);
+testhat_t  *testhat_new_size(char *, char);
 
 // functional.c -- functional tests, off by default.
-void           run_functional_tests  (config_info_t *);
+void run_functional_tests(config_info_t *);
 
 // default.c -- default tests.
-void           run_default_tests     (config_info_t *);
+void run_default_tests(config_info_t *);
 
 // performance.c -- run one performance test. Custom tests are
 // kicked off from the main() function in test.c
-void           run_performance_test  (benchmark_t *);
+void run_performance_test(benchmark_t *);
 
 // config.c -- Command-line argument parsing.
-config_info_t *parse_args            (int, char *[]);
+config_info_t *parse_args(int, char *[]);
 
 // Items kept in test.c.
-void           precompute_hashes     (uint64_t);
+void precompute_hashes(uint64_t);
 
 typedef union {
     struct {

--- a/src/hatrack/hash/ballcap.c
+++ b/src/hatrack/hash/ballcap.c
@@ -56,20 +56,13 @@
 #ifndef HATRACK_NO_PTHREAD
 
 // clang-format off
-
        ballcap_store_t *ballcap_store_new    (uint64_t);
-static void            *ballcap_store_get    (ballcap_store_t *, hatrack_hash_t,
-					      bool *);
-static void            *ballcap_store_put    (ballcap_store_t *, mmm_thread_t *,
-					      ballcap_t *, hatrack_hash_t, void *, bool *);
-static void            *ballcap_store_replace(ballcap_store_t *, mmm_thread_t *,
-					      ballcap_t *, hatrack_hash_t, void *, bool *);
-static bool             ballcap_store_add    (ballcap_store_t *, mmm_thread_t *,
-					      ballcap_t *, hatrack_hash_t, void *);
-static void            *ballcap_store_remove (ballcap_store_t *, mmm_thread_t *,
-					      ballcap_t *, hatrack_hash_t, bool *);
+static void            *ballcap_store_get    (ballcap_store_t *, hatrack_hash_t, bool *);
+static void            *ballcap_store_put    (ballcap_store_t *, mmm_thread_t *, ballcap_t *, hatrack_hash_t, void *, bool *);
+static void            *ballcap_store_replace(ballcap_store_t *, mmm_thread_t *, ballcap_t *, hatrack_hash_t, void *, bool *);
+static bool             ballcap_store_add    (ballcap_store_t *, mmm_thread_t *, ballcap_t *, hatrack_hash_t, void *);
+static void            *ballcap_store_remove (ballcap_store_t *, mmm_thread_t *, ballcap_t *, hatrack_hash_t, bool *);
 static ballcap_store_t *ballcap_store_migrate(ballcap_store_t *, mmm_thread_t *, ballcap_t *);
-
 // clang-format on
 
 ballcap_t *

--- a/src/hatrack/hash/duncecap.c
+++ b/src/hatrack/hash/duncecap.c
@@ -40,19 +40,11 @@
 
 // clang-format off
 static duncecap_store_t *duncecap_store_new    (uint64_t);
-static void             *duncecap_store_get    (duncecap_store_t *,
-						hatrack_hash_t, bool *);
-static void             *duncecap_store_put    (duncecap_store_t *,
-						duncecap_t *, hatrack_hash_t,
-						void *, bool *);
-static void             *duncecap_store_replace(duncecap_store_t *,
-						hatrack_hash_t, void *, bool *);
-static bool              duncecap_store_add    (duncecap_store_t *,
-						duncecap_t *, hatrack_hash_t,
-						void *);
-static void             *duncecap_store_remove (duncecap_store_t *,
-						duncecap_t *, hatrack_hash_t,
-						bool *);
+static void             *duncecap_store_get    (duncecap_store_t *, hatrack_hash_t, bool *);
+static void             *duncecap_store_put    (duncecap_store_t *, duncecap_t *, hatrack_hash_t, void *, bool *);
+static void             *duncecap_store_replace(duncecap_store_t *, hatrack_hash_t, void *, bool *);
+static bool              duncecap_store_add    (duncecap_store_t *, duncecap_t *, hatrack_hash_t, void *);
+static void             *duncecap_store_remove (duncecap_store_t *, duncecap_t *, hatrack_hash_t, bool *);
 static void             duncecap_migrate       (duncecap_t *);
 // clang-format on
 
@@ -541,15 +533,14 @@ duncecap_view_mmm(duncecap_t *self, mmm_thread_t *thread, uint64_t *num, bool so
     return duncecap_view(self, num, sort);
 }
 
-// clang-format off
 static duncecap_store_t *
 duncecap_store_new(uint64_t size)
 {
     duncecap_store_t *ret;
     uint64_t          alloc_len;
 
-    alloc_len      = sizeof(duncecap_store_t);
-    alloc_len     += size * sizeof(duncecap_bucket_t);
+    alloc_len = sizeof(duncecap_store_t);
+    alloc_len += size * sizeof(duncecap_bucket_t);
     ret            = (duncecap_store_t *)hatrack_zalloc(alloc_len);
     ret->alloc_len = alloc_len;
     ret->last_slot = size - 1;
@@ -880,7 +871,7 @@ duncecap_migrate(duncecap_t *self)
 
     cur_store     = self->store_current;
     new_size      = hatrack_new_size(cur_store->last_slot,
-				     duncecap_len(self) + 1);
+                                duncecap_len(self) + 1);
     cur_last_slot = cur_store->last_slot;
     new_last_slot = new_size - 1;
     new_store     = duncecap_store_new(new_size);

--- a/src/hatrack/hash/hihat-a.c
+++ b/src/hatrack/hash/hihat-a.c
@@ -46,18 +46,13 @@
 
 // clang-format off
 static hihat_store_t *hihat_a_store_new    (uint64_t);
-static void          *hihat_a_store_get    (hihat_store_t *, hatrack_hash_t,
-					    bool *);
-static void          *hihat_a_store_put    (hihat_store_t *, mmm_thread_t *, hihat_t *,
-					    hatrack_hash_t, void *, bool *);
-static void          *hihat_a_store_replace(hihat_store_t *, mmm_thread_t *, hihat_t *,
-					    hatrack_hash_t, void *, bool *);
-static bool           hihat_a_store_add    (hihat_store_t *, mmm_thread_t *, hihat_t *,
-					    hatrack_hash_t, void *);
-static void          *hihat_a_store_remove (hihat_store_t *, mmm_thread_t *, hihat_t *,
-					    hatrack_hash_t, bool *);
+static void          *hihat_a_store_get    (hihat_store_t *, hatrack_hash_t, bool *);
+static void          *hihat_a_store_put    (hihat_store_t *, mmm_thread_t *, hihat_t *, hatrack_hash_t, void *, bool *);
+static void          *hihat_a_store_replace(hihat_store_t *, mmm_thread_t *, hihat_t *, hatrack_hash_t, void *, bool *);
+static bool           hihat_a_store_add    (hihat_store_t *, mmm_thread_t *, hihat_t *, hatrack_hash_t, void *);
+static void          *hihat_a_store_remove (hihat_store_t *, mmm_thread_t *, hihat_t *, hatrack_hash_t, bool *);
 static hihat_store_t *hihat_a_store_migrate(hihat_store_t *, mmm_thread_t *, hihat_t *);
-
+// clang-format on
 
 hihat_t *
 hihat_a_new(void)
@@ -99,11 +94,11 @@ hihat_a_init_size(hihat_t *self, char size)
     uint64_t       len;
 
     if (((size_t)size) > (sizeof(intptr_t) * 8)) {
-	abort();
+        abort();
     }
 
     if (size < HATRACK_MIN_SIZE_LOG) {
-	abort();
+        abort();
     }
 
     len              = 1 << size;
@@ -133,11 +128,10 @@ hihat_a_delete(hihat_t *self)
     return;
 }
 
-
 void *
 hihat_a_get_mmm(hihat_t *self, mmm_thread_t *thread, hatrack_hash_t hv, bool *found)
 {
-    void           *ret;
+    void          *ret;
     hihat_store_t *store;
 
     mmm_start_basic_op(thread);
@@ -159,7 +153,7 @@ hihat_a_get(hihat_t *self, hatrack_hash_t hv, bool *found)
 void *
 hihat_a_put_mmm(hihat_t *self, mmm_thread_t *thread, hatrack_hash_t hv, void *item, bool *found)
 {
-    void           *ret;
+    void          *ret;
     hihat_store_t *store;
 
     mmm_start_basic_op(thread);
@@ -181,7 +175,7 @@ hihat_a_put(hihat_t *self, hatrack_hash_t hv, void *item, bool *found)
 void *
 hihat_a_replace_mmm(hihat_t *self, mmm_thread_t *thread, hatrack_hash_t hv, void *item, bool *found)
 {
-    void           *ret;
+    void          *ret;
     hihat_store_t *store;
 
     mmm_start_basic_op(thread);
@@ -203,7 +197,7 @@ hihat_a_replace(hihat_t *self, hatrack_hash_t hv, void *item, bool *found)
 bool
 hihat_a_add_mmm(hihat_t *self, mmm_thread_t *thread, hatrack_hash_t hv, void *item)
 {
-    bool            ret;
+    bool           ret;
     hihat_store_t *store;
 
     mmm_start_basic_op(thread);
@@ -225,7 +219,7 @@ hihat_a_add(hihat_t *self, hatrack_hash_t hv, void *item)
 void *
 hihat_a_remove_mmm(hihat_t *self, mmm_thread_t *thread, hatrack_hash_t hv, bool *found)
 {
-    void           *ret;
+    void          *ret;
     hihat_store_t *store;
 
     mmm_start_basic_op(thread);
@@ -280,12 +274,12 @@ hihat_a_view_mmm(hihat_t *self, mmm_thread_t *thread, uint64_t *num, bool sort)
 
     while (cur < end) {
         record       = atomic_read(&cur->record);
-	record_epoch = record.info & HIHAT_EPOCH_MASK;
+        record_epoch = record.info & HIHAT_EPOCH_MASK;
 
-	if (!record_epoch) {
-	    cur++;
-	    continue;
-	}
+        if (!record_epoch) {
+            cur++;
+            continue;
+        }
 
         p->sort_epoch = record_epoch;
         p->item       = record.item;
@@ -307,7 +301,7 @@ hihat_a_view_mmm(hihat_t *self, mmm_thread_t *thread, uint64_t *num, bool sort)
     view = hatrack_realloc(view, alloc_len, num_items * sizeof(hatrack_view_t));
 
     if (sort) {
-	qsort(view, num_items, sizeof(hatrack_view_t), hatrack_quicksort_cmp);
+        qsort(view, num_items, sizeof(hatrack_view_t), hatrack_quicksort_cmp);
     }
 
     mmm_end_op(thread);
@@ -327,18 +321,18 @@ hihat_a_store_new(uint64_t size)
     hihat_store_t *store;
     uint64_t       alloc_len;
 
-    alloc_len         = sizeof(hihat_store_t) + sizeof(hihat_bucket_t) * size;
-    store             = (hihat_store_t *)mmm_alloc_committed(alloc_len);
-    store->last_slot  = size - 1;
-    store->threshold  = hatrack_compute_table_threshold(size);
+    alloc_len        = sizeof(hihat_store_t) + sizeof(hihat_bucket_t) * size;
+    store            = (hihat_store_t *)mmm_alloc_committed(alloc_len);
+    store->last_slot = size - 1;
+    store->threshold = hatrack_compute_table_threshold(size);
 
     return store;
 }
 
 static void *
 hihat_a_store_get(hihat_store_t *self,
-                 hatrack_hash_t  hv1,
-                 bool           *found)
+                  hatrack_hash_t hv1,
+                  bool          *found)
 {
     uint64_t        bix;
     uint64_t        i;
@@ -382,11 +376,11 @@ not_found:
 
 static void *
 hihat_a_store_put(hihat_store_t *self,
-mmm_thread_t *thread,
-                 hihat_t        *top,
-                 hatrack_hash_t  hv1,
-                 void           *item,
-                 bool           *found)
+                  mmm_thread_t  *thread,
+                  hihat_t       *top,
+                  hatrack_hash_t hv1,
+                  void          *item,
+                  bool          *found)
 {
     void           *old_item;
     bool            new_item;
@@ -401,53 +395,52 @@ mmm_thread_t *thread,
 
     for (i = 0; i <= self->last_slot; i++) {
         bucket = &self->buckets[bix];
-	hv2    = atomic_read(&bucket->hv);
+        hv2    = atomic_read(&bucket->hv);
 
-	if (hatrack_bucket_unreserved(hv2)) {
-	    if (LCAS(&bucket->hv, &hv2, hv1, HIHAT_CTR_BUCKET_ACQUIRE)) {
+        if (hatrack_bucket_unreserved(hv2)) {
+            if (LCAS(&bucket->hv, &hv2, hv1, HIHAT_CTR_BUCKET_ACQUIRE)) {
+                if (atomic_fetch_add(&self->used_count, 1) >= self->threshold) {
+                    goto migrate_and_retry;
+                }
 
-		if (atomic_fetch_add(&self->used_count, 1) >= self->threshold) {
-		    goto migrate_and_retry;
-		}
+                goto found_bucket;
+            }
+        }
 
-		goto found_bucket;
-	    }
-	}
-
-	if (!hatrack_hashes_eq(hv1, hv2)) {
-	    bix = (bix + 1) & self->last_slot;
-	    continue;
-	}
+        if (!hatrack_hashes_eq(hv1, hv2)) {
+            bix = (bix + 1) & self->last_slot;
+            continue;
+        }
 
         goto found_bucket;
     }
- migrate_and_retry:
+migrate_and_retry:
     self = hihat_a_store_migrate(self, thread, top);
     return hihat_a_store_put(self, thread, top, hv1, item, found);
 
- found_bucket:
+found_bucket:
     record = atomic_read(&bucket->record);
     if (record.info & HIHAT_F_MOVING) {
-	goto migrate_and_retry;
+        goto migrate_and_retry;
     }
 
     if (record.info & HIHAT_EPOCH_MASK) {
-	if (found) {
-	    *found = true;
-	}
+        if (found) {
+            *found = true;
+        }
 
-	old_item       = record.item;
-	new_item       = false;
-	candidate.info = record.info;
+        old_item       = record.item;
+        new_item       = false;
+        candidate.info = record.info;
     }
     else {
-	if (found) {
-	    *found = false;
-	}
+        if (found) {
+            *found = false;
+        }
 
-	old_item       = NULL;
-	new_item       = true;
-	candidate.info = HIHAT_F_INITED | top->next_epoch++;
+        old_item       = NULL;
+        new_item       = true;
+        candidate.info = HIHAT_F_INITED | top->next_epoch++;
     }
 
     candidate.item = item;
@@ -461,7 +454,7 @@ mmm_thread_t *thread,
     }
 
     if (record.info & HIHAT_F_MOVING) {
-	goto migrate_and_retry;
+        goto migrate_and_retry;
     }
 
     return item;
@@ -469,11 +462,11 @@ mmm_thread_t *thread,
 
 static void *
 hihat_a_store_replace(hihat_store_t *self,
-mmm_thread_t *thread,
-		     hihat_t        *top,
-		     hatrack_hash_t  hv1,
-		     void           *item,
-		     bool           *found)
+                      mmm_thread_t  *thread,
+                      hihat_t       *top,
+                      hatrack_hash_t hv1,
+                      void          *item,
+                      bool          *found)
 {
     uint64_t        bix;
     uint64_t        i;
@@ -486,55 +479,55 @@ mmm_thread_t *thread,
 
     for (i = 0; i <= self->last_slot; i++) {
         bucket = &self->buckets[bix];
-	hv2    = atomic_read(&bucket->hv);
+        hv2    = atomic_read(&bucket->hv);
 
-	if (hatrack_bucket_unreserved(hv2)) {
-	    goto not_found;
-	}
+        if (hatrack_bucket_unreserved(hv2)) {
+            goto not_found;
+        }
 
-	if (!hatrack_hashes_eq(hv1, hv2)) {
-	    bix = (bix + 1) & self->last_slot;
-	    continue;
-	}
+        if (!hatrack_hashes_eq(hv1, hv2)) {
+            bix = (bix + 1) & self->last_slot;
+            continue;
+        }
 
         goto found_bucket;
     }
 
- not_found:
+not_found:
     if (found) {
-	*found = false;
+        *found = false;
     }
 
     return NULL;
 
- found_bucket:
+found_bucket:
     record = atomic_read(&bucket->record);
 
     if (record.info & HIHAT_F_MOVING) {
-    migrate_and_retry:
-	self = hihat_a_store_migrate(self, thread, top);
-	return hihat_a_store_replace(self, thread, top, hv1, item, found);
+migrate_and_retry:
+        self = hihat_a_store_migrate(self, thread, top);
+        return hihat_a_store_replace(self, thread, top, hv1, item, found);
     }
 
     if (!(record.info & HIHAT_EPOCH_MASK)) {
-	goto not_found;
+        goto not_found;
     }
 
     candidate.item = item;
     candidate.info = record.info;
 
-    while(!LCAS(&bucket->record, &record, candidate, HIHAT_CTR_REC_INSTALL)) {
-	if (record.info & HIHAT_F_MOVING) {
-	    goto migrate_and_retry;
-	}
+    while (!LCAS(&bucket->record, &record, candidate, HIHAT_CTR_REC_INSTALL)) {
+        if (record.info & HIHAT_F_MOVING) {
+            goto migrate_and_retry;
+        }
 
-	if (!(record.info & HIHAT_EPOCH_MASK)) {
-	    goto not_found;
-	}
+        if (!(record.info & HIHAT_EPOCH_MASK)) {
+            goto not_found;
+        }
     }
 
     if (found) {
-	*found = true;
+        *found = true;
     }
 
     return record.item;
@@ -542,10 +535,10 @@ mmm_thread_t *thread,
 
 static bool
 hihat_a_store_add(hihat_store_t *self,
-mmm_thread_t *thread,
-		 hihat_t        *top,
-		 hatrack_hash_t  hv1,
-		 void           *item)
+                  mmm_thread_t  *thread,
+                  hihat_t       *top,
+                  hatrack_hash_t hv1,
+                  void          *item)
 {
     uint64_t        bix;
     uint64_t        i;
@@ -558,28 +551,27 @@ mmm_thread_t *thread,
 
     for (i = 0; i <= self->last_slot; i++) {
         bucket = &self->buckets[bix];
-	hv2    = atomic_read(&bucket->hv);
+        hv2    = atomic_read(&bucket->hv);
 
-	if (hatrack_bucket_unreserved(hv2)) {
-	    if (LCAS(&bucket->hv, &hv2, hv1, HIHAT_CTR_BUCKET_ACQUIRE)) {
+        if (hatrack_bucket_unreserved(hv2)) {
+            if (LCAS(&bucket->hv, &hv2, hv1, HIHAT_CTR_BUCKET_ACQUIRE)) {
+                if (atomic_fetch_add(&self->used_count, 1) >= self->threshold) {
+                    goto migrate_and_retry;
+                }
 
-		if (atomic_fetch_add(&self->used_count, 1) >= self->threshold) {
-		    goto migrate_and_retry;
-		}
+                goto found_bucket;
+            }
+        }
 
-		goto found_bucket;
-	    }
-	}
-
-	if (!hatrack_hashes_eq(hv1, hv2)) {
-	    bix = (bix + 1) & self->last_slot;
-	    continue;
-	}
+        if (!hatrack_hashes_eq(hv1, hv2)) {
+            bix = (bix + 1) & self->last_slot;
+            continue;
+        }
 
         goto found_bucket;
     }
 
- migrate_and_retry:
+migrate_and_retry:
     self = hihat_a_store_migrate(self, thread, top);
     return hihat_a_store_add(self, thread, top, hv1, item);
 
@@ -587,7 +579,7 @@ found_bucket:
     record = atomic_read(&bucket->record);
 
     if (record.info & HIHAT_F_MOVING) {
-	goto migrate_and_retry;
+        goto migrate_and_retry;
     }
 
     if (record.info & HIHAT_EPOCH_MASK) {
@@ -598,12 +590,12 @@ found_bucket:
     candidate.info = HIHAT_F_INITED | top->next_epoch++;
 
     if (LCAS(&bucket->record, &record, candidate, HIHAT_CTR_REC_INSTALL)) {
-	atomic_fetch_add(&top->item_count, 1);
+        atomic_fetch_add(&top->item_count, 1);
         return true;
     }
 
     if (record.info & HIHAT_F_MOVING) {
-	goto migrate_and_retry;
+        goto migrate_and_retry;
     }
 
     return false;
@@ -611,10 +603,10 @@ found_bucket:
 
 static void *
 hihat_a_store_remove(hihat_store_t *self,
-mmm_thread_t *thread,
-                    hihat_t        *top,
-                    hatrack_hash_t  hv1,
-                    bool           *found)
+                     mmm_thread_t  *thread,
+                     hihat_t       *top,
+                     hatrack_hash_t hv1,
+                     bool          *found)
 {
     void           *old_item;
     uint64_t        bix;
@@ -652,10 +644,10 @@ found_bucket:
     record = atomic_read(&bucket->record);
 
     if (record.info & HIHAT_F_MOVING) {
-    migrate_and_retry:
-	self = hihat_a_store_migrate(self, thread, top);
+migrate_and_retry:
+        self = hihat_a_store_migrate(self, thread, top);
 
-	return hihat_a_store_remove(self, thread, top, hv1, found);
+        return hihat_a_store_remove(self, thread, top, hv1, found);
     }
 
     if (!(record.info & HIHAT_EPOCH_MASK)) {
@@ -681,7 +673,7 @@ found_bucket:
     }
 
     if (record.info & HIHAT_F_MOVING) {
-	goto migrate_and_retry;
+        goto migrate_and_retry;
     }
 
     if (found) {
@@ -702,26 +694,25 @@ found_bucket:
  */
 static const struct timespec sleep_time = {
     .tv_sec  = 0,
-    .tv_nsec = HIHATa_MIGRATE_SLEEP_TIME_NS
-};
+    .tv_nsec = HIHATa_MIGRATE_SLEEP_TIME_NS};
 
 static hihat_store_t *
 hihat_a_store_migrate(hihat_store_t *self, mmm_thread_t *thread, hihat_t *top)
 {
-    hihat_store_t   *new_store;
-    hihat_store_t   *candidate_store;
-    uint64_t         new_size;
-    hihat_bucket_t  *bucket;
-    hihat_bucket_t  *new_bucket;
-    hihat_record_t   record;
-    hihat_record_t   candidate_record;
-    hihat_record_t   expected_record;
-    hatrack_hash_t   expected_hv;
-    hatrack_hash_t   hv;
-    uint64_t         i, j;
-    uint64_t         bix;
-    uint64_t         new_used;
-    uint64_t         expected_used;
+    hihat_store_t  *new_store;
+    hihat_store_t  *candidate_store;
+    uint64_t        new_size;
+    hihat_bucket_t *bucket;
+    hihat_bucket_t *new_bucket;
+    hihat_record_t  record;
+    hihat_record_t  candidate_record;
+    hihat_record_t  expected_record;
+    hatrack_hash_t  expected_hv;
+    hatrack_hash_t  hv;
+    uint64_t        i, j;
+    uint64_t        bix;
+    uint64_t        new_used;
+    uint64_t        expected_used;
 
     /* We first check to see if there's already a new
      * store in place in the top level. If there is, we can succeed
@@ -743,34 +734,34 @@ hihat_a_store_migrate(hihat_store_t *self, mmm_thread_t *thread, hihat_t *top)
     new_store = atomic_read(&top->store_current);
 
     if (new_store != self) {
-	return new_store;
+        return new_store;
     }
 
     new_store = atomic_read(&self->store_next);
 
     if (new_store) {
-	// Try twice to let anyone in front of us complete the migration.
-	nanosleep(&sleep_time, NULL);
-	new_store = atomic_read(&self->store_next);
+        // Try twice to let anyone in front of us complete the migration.
+        nanosleep(&sleep_time, NULL);
+        new_store = atomic_read(&self->store_next);
 
-	if (new_store == atomic_read(&top->store_current)) {
-	    HATRACK_CTR(HATRACK_CTR_HIa_SLEEP1_WORKED);
-	    return new_store;
-	}
+        if (new_store == atomic_read(&top->store_current)) {
+            HATRACK_CTR(HATRACK_CTR_HIa_SLEEP1_WORKED);
+            return new_store;
+        }
 
-	HATRACK_CTR(HATRACK_CTR_HIa_SLEEP1_FAILED);
+        HATRACK_CTR(HATRACK_CTR_HIa_SLEEP1_FAILED);
 
-	nanosleep(&sleep_time, NULL);
-	new_store = atomic_read(&self->store_next);
+        nanosleep(&sleep_time, NULL);
+        new_store = atomic_read(&self->store_next);
 
-	if (new_store == atomic_read(&top->store_current)) {
-	    HATRACK_CTR(HATRACK_CTR_HIa_SLEEP2_WORKED);
-	    return new_store;
-	}
+        if (new_store == atomic_read(&top->store_current)) {
+            HATRACK_CTR(HATRACK_CTR_HIa_SLEEP2_WORKED);
+            return new_store;
+        }
 
-	HATRACK_CTR(HATRACK_CTR_HIa_SLEEP2_FAILED);
+        HATRACK_CTR(HATRACK_CTR_HIa_SLEEP2_FAILED);
 
-	goto have_new_store;
+        goto have_new_store;
     }
 
     for (i = 0; i <= self->last_slot; i++) {
@@ -778,24 +769,24 @@ hihat_a_store_migrate(hihat_store_t *self, mmm_thread_t *thread, hihat_t *top)
         record                = atomic_read(&bucket->record);
         candidate_record.item = record.item;
 
-	if (record.info & HIHAT_F_MOVING) {
-	    if (record.info & HIHAT_EPOCH_MASK) {
-		new_used++;
-	    }
+        if (record.info & HIHAT_F_MOVING) {
+            if (record.info & HIHAT_EPOCH_MASK) {
+                new_used++;
+            }
 
-	    continue;
-	}
+            continue;
+        }
 
-	OR2X64L(&bucket->record, HIHAT_F_MOVING);
+        OR2X64L(&bucket->record, HIHAT_F_MOVING);
 
-	record = atomic_read(&bucket->record);
+        record = atomic_read(&bucket->record);
 
-	if (record.info & HIHAT_EPOCH_MASK) {
-	    new_used++;
-	}
-	else {
-	    OR2X64L(&bucket->record, HIHAT_F_MOVING | HIHAT_F_MOVED);
-	}
+        if (record.info & HIHAT_EPOCH_MASK) {
+            new_used++;
+        }
+        else {
+            OR2X64L(&bucket->record, HIHAT_F_MOVING | HIHAT_F_MOVED);
+        }
     }
 
     new_store = atomic_read(&self->store_next);
@@ -808,14 +799,13 @@ hihat_a_store_migrate(hihat_store_t *self, mmm_thread_t *thread, hihat_t *top)
                   &new_store,
                   candidate_store,
                   HIHAT_CTR_NEW_STORE)) {
-
             mmm_retire_unused(candidate_store);
-	    /* This is another place we can potentially sleep if we
-	     * lose. However, we're not that far behind, and if there
-	     * are only two threads going, the bigger the table, the
-	     * more likely the lead thread is to get pre-empted at
-	     * some point. So let's just soldier on through.
-	     */
+            /* This is another place we can potentially sleep if we
+             * lose. However, we're not that far behind, and if there
+             * are only two threads going, the bigger the table, the
+             * more likely the lead thread is to get pre-empted at
+             * some point. So let's just soldier on through.
+             */
         }
         else {
             new_store = candidate_store;
@@ -829,16 +819,16 @@ hihat_a_store_migrate(hihat_store_t *self, mmm_thread_t *thread, hihat_t *top)
      * That means, unlike with hihat, we have to RE-count, just in
      * case we are the thread that installs the value in the new table.
      */
- have_new_store:
+have_new_store:
     new_used = 0;
 
     for (i = 0; i <= self->last_slot; i++) {
         bucket = &self->buckets[i];
         record = atomic_read(&bucket->record);
 
-	if (record.info & HIHAT_EPOCH_MASK) {
-	    new_used++;
-	}
+        if (record.info & HIHAT_EPOCH_MASK) {
+            new_used++;
+        }
 
         if (record.info & HIHAT_F_MOVED) {
             continue;
@@ -848,37 +838,36 @@ hihat_a_store_migrate(hihat_store_t *self, mmm_thread_t *thread, hihat_t *top)
         bix = hatrack_bucket_index(hv, new_store->last_slot);
 
         for (j = 0; j <= new_store->last_slot; j++) {
-            new_bucket     = &new_store->buckets[bix];
-	    expected_hv    = atomic_read(&new_bucket->hv);
+            new_bucket  = &new_store->buckets[bix];
+            expected_hv = atomic_read(&new_bucket->hv);
 
-	    if (hatrack_bucket_unreserved(expected_hv)) {
-		if (LCAS(&new_bucket->hv,
-			 &expected_hv,
-			 hv,
-			 HIHAT_CTR_MIGRATE_HV)) {
-		    break;
-		}
-	    }
+            if (hatrack_bucket_unreserved(expected_hv)) {
+                if (LCAS(&new_bucket->hv,
+                         &expected_hv,
+                         hv,
+                         HIHAT_CTR_MIGRATE_HV)) {
+                    break;
+                }
+            }
 
-	    if (!hatrack_hashes_eq(expected_hv, hv)) {
-		bix = (bix + 1) & new_store->last_slot;
-		continue;
+            if (!hatrack_hashes_eq(expected_hv, hv)) {
+                bix = (bix + 1) & new_store->last_slot;
+                continue;
             }
             break;
         }
 
-        candidate_record.info = (record.info & HIHAT_EPOCH_MASK) |
-	                        HIHAT_F_INITED;
+        candidate_record.info = (record.info & HIHAT_EPOCH_MASK) | HIHAT_F_INITED;
         candidate_record.item = record.item;
         expected_record.info  = 0;
         expected_record.item  = NULL;
 
         LCAS(&new_bucket->record,
-	     &expected_record,
-	     candidate_record,
-	     HIHAT_CTR_MIG_REC);
+             &expected_record,
+             candidate_record,
+             HIHAT_CTR_MIG_REC);
 
-	OR2X64L(&bucket->record, HIHAT_F_MOVED);
+        OR2X64L(&bucket->record, HIHAT_F_MOVED);
     }
 
     expected_used = 0;

--- a/src/hatrack/hash/hihat.c
+++ b/src/hatrack/hash/hihat.c
@@ -33,17 +33,13 @@
 
 // clang-format off
 static hihat_store_t *hihat_store_new    (uint64_t);
-static void          *hihat_store_get    (hihat_store_t *, hatrack_hash_t,
-					  bool *);
-static void          *hihat_store_put    (hihat_store_t *, mmm_thread_t *, hihat_t *,
-					  hatrack_hash_t, void *, bool *);
-static void          *hihat_store_replace(hihat_store_t *, mmm_thread_t *, hihat_t *,
-					  hatrack_hash_t, void *, bool *);
-static bool           hihat_store_add    (hihat_store_t *, mmm_thread_t *, hihat_t *,
-					  hatrack_hash_t, void *);
-static void          *hihat_store_remove (hihat_store_t *, mmm_thread_t *, hihat_t *,
-					  hatrack_hash_t, bool *);
+static void          *hihat_store_get    (hihat_store_t *, hatrack_hash_t, bool *);
+static void          *hihat_store_put    (hihat_store_t *, mmm_thread_t *, hihat_t *, hatrack_hash_t, void *, bool *);
+static void          *hihat_store_replace(hihat_store_t *, mmm_thread_t *, hihat_t *, hatrack_hash_t, void *, bool *);
+static bool           hihat_store_add    (hihat_store_t *, mmm_thread_t *, hihat_t *, hatrack_hash_t, void *);
+static void          *hihat_store_remove (hihat_store_t *, mmm_thread_t *, hihat_t *, hatrack_hash_t, bool *);
 static hihat_store_t *hihat_store_migrate(hihat_store_t *, mmm_thread_t *, hihat_t *);
+// clang-format on
 
 /* hihat_new()
  *
@@ -88,11 +84,11 @@ hihat_init_size(hihat_t *self, char size)
     uint64_t       len;
 
     if (((size_t)size) > (sizeof(intptr_t) * 8)) {
-	abort();
+        abort();
     }
 
     if (size < HATRACK_MIN_SIZE_LOG) {
-	abort();
+        abort();
     }
 
     len              = 1 << size;
@@ -124,7 +120,6 @@ hihat_cleanup(hihat_t *self)
     return;
 }
 
-
 /* hihat_delete()
  *
  * Deallocate a hihat object and its internal state (via hihat_cleanup).
@@ -140,7 +135,6 @@ hihat_delete(hihat_t *self)
 
     return;
 }
-
 
 /* hihat_get(), _put(), _replace(), _add(), _remove()
  *
@@ -304,7 +298,7 @@ hihat_add(hihat_t *self, hatrack_hash_t hv, void *item)
 void *
 hihat_remove_mmm(hihat_t *self, mmm_thread_t *thread, hatrack_hash_t hv, bool *found)
 {
-    void           *ret;
+    void          *ret;
     hihat_store_t *store;
 
     mmm_start_basic_op(thread);
@@ -426,14 +420,14 @@ hihat_view_mmm(hihat_t *self, mmm_thread_t *thread, uint64_t *num, bool sort)
         record       = atomic_read(&cur->record);
         record_epoch = record.info & HIHAT_EPOCH_MASK;
 
-	// If there's no epoch in the record, then the bucket was
-	// empty, and we skip it.
-	if (!record_epoch) {
-	    cur++;
-	    continue;
-	}
+        // If there's no epoch in the record, then the bucket was
+        // empty, and we skip it.
+        if (!record_epoch) {
+            cur++;
+            continue;
+        }
 
-	p->sort_epoch = record_epoch;
+        p->sort_epoch = record_epoch;
         p->item       = record.item;
 
         p++;
@@ -453,9 +447,9 @@ hihat_view_mmm(hihat_t *self, mmm_thread_t *thread, uint64_t *num, bool sort)
     view = hatrack_realloc(view, alloc_len, num_items * sizeof(hatrack_view_t));
 
     if (sort) {
-	// Unordered buckets should be in random order, so quicksort
-	// is a good option.
-	qsort(view, num_items, sizeof(hatrack_view_t), hatrack_quicksort_cmp);
+        // Unordered buckets should be in random order, so quicksort
+        // is a good option.
+        qsort(view, num_items, sizeof(hatrack_view_t), hatrack_quicksort_cmp);
     }
 
     mmm_end_op(thread);
@@ -479,10 +473,10 @@ hihat_store_new(uint64_t size)
     hihat_store_t *store;
     uint64_t       alloc_len;
 
-    alloc_len         = sizeof(hihat_store_t) + sizeof(hihat_bucket_t) * size;
-    store             = (hihat_store_t *)mmm_alloc_committed(alloc_len);
-    store->last_slot  = size - 1;
-    store->threshold  = hatrack_compute_table_threshold(size);
+    alloc_len        = sizeof(hihat_store_t) + sizeof(hihat_bucket_t) * size;
+    store            = (hihat_store_t *)mmm_alloc_committed(alloc_len);
+    store->last_slot = size - 1;
+    store->threshold = hatrack_compute_table_threshold(size);
 
     return store;
 }
@@ -526,9 +520,9 @@ hihat_store_new(uint64_t size)
  * value we got.
  */
 static void *
-hihat_store_get(hihat_store_t  *self,
-                 hatrack_hash_t hv1,
-                 bool          *found)
+hihat_store_get(hihat_store_t *self,
+                hatrack_hash_t hv1,
+                bool          *found)
 {
     uint64_t        bix;
     uint64_t        i;
@@ -613,12 +607,12 @@ not_found:
  * smaller and more easily digestable.
  */
 static void *
-hihat_store_put(hihat_store_t   *self,
-mmm_thread_t *thread,
-                 hihat_t        *top,
-                 hatrack_hash_t  hv1,
-                 void           *item,
-                 bool           *found)
+hihat_store_put(hihat_store_t *self,
+                mmm_thread_t  *thread,
+                hihat_t       *top,
+                hatrack_hash_t hv1,
+                void          *item,
+                bool          *found)
 {
     void           *old_item;
     bool            new_item;
@@ -633,48 +627,48 @@ mmm_thread_t *thread,
 
     for (i = 0; i <= self->last_slot; i++) {
         bucket = &self->buckets[bix];
-	/* We load the current hash value and check it, making sure
-	 * it's empty before we attempt to write out out value.
-	 * We *could* assume the bucket is empty, and attempt to
-	 * swap into it, then just move on if the swap fails.
-	 *
-	 * In my testing, it's generally significantly more performant
-	 * to do the extra check, and NOT CAS the hash value every
-	 * time.  The alternative involves a load anyway, since we
-	 * have to load 0's into the expected value (hv2), in that
-	 * case.
-	 */
-	hv2    = atomic_read(&bucket->hv);
+        /* We load the current hash value and check it, making sure
+         * it's empty before we attempt to write out out value.
+         * We *could* assume the bucket is empty, and attempt to
+         * swap into it, then just move on if the swap fails.
+         *
+         * In my testing, it's generally significantly more performant
+         * to do the extra check, and NOT CAS the hash value every
+         * time.  The alternative involves a load anyway, since we
+         * have to load 0's into the expected value (hv2), in that
+         * case.
+         */
+        hv2    = atomic_read(&bucket->hv);
 
-	if (hatrack_bucket_unreserved(hv2)) {
-	    /* Note that our compare-and-swap macro is defined in hatomic.h.
-	     * It includes a facility where, if we have counters turned on,
-	     * we can keep track of how often individual operations succed
-	     * or fail.
-	     *
-	     * When those facilities are off, the macros expand
-	     * directly to a C11 atomic_compare_exchange_strong()
-	     * operation.
-	     */
-	    if (LCAS(&bucket->hv, &hv2, hv1, HIHAT_CTR_BUCKET_ACQUIRE)) {
-		/* Our resize metric. If this insert puts us at the
-		 * 75% mark, then we need to resize. If this CAS
-		 * fails, we're not contributing to filling up the
-		 * table, because we're going to try to write over an
-		 * old record.  So we don't need to check on fail.
-		 */
-		if (atomic_fetch_add(&self->used_count, 1) >= self->threshold) {
-		    goto migrate_and_retry;
-		}
+        if (hatrack_bucket_unreserved(hv2)) {
+            /* Note that our compare-and-swap macro is defined in hatomic.h.
+             * It includes a facility where, if we have counters turned on,
+             * we can keep track of how often individual operations succed
+             * or fail.
+             *
+             * When those facilities are off, the macros expand
+             * directly to a C11 atomic_compare_exchange_strong()
+             * operation.
+             */
+            if (LCAS(&bucket->hv, &hv2, hv1, HIHAT_CTR_BUCKET_ACQUIRE)) {
+                /* Our resize metric. If this insert puts us at the
+                 * 75% mark, then we need to resize. If this CAS
+                 * fails, we're not contributing to filling up the
+                 * table, because we're going to try to write over an
+                 * old record.  So we don't need to check on fail.
+                 */
+                if (atomic_fetch_add(&self->used_count, 1) >= self->threshold) {
+                    goto migrate_and_retry;
+                }
 
-		goto found_bucket;
-	    }
-	}
+                goto found_bucket;
+            }
+        }
 
-	if (!hatrack_hashes_eq(hv1, hv2)) {
-	    bix = (bix + 1) & self->last_slot;
-	    continue;
-	}
+        if (!hatrack_hashes_eq(hv1, hv2)) {
+            bix = (bix + 1) & self->last_slot;
+            continue;
+        }
 
         goto found_bucket;
     }
@@ -683,11 +677,11 @@ mmm_thread_t *thread,
      * table got full, fast. We need to resize, to try to make room,
      * and then try again via a recursive call.
      */
- migrate_and_retry:
+migrate_and_retry:
     self = hihat_store_migrate(self, thread, top);
     return hihat_store_put(self, thread, top, hv1, item, found);
 
- found_bucket:
+found_bucket:
     /* Once we've found the right bucket, we are not quite ready to
      * try to write to it. First, we need to check to make sure that
      * this bucket isn't marked for migration.  If it is so marked,
@@ -697,54 +691,54 @@ mmm_thread_t *thread,
     record = atomic_read(&bucket->record);
 
     if (record.info & HIHAT_F_MOVING) {
-	goto migrate_and_retry;
+        goto migrate_and_retry;
     }
 
     /*
      * The way we tell if there's an actual item in this bucket is by
      * extracting the "epoch" (essentially a timestamp), and seeing if
      * it is non-zero.
-      */
+     */
     if (record.info & HIHAT_EPOCH_MASK) {
-	if (found) {
-	    *found = true;
-	}
-	/* We need to remember for later a couple of things:
-	 * 1) The old item, so that we can return it, but only
+        if (found) {
+            *found = true;
+        }
+        /* We need to remember for later a couple of things:
+         * 1) The old item, so that we can return it, but only
          *    if our CAS is successful, and
-	 *
-	 * 2) Whether or not this is a 'new item', If our CAS is
-	 *    successful. The thread that successfully adds the new
-	 *    item becomes responsible for updating the approximate
-	 *    item count.
-	 *
-	 * Plus, when setting up the record we want to swap in, since
-	 * there's already a value, we want to preserve its write
-	 * epoch for the purposes of sorting by insertion time.
-	 */
-	old_item       = record.item;
-	new_item       = false;
-	candidate.info = record.info;
+         *
+         * 2) Whether or not this is a 'new item', If our CAS is
+         *    successful. The thread that successfully adds the new
+         *    item becomes responsible for updating the approximate
+         *    item count.
+         *
+         * Plus, when setting up the record we want to swap in, since
+         * there's already a value, we want to preserve its write
+         * epoch for the purposes of sorting by insertion time.
+         */
+        old_item       = record.item;
+        new_item       = false;
+        candidate.info = record.info;
     }
     else {
-	if (found) {
-	    *found = false;
-	}
-	/* In this branch, we grab a new epoch for our (hopefully)
-	 * new item. The epoch will go unused if we don't win, and
-	 * that's just fine.
-	 *
-	 * On the flip side, multiple threads are creating epochs in
-	 * parallel, without ensuring atomicity. That means that more
-	 * than one item could end up with the same epoch.
-	 *
-	 * Since we aren't requiring full consistency for our views in
-	 * hihat, that doesn't matter to us. If we care about
-	 * consistency, lohat (and woolhat) solve this problem.
-	 */
-	old_item       = NULL;
-	new_item       = true;
-	candidate.info = HIHAT_F_INITED | top->next_epoch++;
+        if (found) {
+            *found = false;
+        }
+        /* In this branch, we grab a new epoch for our (hopefully)
+         * new item. The epoch will go unused if we don't win, and
+         * that's just fine.
+         *
+         * On the flip side, multiple threads are creating epochs in
+         * parallel, without ensuring atomicity. That means that more
+         * than one item could end up with the same epoch.
+         *
+         * Since we aren't requiring full consistency for our views in
+         * hihat, that doesn't matter to us. If we care about
+         * consistency, lohat (and woolhat) solve this problem.
+         */
+        old_item       = NULL;
+        new_item       = true;
+        candidate.info = HIHAT_F_INITED | top->next_epoch++;
     }
 
     candidate.item = item;
@@ -765,7 +759,7 @@ mmm_thread_t *thread,
      * the migration, before retrying our operation.
      */
     if (record.info & HIHAT_F_MOVING) {
-	goto migrate_and_retry;
+        goto migrate_and_retry;
     }
 
     return item;
@@ -779,12 +773,12 @@ mmm_thread_t *thread,
  * ourselves to concerns (somewhat) specific to a replace operation.
  */
 static void *
-hihat_store_replace(hihat_store_t   *self,
-		     mmm_thread_t *thread,
-hihat_t        *top,
-		     hatrack_hash_t  hv1,
-		     void           *item,
-		     bool           *found)
+hihat_store_replace(hihat_store_t *self,
+                    mmm_thread_t  *thread,
+                    hihat_t       *top,
+                    hatrack_hash_t hv1,
+                    void          *item,
+                    bool          *found)
 {
     uint64_t        bix;
     uint64_t        i;
@@ -797,39 +791,39 @@ hihat_t        *top,
 
     for (i = 0; i <= self->last_slot; i++) {
         bucket = &self->buckets[bix];
-	hv2    = atomic_read(&bucket->hv);
+        hv2    = atomic_read(&bucket->hv);
 
-	if (hatrack_bucket_unreserved(hv2)) {
-	    goto not_found;
-	}
+        if (hatrack_bucket_unreserved(hv2)) {
+            goto not_found;
+        }
 
-	if (!hatrack_hashes_eq(hv1, hv2)) {
-	    bix = (bix + 1) & self->last_slot;
-	    continue;
-	}
+        if (!hatrack_hashes_eq(hv1, hv2)) {
+            bix = (bix + 1) & self->last_slot;
+            continue;
+        }
 
         goto found_bucket;
     }
 
- not_found:
+not_found:
     if (found) {
-	*found = false;
+        *found = false;
     }
 
     return NULL;
 
- found_bucket:
+found_bucket:
     record = atomic_read(&bucket->record);
 
     if (record.info & HIHAT_F_MOVING) {
-    migrate_and_retry:
-	self = hihat_store_migrate(self, thread, top);
+migrate_and_retry:
+        self = hihat_store_migrate(self, thread, top);
 
-	return hihat_store_replace(self, thread, top, hv1, item, found);
+        return hihat_store_replace(self, thread, top, hv1, item, found);
     }
 
     if (!(record.info & HIHAT_EPOCH_MASK)) {
-	goto not_found;
+        goto not_found;
     }
 
     candidate.item = item;
@@ -856,18 +850,18 @@ hihat_t        *top,
      * this issue is one of the two real differences between hihat
      * and witchhat.
      */
-    while(!LCAS(&bucket->record, &record, candidate, HIHAT_CTR_REC_INSTALL)) {
-	if (record.info & HIHAT_F_MOVING) {
-	    goto migrate_and_retry;
-	}
+    while (!LCAS(&bucket->record, &record, candidate, HIHAT_CTR_REC_INSTALL)) {
+        if (record.info & HIHAT_F_MOVING) {
+            goto migrate_and_retry;
+        }
 
-	if (!(record.info & HIHAT_EPOCH_MASK)) {
-	    goto not_found;
-	}
+        if (!(record.info & HIHAT_EPOCH_MASK)) {
+            goto not_found;
+        }
     }
 
     if (found) {
-	*found = true;
+        *found = true;
     }
 
     return record.item;
@@ -885,11 +879,11 @@ hihat_t        *top,
  * parameter being passed.
  */
 static bool
-hihat_store_add(hihat_store_t   *self,
-mmm_thread_t *thread,
-		 hihat_t        *top,
-		 hatrack_hash_t  hv1,
-		 void           *item)
+hihat_store_add(hihat_store_t *self,
+                mmm_thread_t  *thread,
+                hihat_t       *top,
+                hatrack_hash_t hv1,
+                void          *item)
 {
     uint64_t        bix;
     uint64_t        i;
@@ -902,28 +896,27 @@ mmm_thread_t *thread,
 
     for (i = 0; i <= self->last_slot; i++) {
         bucket = &self->buckets[bix];
-	hv2    = atomic_read(&bucket->hv);
+        hv2    = atomic_read(&bucket->hv);
 
-	if (hatrack_bucket_unreserved(hv2)) {
-	    if (LCAS(&bucket->hv, &hv2, hv1, HIHAT_CTR_BUCKET_ACQUIRE)) {
+        if (hatrack_bucket_unreserved(hv2)) {
+            if (LCAS(&bucket->hv, &hv2, hv1, HIHAT_CTR_BUCKET_ACQUIRE)) {
+                if (atomic_fetch_add(&self->used_count, 1) >= self->threshold) {
+                    goto migrate_and_retry;
+                }
 
-		if (atomic_fetch_add(&self->used_count, 1) >= self->threshold) {
-		    goto migrate_and_retry;
-		}
+                goto found_bucket;
+            }
+        }
 
-		goto found_bucket;
-	    }
-	}
-
-	if (!hatrack_hashes_eq(hv1, hv2)) {
-	    bix = (bix + 1) & self->last_slot;
-	    continue;
-	}
+        if (!hatrack_hashes_eq(hv1, hv2)) {
+            bix = (bix + 1) & self->last_slot;
+            continue;
+        }
 
         goto found_bucket;
     }
 
- migrate_and_retry:
+migrate_and_retry:
     self = hihat_store_migrate(self, thread, top);
     return hihat_store_add(self, thread, top, hv1, item);
 
@@ -931,7 +924,7 @@ found_bucket:
     record = atomic_read(&bucket->record);
 
     if (record.info & HIHAT_F_MOVING) {
-	goto migrate_and_retry;
+        goto migrate_and_retry;
     }
 
     if (record.info & HIHAT_EPOCH_MASK) {
@@ -942,12 +935,12 @@ found_bucket:
     candidate.info = HIHAT_F_INITED | top->next_epoch++;
 
     if (LCAS(&bucket->record, &record, candidate, HIHAT_CTR_REC_INSTALL)) {
-	atomic_fetch_add(&top->item_count, 1);
+        atomic_fetch_add(&top->item_count, 1);
         return true;
     }
 
     if (record.info & HIHAT_F_MOVING) {
-	goto migrate_and_retry;
+        goto migrate_and_retry;
     }
 
     // Since we don't allow double deletions, at some point
@@ -966,11 +959,11 @@ found_bucket:
  * previous value for the sake of memory management.
  */
 static void *
-hihat_store_remove(hihat_store_t   *self,
-mmm_thread_t *thread,
-                    hihat_t        *top,
-                    hatrack_hash_t  hv1,
-                    bool           *found)
+hihat_store_remove(hihat_store_t *self,
+                   mmm_thread_t  *thread,
+                   hihat_t       *top,
+                   hatrack_hash_t hv1,
+                   bool          *found)
 {
     void           *old_item;
     uint64_t        bix;
@@ -1008,10 +1001,10 @@ found_bucket:
     record = atomic_read(&bucket->record);
 
     if (record.info & HIHAT_F_MOVING) {
-    migrate_and_retry:
-	self = hihat_store_migrate(self, thread, top);
+migrate_and_retry:
+        self = hihat_store_migrate(self, thread, top);
 
-	return hihat_store_remove(self, thread, top, hv1, found);
+        return hihat_store_remove(self, thread, top, hv1, found);
     }
 
     if (!(record.info & HIHAT_EPOCH_MASK)) {
@@ -1037,7 +1030,7 @@ found_bucket:
     }
 
     if (record.info & HIHAT_F_MOVING) {
-	goto migrate_and_retry;
+        goto migrate_and_retry;
     }
 
     if (found) {
@@ -1154,17 +1147,16 @@ hihat_store_migrate(hihat_store_t *self, mmm_thread_t *thread, hihat_t *top)
     uint64_t        new_used;
     uint64_t        expected_used;
 
-
     /* If we're a late-enough writer, let's just double check to see if
      * we need to help at all.
      */
     new_store = atomic_read(&top->store_current);
 
     if (new_store != self) {
-	return new_store;
+        return new_store;
     }
 
-    new_used  = 0;
+    new_used = 0;
 
     /* Quickly run through every history bucket, and mark any bucket
      * that doesn't already have F_MOVING set.  Note that the CAS
@@ -1193,33 +1185,34 @@ hihat_store_migrate(hihat_store_t *self, mmm_thread_t *thread, hihat_t *top)
         record                = atomic_read(&bucket->record);
         candidate_record.item = record.item;
 
-	/* Here, we look at the old record to count how many items
-	 * we're going to migrate, so we can try to install the value
-	 * in the new store when we're done, as used_count.
-	 *
-	 * Since used_count is part of our resize metric, we want this
-	 * to stay as accurate as possible, which is why we don't just
-	 * read item_count from the top-level... late writers might get
-	 * suspended before bumping the count, leading us to under-count
-	 * the items in the next table.
-	 */
+        /* Here, we look at the old record to count how many items
+         * we're going to migrate, so we can try to install the value
+         * in the new store when we're done, as used_count.
+         *
+         * Since used_count is part of our resize metric, we want this
+         * to stay as accurate as possible, which is why we don't just
+         * read item_count from the top-level... late writers might get
+         * suspended before bumping the count, leading us to under-count
+         * the items in the next table.
+         */
 
-	if (record.info & HIHAT_F_MOVING) {
-	    if (record.info & HIHAT_EPOCH_MASK) {
-		new_used++;
-	    }
-	    continue;
-	}
+        if (record.info & HIHAT_F_MOVING) {
+            if (record.info & HIHAT_EPOCH_MASK) {
+                new_used++;
+            }
+            continue;
+        }
 
-	OR2X64L(&bucket->record, HIHAT_F_MOVING);
+        OR2X64L(&bucket->record, HIHAT_F_MOVING);
 
-	record = atomic_read(&bucket->record);
+        record = atomic_read(&bucket->record);
 
-	if (record.info & HIHAT_EPOCH_MASK) {
-	    new_used++;
-	} else {
-	    OR2X64L(&bucket->record, HIHAT_F_MOVED);
-	}
+        if (record.info & HIHAT_EPOCH_MASK) {
+            new_used++;
+        }
+        else {
+            OR2X64L(&bucket->record, HIHAT_F_MOVED);
+        }
     }
 
     new_store = atomic_read(&self->store_next);
@@ -1287,54 +1280,54 @@ hihat_store_migrate(hihat_store_t *self, mmm_thread_t *thread, hihat_t *top)
             continue;
         }
 
-	// If it hasn't been moved, there's definitely an item in it,
-	// as empty buckets got MOVED set in the first loop.
+        // If it hasn't been moved, there's definitely an item in it,
+        // as empty buckets got MOVED set in the first loop.
         hv  = atomic_read(&bucket->hv);
         bix = hatrack_bucket_index(hv, new_store->last_slot);
 
-	// This loop acquires a bucket in the destination hash table,
-	// with the same bucket acquisition logic as operations above.
+        // This loop acquires a bucket in the destination hash table,
+        // with the same bucket acquisition logic as operations above.
         for (j = 0; j <= new_store->last_slot; j++) {
-            new_bucket     = &new_store->buckets[bix];
-	    expected_hv    = atomic_read(&new_bucket->hv);
+            new_bucket  = &new_store->buckets[bix];
+            expected_hv = atomic_read(&new_bucket->hv);
 
-	    if (hatrack_bucket_unreserved(expected_hv)) {
-		if (LCAS(&new_bucket->hv,
-			 &expected_hv,
-			 hv,
-			 HIHAT_CTR_MIGRATE_HV)) {
-		    break;
-		}
-	    }
+            if (hatrack_bucket_unreserved(expected_hv)) {
+                if (LCAS(&new_bucket->hv,
+                         &expected_hv,
+                         hv,
+                         HIHAT_CTR_MIGRATE_HV)) {
+                    break;
+                }
+            }
 
-	    if (!hatrack_hashes_eq(expected_hv, hv)) {
-		bix = (bix + 1) & new_store->last_slot;
-		continue;
+            if (!hatrack_hashes_eq(expected_hv, hv)) {
+                bix = (bix + 1) & new_store->last_slot;
+                continue;
             }
             break;
         }
 
-	/* Set up the value we want to install, as well as the
-	 * value we expect to see in the target bucket, if our
-	 * thread succeeds in doing the move.
-	 */
+        /* Set up the value we want to install, as well as the
+         * value we expect to see in the target bucket, if our
+         * thread succeeds in doing the move.
+         */
         candidate_record.info = record.info & HIHAT_EPOCH_MASK;
         candidate_record.item = record.item;
         expected_record.info  = 0;
         expected_record.item  = NULL;
 
-	// The only way this can fail is if some other thread succeeded,
-	// so we don't need to concern ourselves with the return value.
+        // The only way this can fail is if some other thread succeeded,
+        // so we don't need to concern ourselves with the return value.
         LCAS(&new_bucket->record,
-	     &expected_record,
-	     candidate_record,
-	     HIHAT_CTR_MIG_REC);
+             &expected_record,
+             candidate_record,
+             HIHAT_CTR_MIG_REC);
 
-	/* Whether we won or not, assume the winner might have
-	 * stalled.  Every thread updates the source
-	 * bucket, to denote that the move was successful.
-	 */
-	OR2X64L(&bucket->record, HIHAT_F_MOVED);
+        /* Whether we won or not, assume the winner might have
+         * stalled.  Every thread updates the source
+         * bucket, to denote that the move was successful.
+         */
+        OR2X64L(&bucket->record, HIHAT_F_MOVED);
     }
 
     /* All buckets are migrated. Attempt to write to the new table how

--- a/src/hatrack/hash/lohat.c
+++ b/src/hatrack/hash/lohat.c
@@ -35,16 +35,11 @@
 // clang-format off
 
 static lohat_store_t  *lohat_store_new    (uint64_t);
-static void           *lohat_store_get    (lohat_store_t *, hatrack_hash_t,
-					   bool *);
-static void           *lohat_store_put    (lohat_store_t *, mmm_thread_t *, lohat_t *,
-					   hatrack_hash_t, void *, bool *);
-static void           *lohat_store_replace(lohat_store_t *, mmm_thread_t *, lohat_t *,
-					   hatrack_hash_t, void *, bool *);
-static bool            lohat_store_add    (lohat_store_t *, mmm_thread_t *, lohat_t *,
-					   hatrack_hash_t, void *);
-static void           *lohat_store_remove (lohat_store_t *, mmm_thread_t *, lohat_t *,
-					   hatrack_hash_t, bool *);
+static void           *lohat_store_get    (lohat_store_t *, hatrack_hash_t, bool *);
+static void           *lohat_store_put    (lohat_store_t *, mmm_thread_t *, lohat_t *, hatrack_hash_t, void *, bool *);
+static void           *lohat_store_replace(lohat_store_t *, mmm_thread_t *, lohat_t *, hatrack_hash_t, void *, bool *);
+static bool            lohat_store_add    (lohat_store_t *, mmm_thread_t *, lohat_t *, hatrack_hash_t, void *);
+static void           *lohat_store_remove (lohat_store_t *, mmm_thread_t *, lohat_t *, hatrack_hash_t, bool *);
 static lohat_store_t  *lohat_store_migrate(lohat_store_t *, mmm_thread_t *, lohat_t *);
 
 // clang-format on

--- a/src/hatrack/hash/newshat.c
+++ b/src/hatrack/hash/newshat.c
@@ -39,18 +39,11 @@
 // stick it in our public prototypes.
        newshat_store_t *newshat_store_new    (uint64_t);
 static void             newshat_store_delete (newshat_store_t *, void *);
-static void            *newshat_store_get    (newshat_store_t *, hatrack_hash_t,
-					      bool *);
-static void            *newshat_store_put    (newshat_store_t *, mmm_thread_t *, newshat_t *,
-					      hatrack_hash_t, void *,
-					      bool *);
-static void            *newshat_store_replace(newshat_store_t *, mmm_thread_t *, newshat_t *,
-					      hatrack_hash_t, void *,
-					      bool *);
-static bool             newshat_store_add    (newshat_store_t *, mmm_thread_t *, newshat_t *,
-					      hatrack_hash_t, void *);
-static void            *newshat_store_remove (newshat_store_t *, mmm_thread_t *, newshat_t *,
-					      hatrack_hash_t, bool *);
+static void            *newshat_store_get    (newshat_store_t *, hatrack_hash_t, bool *);
+static void            *newshat_store_put    (newshat_store_t *, mmm_thread_t *, newshat_t *, hatrack_hash_t, void *, bool *);
+static void            *newshat_store_replace(newshat_store_t *, mmm_thread_t *, newshat_t *, hatrack_hash_t, void *, bool *);
+static bool             newshat_store_add    (newshat_store_t *, mmm_thread_t *, newshat_t *, hatrack_hash_t, void *);
+static void            *newshat_store_remove (newshat_store_t *, mmm_thread_t *, newshat_t *, hatrack_hash_t, bool *);
 static newshat_store_t *newshat_store_migrate(newshat_store_t *, mmm_thread_t *, newshat_t *);
 
 // clang-format on

--- a/src/hatrack/hash/swimcap.c
+++ b/src/hatrack/hash/swimcap.c
@@ -44,19 +44,11 @@
 
 // clang-format off
 static swimcap_store_t *swimcap_store_new    (uint64_t);
-static void            *swimcap_store_get    (swimcap_store_t *,
-					      hatrack_hash_t, bool *);
-static void            *swimcap_store_put    (swimcap_store_t *, mmm_thread_t *,
-					      swimcap_t *, hatrack_hash_t,
-					      void *, bool *);
-static void            *swimcap_store_replace(swimcap_store_t *, mmm_thread_t *,
-					      hatrack_hash_t, void *, bool *);
-static bool             swimcap_store_add    (swimcap_store_t *, mmm_thread_t *,
-					      swimcap_t *, hatrack_hash_t,
-					      void *);
-static void            *swimcap_store_remove (swimcap_store_t *, mmm_thread_t *,
-					      swimcap_t *, hatrack_hash_t,
-					      bool *);
+static void            *swimcap_store_get    (swimcap_store_t *, hatrack_hash_t, bool *);
+static void            *swimcap_store_put    (swimcap_store_t *, mmm_thread_t *, swimcap_t *, hatrack_hash_t, void *, bool *);
+static void            *swimcap_store_replace(swimcap_store_t *, mmm_thread_t *, hatrack_hash_t, void *, bool *);
+static bool             swimcap_store_add    (swimcap_store_t *, mmm_thread_t *, swimcap_t *, hatrack_hash_t, void *);
+static void            *swimcap_store_remove (swimcap_store_t *, mmm_thread_t *, swimcap_t *, hatrack_hash_t, bool *);
 static void             swimcap_migrate      (swimcap_t *, mmm_thread_t *);
 // clang-format on
 
@@ -544,7 +536,6 @@ swimcap_view(swimcap_t *self, uint64_t *num, bool sort)
  * strictly necessary for our use of MMM here; we really only care
  * about the epoch in which we were retired.
  */
-//clang-format off
 
 static swimcap_store_t *
 swimcap_store_new(uint64_t size)

--- a/src/hatrack/hash/witchhat.c
+++ b/src/hatrack/hash/witchhat.c
@@ -39,12 +39,13 @@
 
 #include <stdlib.h>
 
-// clang-format off
 // Most of the store functions are needed by other modules, for better
 // or worse, so we lifted their prototypes into the header.
-static witchhat_store_t  *witchhat_store_migrate(witchhat_store_t *, mmm_thread_t *, witchhat_t *);
-static inline bool        witchhat_help_required(uint64_t);
-static inline bool        witchhat_need_to_help (witchhat_t *);
+static witchhat_store_t *
+witchhat_store_migrate(witchhat_store_t *, mmm_thread_t *, witchhat_t *);
+
+static bool witchhat_help_required(uint64_t);
+static bool witchhat_need_to_help(witchhat_t *);
 
 witchhat_t *
 witchhat_new(void)
@@ -85,11 +86,11 @@ witchhat_init_size(witchhat_t *self, char size)
     uint64_t          len;
 
     if (((size_t)size) > (sizeof(intptr_t) * 8)) {
-	abort();
+        abort();
     }
 
     if (size < HATRACK_MIN_SIZE_LOG) {
-	abort();
+        abort();
     }
 
     len              = 1 << size;
@@ -122,7 +123,7 @@ witchhat_delete(witchhat_t *self)
 void *
 witchhat_get_mmm(witchhat_t *self, mmm_thread_t *thread, hatrack_hash_t hv, bool *found)
 {
-    void           *ret;
+    void             *ret;
     witchhat_store_t *store;
 
     mmm_start_basic_op(thread);
@@ -144,7 +145,7 @@ witchhat_get(witchhat_t *self, hatrack_hash_t hv, bool *found)
 void *
 witchhat_put_mmm(witchhat_t *self, mmm_thread_t *thread, hatrack_hash_t hv, void *item, bool *found)
 {
-    void           *ret;
+    void             *ret;
     witchhat_store_t *store;
 
     mmm_start_basic_op(thread);
@@ -166,7 +167,7 @@ witchhat_put(witchhat_t *self, hatrack_hash_t hv, void *item, bool *found)
 void *
 witchhat_replace_mmm(witchhat_t *self, mmm_thread_t *thread, hatrack_hash_t hv, void *item, bool *found)
 {
-    void           *ret;
+    void             *ret;
     witchhat_store_t *store;
 
     mmm_start_basic_op(thread);
@@ -188,7 +189,7 @@ witchhat_replace(witchhat_t *self, hatrack_hash_t hv, void *item, bool *found)
 bool
 witchhat_add_mmm(witchhat_t *self, mmm_thread_t *thread, hatrack_hash_t hv, void *item)
 {
-    bool            ret;
+    bool              ret;
     witchhat_store_t *store;
 
     mmm_start_basic_op(thread);
@@ -210,7 +211,7 @@ witchhat_add(witchhat_t *self, hatrack_hash_t hv, void *item)
 void *
 witchhat_remove_mmm(witchhat_t *self, mmm_thread_t *thread, hatrack_hash_t hv, bool *found)
 {
-    void           *ret;
+    void             *ret;
     witchhat_store_t *store;
 
     mmm_start_basic_op(thread);
@@ -242,7 +243,7 @@ witchhat_len_mmm(witchhat_t *self, mmm_thread_t *thread)
 }
 
 hatrack_view_t *
-witchhat_view_mmm(witchhat_t *self, mmm_thread_t * thread, uint64_t *num, bool start)
+witchhat_view_mmm(witchhat_t *self, mmm_thread_t *thread, uint64_t *num, bool start)
 {
     hatrack_view_t *ret;
 
@@ -287,12 +288,12 @@ witchhat_view_no_mmm(witchhat_t *self, uint64_t *num, bool sort)
         record        = atomic_read(&cur->record);
         p->sort_epoch = record.info & WITCHHAT_EPOCH_MASK;
 
-	if (!p->sort_epoch) {
-	    cur++;
-	    continue;
-	}
+        if (!p->sort_epoch) {
+            cur++;
+            continue;
+        }
 
-        p->item       = record.item;
+        p->item = record.item;
 
         p++;
         cur++;
@@ -310,7 +311,7 @@ witchhat_view_no_mmm(witchhat_t *self, uint64_t *num, bool sort)
     view = hatrack_realloc(view, alloc_len, num_items * sizeof(hatrack_view_t));
 
     if (sort) {
-	qsort(view, num_items, sizeof(hatrack_view_t), hatrack_quicksort_cmp);
+        qsort(view, num_items, sizeof(hatrack_view_t), hatrack_quicksort_cmp);
     }
 
     return view;
@@ -320,21 +321,21 @@ witchhat_store_t *
 witchhat_store_new(uint64_t size)
 {
     witchhat_store_t *store;
-    uint64_t        alloc_len;
+    uint64_t          alloc_len;
 
     alloc_len = sizeof(witchhat_store_t) + sizeof(witchhat_bucket_t) * size;
     store     = (witchhat_store_t *)mmm_alloc_committed(alloc_len);
 
-    store->last_slot  = size - 1;
-    store->threshold  = hatrack_compute_table_threshold(size);
+    store->last_slot = size - 1;
+    store->threshold = hatrack_compute_table_threshold(size);
 
     return store;
 }
 
 void *
 witchhat_store_get(witchhat_store_t *self,
-                 hatrack_hash_t      hv1,
-                 bool               *found)
+                   hatrack_hash_t    hv1,
+                   bool             *found)
 {
     uint64_t           bix;
     uint64_t           i;
@@ -378,12 +379,12 @@ not_found:
 
 void *
 witchhat_store_put(witchhat_store_t *self,
-mmm_thread_t *thread,
-		   witchhat_t       *top,
-		   hatrack_hash_t    hv1,
-		   void             *item,
-		   bool             *found,
-		   uint64_t          count)
+                   mmm_thread_t     *thread,
+                   witchhat_t       *top,
+                   hatrack_hash_t    hv1,
+                   void             *item,
+                   bool             *found,
+                   uint64_t          count)
 {
     void              *old_item;
     bool               new_item;
@@ -398,27 +399,27 @@ mmm_thread_t *thread,
 
     for (i = 0; i <= self->last_slot; i++) {
         bucket = &self->buckets[bix];
-	hv2    = atomic_read(&bucket->hv);
+        hv2    = atomic_read(&bucket->hv);
 
-	if (hatrack_bucket_unreserved(hv2)) {
-	    if (LCAS(&bucket->hv, &hv2, hv1, WITCHHAT_CTR_BUCKET_ACQUIRE)) {
-		if (atomic_fetch_add(&self->used_count, 1) >= self->threshold) {
-		    goto migrate_and_retry;
-		}
+        if (hatrack_bucket_unreserved(hv2)) {
+            if (LCAS(&bucket->hv, &hv2, hv1, WITCHHAT_CTR_BUCKET_ACQUIRE)) {
+                if (atomic_fetch_add(&self->used_count, 1) >= self->threshold) {
+                    goto migrate_and_retry;
+                }
 
-		goto found_bucket;
-	    }
-	}
+                goto found_bucket;
+            }
+        }
 
-	if (hatrack_hashes_eq(hv1, hv2)) {
-	    goto found_bucket;
-	}
+        if (hatrack_hashes_eq(hv1, hv2)) {
+            goto found_bucket;
+        }
 
-	bix = (bix + 1) & self->last_slot;
-	continue;
+        bix = (bix + 1) & self->last_slot;
+        continue;
     }
 
- migrate_and_retry:
+migrate_and_retry:
     /* One of the places where hihat is lock-free instead of wait-free
      * is when a write operation has to help migrate. In theory, it
      * could go help migrate, and by the time it tries to write again,
@@ -452,45 +453,45 @@ mmm_thread_t *thread,
      */
     count = count + 1;
     if (witchhat_help_required(count)) {
-	HATRACK_CTR(HATRACK_CTR_WH_HELP_REQUESTS);
+        HATRACK_CTR(HATRACK_CTR_WH_HELP_REQUESTS);
 
-	atomic_fetch_add(&top->help_needed, 1);
+        atomic_fetch_add(&top->help_needed, 1);
 
-	self     = witchhat_store_migrate(self, thread, top);
-	old_item = witchhat_store_put(self, thread, top, hv1, item, found, count);
+        self     = witchhat_store_migrate(self, thread, top);
+        old_item = witchhat_store_put(self, thread, top, hv1, item, found, count);
 
-	atomic_fetch_sub(&top->help_needed, 1);
+        atomic_fetch_sub(&top->help_needed, 1);
 
-	return old_item;
+        return old_item;
     }
 
     self = witchhat_store_migrate(self, thread, top);
     return witchhat_store_put(self, thread, top, hv1, item, found, count);
 
- found_bucket:
+found_bucket:
     record = atomic_read(&bucket->record);
 
     if (record.info & WITCHHAT_F_MOVING) {
-	goto migrate_and_retry;
+        goto migrate_and_retry;
     }
 
     if (record.info & WITCHHAT_EPOCH_MASK) {
-	if (found) {
-	    *found = true;
-	}
+        if (found) {
+            *found = true;
+        }
 
-	old_item       = record.item;
-	new_item       = false;
-	candidate.info = record.info;
+        old_item       = record.item;
+        new_item       = false;
+        candidate.info = record.info;
     }
     else {
-	if (found) {
-	    *found = false;
-	}
+        if (found) {
+            *found = false;
+        }
 
-	old_item       = NULL;
-	new_item       = true;
-	candidate.info = WITCHHAT_F_INITED | top->next_epoch++;
+        old_item       = NULL;
+        new_item       = true;
+        candidate.info = WITCHHAT_F_INITED | top->next_epoch++;
     }
 
     candidate.item = item;
@@ -504,7 +505,7 @@ mmm_thread_t *thread,
     }
 
     if (record.info & WITCHHAT_F_MOVING) {
-	goto migrate_and_retry;
+        goto migrate_and_retry;
     }
 
     /* In witchhat, whenever we successfully overwrite a value, we
@@ -514,9 +515,9 @@ mmm_thread_t *thread,
      * witchhat_store_migrate() wait free.
      */
     if (!new_item) {
-	if (atomic_read(&self->used_count) >= self->threshold) {
-	    witchhat_store_migrate(self, thread, top);
-	}
+        if (atomic_read(&self->used_count) >= self->threshold) {
+            witchhat_store_migrate(self, thread, top);
+        }
     }
 
     return item;
@@ -524,12 +525,12 @@ mmm_thread_t *thread,
 
 void *
 witchhat_store_replace(witchhat_store_t *self,
-mmm_thread_t *thread,
-		       witchhat_t       *top,
-		       hatrack_hash_t    hv1,
-		       void             *item,
-		       bool             *found,
-		       uint64_t          count)
+                       mmm_thread_t     *thread,
+                       witchhat_t       *top,
+                       hatrack_hash_t    hv1,
+                       void             *item,
+                       bool             *found,
+                       uint64_t          count)
 {
     void              *ret;
     uint64_t           bix;
@@ -543,53 +544,53 @@ mmm_thread_t *thread,
 
     for (i = 0; i <= self->last_slot; i++) {
         bucket = &self->buckets[bix];
-	hv2    = atomic_read(&bucket->hv);
+        hv2    = atomic_read(&bucket->hv);
 
-	if (hatrack_bucket_unreserved(hv2)) {
-	    goto not_found;
-	}
+        if (hatrack_bucket_unreserved(hv2)) {
+            goto not_found;
+        }
 
-	if (hatrack_hashes_eq(hv1, hv2)) {
-	    goto found_bucket;
-	}
+        if (hatrack_hashes_eq(hv1, hv2)) {
+            goto found_bucket;
+        }
 
-	bix = (bix + 1) & self->last_slot;
-	continue;
+        bix = (bix + 1) & self->last_slot;
+        continue;
     }
 
- not_found:
+not_found:
     if (found) {
-	*found = false;
+        *found = false;
     }
     return NULL;
 
- found_bucket:
+found_bucket:
     record = atomic_read(&bucket->record);
 
     if (record.info & WITCHHAT_F_MOVING) {
-    migrate_and_retry:
-	// This uses the same helping mechanism as in
-	// witchhat_store_put().  Look there for an overview.
-	count = count + 1;
+migrate_and_retry:
+        // This uses the same helping mechanism as in
+        // witchhat_store_put().  Look there for an overview.
+        count = count + 1;
 
-	if (witchhat_help_required(count)) {
-	    HATRACK_CTR(HATRACK_CTR_WH_HELP_REQUESTS);
+        if (witchhat_help_required(count)) {
+            HATRACK_CTR(HATRACK_CTR_WH_HELP_REQUESTS);
 
-	    atomic_fetch_add(&top->help_needed, 1);
-	    self = witchhat_store_migrate(self, thread, top);
-	    ret  = witchhat_store_replace(self, thread, top, hv1, item, found, count);
+            atomic_fetch_add(&top->help_needed, 1);
+            self = witchhat_store_migrate(self, thread, top);
+            ret  = witchhat_store_replace(self, thread, top, hv1, item, found, count);
 
-	    atomic_fetch_sub(&top->help_needed, 1);
+            atomic_fetch_sub(&top->help_needed, 1);
 
-	    return ret;
-	}
+            return ret;
+        }
 
-	self = witchhat_store_migrate(self, thread, top);
-	return witchhat_store_replace(self, thread, top, hv1, item, found, count);
+        self = witchhat_store_migrate(self, thread, top);
+        return witchhat_store_replace(self, thread, top, hv1, item, found, count);
     }
 
     if (!(record.info & WITCHHAT_EPOCH_MASK)) {
-	goto not_found;
+        goto not_found;
     }
 
     candidate.item = item;
@@ -618,16 +619,16 @@ mmm_thread_t *thread,
      * Essentially, all we are doing is simply replacing a while loop
      * that could theoretically last forever with a single attempt.
      */
-    if(!LCAS(&bucket->record, &record, candidate, WITCHHAT_CTR_REC_INSTALL)) {
-	if (record.info & WITCHHAT_F_MOVING) {
-	    goto migrate_and_retry;
-	}
+    if (!LCAS(&bucket->record, &record, candidate, WITCHHAT_CTR_REC_INSTALL)) {
+        if (record.info & WITCHHAT_F_MOVING) {
+            goto migrate_and_retry;
+        }
 
-	goto not_found;
+        goto not_found;
     }
 
     if (found) {
-	*found = true;
+        *found = true;
     }
 
     /* In witchhat, whenever we successfully overwrite a value, we
@@ -637,7 +638,7 @@ mmm_thread_t *thread,
      * wait free.
      */
     if (atomic_read(&self->used_count) >= self->threshold) {
-	witchhat_store_migrate(self, thread, top);
+        witchhat_store_migrate(self, thread, top);
     }
 
     return record.item;
@@ -645,11 +646,11 @@ mmm_thread_t *thread,
 
 bool
 witchhat_store_add(witchhat_store_t *self,
-mmm_thread_t *thread,
-		   witchhat_t       *top,
-		   hatrack_hash_t    hv1,
-		   void             *item,
-		   uint64_t          count)
+                   mmm_thread_t     *thread,
+                   witchhat_t       *top,
+                   hatrack_hash_t    hv1,
+                   void             *item,
+                   uint64_t          count)
 {
     uint64_t           bix;
     uint64_t           i;
@@ -662,42 +663,42 @@ mmm_thread_t *thread,
 
     for (i = 0; i <= self->last_slot; i++) {
         bucket = &self->buckets[bix];
-	hv2    = atomic_read(&bucket->hv);
+        hv2    = atomic_read(&bucket->hv);
 
-	if (hatrack_bucket_unreserved(hv2)) {
-	    if (LCAS(&bucket->hv, &hv2, hv1, WITCHHAT_CTR_BUCKET_ACQUIRE)) {
-		if (atomic_fetch_add(&self->used_count, 1) >= self->threshold) {
-		    goto migrate_and_retry;
-		}
-		goto found_bucket;
-	    }
-	}
+        if (hatrack_bucket_unreserved(hv2)) {
+            if (LCAS(&bucket->hv, &hv2, hv1, WITCHHAT_CTR_BUCKET_ACQUIRE)) {
+                if (atomic_fetch_add(&self->used_count, 1) >= self->threshold) {
+                    goto migrate_and_retry;
+                }
+                goto found_bucket;
+            }
+        }
 
-	if (!hatrack_hashes_eq(hv1, hv2)) {
-	    bix = (bix + 1) & self->last_slot;
-	    continue;
-	}
+        if (!hatrack_hashes_eq(hv1, hv2)) {
+            bix = (bix + 1) & self->last_slot;
+            continue;
+        }
 
         goto found_bucket;
     }
 
- migrate_and_retry:
+migrate_and_retry:
     // This uses the same helping mechanism as in
     // witchhat_store_put().  Look there for an overview.
     count = count + 1;
     if (witchhat_help_required(count)) {
-	bool ret;
+        bool ret;
 
-	HATRACK_CTR(HATRACK_CTR_WH_HELP_REQUESTS);
+        HATRACK_CTR(HATRACK_CTR_WH_HELP_REQUESTS);
 
-	atomic_fetch_add(&top->help_needed, 1);
+        atomic_fetch_add(&top->help_needed, 1);
 
-	self = witchhat_store_migrate(self, thread, top);
-	ret  = witchhat_store_add(self, thread, top, hv1, item, count);
+        self = witchhat_store_migrate(self, thread, top);
+        ret  = witchhat_store_add(self, thread, top, hv1, item, count);
 
-	atomic_fetch_sub(&top->help_needed, 1);
+        atomic_fetch_sub(&top->help_needed, 1);
 
-	return ret;
+        return ret;
     }
 
     self = witchhat_store_migrate(self, thread, top);
@@ -706,7 +707,7 @@ mmm_thread_t *thread,
 found_bucket:
     record = atomic_read(&bucket->record);
     if (record.info & WITCHHAT_F_MOVING) {
-	goto migrate_and_retry;
+        goto migrate_and_retry;
     }
 
     if ((record.info & WITCHHAT_EPOCH_MASK)) {
@@ -717,12 +718,12 @@ found_bucket:
     candidate.info = WITCHHAT_F_INITED | top->next_epoch++;
 
     if (LCAS(&bucket->record, &record, candidate, WITCHHAT_CTR_REC_INSTALL)) {
-	atomic_fetch_add(&top->item_count, 1);
+        atomic_fetch_add(&top->item_count, 1);
         return true;
     }
 
     if (record.info & WITCHHAT_F_MOVING) {
-	goto migrate_and_retry;
+        goto migrate_and_retry;
     }
 
     return false;
@@ -730,11 +731,11 @@ found_bucket:
 
 void *
 witchhat_store_remove(witchhat_store_t *self,
-mmm_thread_t *thread,
-		      witchhat_t       *top,
-		      hatrack_hash_t    hv1,
-		      bool             *found,
-		      uint64_t          count)
+                      mmm_thread_t     *thread,
+                      witchhat_t       *top,
+                      hatrack_hash_t    hv1,
+                      bool             *found,
+                      uint64_t          count)
 {
     void              *old_item;
     uint64_t           bix;
@@ -755,11 +756,11 @@ mmm_thread_t *thread,
         }
 
         if (hatrack_hashes_eq(hv1, hv2)) {
-	    goto found_bucket;
+            goto found_bucket;
         }
 
-	bix = (bix + 1) & self->last_slot;
-	continue;
+        bix = (bix + 1) & self->last_slot;
+        continue;
     }
 
     if (found) {
@@ -771,22 +772,22 @@ mmm_thread_t *thread,
 found_bucket:
     record = atomic_read(&bucket->record);
     if (record.info & WITCHHAT_F_MOVING) {
-    migrate_and_retry:
-	// This uses the same helping mechanism as in
-	// witchhat_store_put().  Look there for an overview.
-	count = count + 1;
+migrate_and_retry:
+        // This uses the same helping mechanism as in
+        // witchhat_store_put().  Look there for an overview.
+        count = count + 1;
 
-	if (witchhat_help_required(count)) {
-	    HATRACK_CTR(HATRACK_CTR_WH_HELP_REQUESTS);
-	    atomic_fetch_add(&top->help_needed, 1);
-	    self     = witchhat_store_migrate(self, thread, top);
-	    old_item = witchhat_store_remove(self, thread, top, hv1, found, count);
-	    atomic_fetch_sub(&top->help_needed, 1);
-	    return old_item;
-	}
+        if (witchhat_help_required(count)) {
+            HATRACK_CTR(HATRACK_CTR_WH_HELP_REQUESTS);
+            atomic_fetch_add(&top->help_needed, 1);
+            self     = witchhat_store_migrate(self, thread, top);
+            old_item = witchhat_store_remove(self, thread, top, hv1, found, count);
+            atomic_fetch_sub(&top->help_needed, 1);
+            return old_item;
+        }
 
-	self = witchhat_store_migrate(self, thread, top);
-	return witchhat_store_remove(self, thread, top, hv1, found, count);
+        self = witchhat_store_migrate(self, thread, top);
+        return witchhat_store_remove(self, thread, top, hv1, found, count);
     }
 
     if (!(record.info & WITCHHAT_EPOCH_MASK)) {
@@ -808,22 +809,21 @@ found_bucket:
             *found = true;
         }
 
-
-	/* In witchhat, whenever we successfully overwrite a value, we
-	 * need to help migrate, if a migration is in process.  See
-	 * witchhat_store_migrate() for a bit more detailed an
-	 * explaination, but doing this makes witchhat_store_migrate()
-	 * wait free.
-	 */
-	if (atomic_read(&self->used_count) >= self->threshold) {
-	    witchhat_store_migrate(self, thread, top);
-	}
+        /* In witchhat, whenever we successfully overwrite a value, we
+         * need to help migrate, if a migration is in process.  See
+         * witchhat_store_migrate() for a bit more detailed an
+         * explaination, but doing this makes witchhat_store_migrate()
+         * wait free.
+         */
+        if (atomic_read(&self->used_count) >= self->threshold) {
+            witchhat_store_migrate(self, thread, top);
+        }
 
         return old_item;
     }
 
     if (record.info & WITCHHAT_F_MOVING) {
-	goto migrate_and_retry;
+        goto migrate_and_retry;
     }
 
     if (found) {
@@ -855,7 +855,7 @@ witchhat_store_migrate(witchhat_store_t *self, mmm_thread_t *thread, witchhat_t 
     new_store = atomic_read(&top->store_current);
 
     if (new_store != self) {
-	return new_store;
+        return new_store;
     }
 
     for (i = 0; i <= self->last_slot; i++) {
@@ -863,55 +863,55 @@ witchhat_store_migrate(witchhat_store_t *self, mmm_thread_t *thread, witchhat_t 
         record                = atomic_read(&bucket->record);
         candidate_record.item = record.item;
 
-	if (record.info & WITCHHAT_F_MOVING) {
-	    if (record.info & WITCHHAT_EPOCH_MASK) {
-		new_used++;
-	    }
+        if (record.info & WITCHHAT_F_MOVING) {
+            if (record.info & WITCHHAT_EPOCH_MASK) {
+                new_used++;
+            }
 
-	    continue;
-	}
+            continue;
+        }
 
-	OR2X64L(&bucket->record, WITCHHAT_F_MOVING);
+        OR2X64L(&bucket->record, WITCHHAT_F_MOVING);
 
-	record = atomic_read(&bucket->record);
+        record = atomic_read(&bucket->record);
 
-	if (record.info & WITCHHAT_EPOCH_MASK) {
-	    new_used++;
-	}
-	else {
-	    OR2X64L(&bucket->record, WITCHHAT_F_MOVED);
-	}
+        if (record.info & WITCHHAT_EPOCH_MASK) {
+            new_used++;
+        }
+        else {
+            OR2X64L(&bucket->record, WITCHHAT_F_MOVED);
+        }
     }
 
     new_store = atomic_read(&self->store_next);
 
     if (!new_store) {
-	/* When threads need help in the face of a resize, this is
-	 * where we provide that help.  We do it simply by forcing
-	 * the table to resize up, when help is required.
-	 *
-	 * Note that different threads might end up producing
-	 * different store sizes, if their value of top->help_needed
-	 * changes.  This is ultimately irrelevent, because whichever
-	 * store we swap in will be big enough to handle the
-	 * migration.
-	 *
-	 * Plus, the helper isn't the one responsible for
-	 * determining when help is no longer necessary, so if the
-	 * smaller store is selected, the next resize will definitely
-	 * be bigger, if help was needed continuously.
-	 *
-	 * This mechanism is, in practice, the only mechanism that
-	 * seems like it might have any sort of impact on the overall
-	 * performance of the algorithm, and if it does have an
-	 * impact, it seems to be completely in the noise.
-	 */
-	if (witchhat_need_to_help(top)) {
-	    new_size = (self->last_slot + 1) << 1;
-	}
-	else {
-	    new_size        = hatrack_new_size(self->last_slot, new_used);
-	}
+        /* When threads need help in the face of a resize, this is
+         * where we provide that help.  We do it simply by forcing
+         * the table to resize up, when help is required.
+         *
+         * Note that different threads might end up producing
+         * different store sizes, if their value of top->help_needed
+         * changes.  This is ultimately irrelevent, because whichever
+         * store we swap in will be big enough to handle the
+         * migration.
+         *
+         * Plus, the helper isn't the one responsible for
+         * determining when help is no longer necessary, so if the
+         * smaller store is selected, the next resize will definitely
+         * be bigger, if help was needed continuously.
+         *
+         * This mechanism is, in practice, the only mechanism that
+         * seems like it might have any sort of impact on the overall
+         * performance of the algorithm, and if it does have an
+         * impact, it seems to be completely in the noise.
+         */
+        if (witchhat_need_to_help(top)) {
+            new_size = (self->last_slot + 1) << 1;
+        }
+        else {
+            new_size = hatrack_new_size(self->last_slot, new_used);
+        }
 
         candidate_store = witchhat_store_new(new_size);
 
@@ -938,21 +938,21 @@ witchhat_store_migrate(witchhat_store_t *self, mmm_thread_t *thread, witchhat_t 
         bix = hatrack_bucket_index(hv, new_store->last_slot);
 
         for (j = 0; j <= new_store->last_slot; j++) {
-            new_bucket     = &new_store->buckets[bix];
-	    expected_hv    = atomic_read(&new_bucket->hv);
+            new_bucket  = &new_store->buckets[bix];
+            expected_hv = atomic_read(&new_bucket->hv);
 
-	    if (hatrack_bucket_unreserved(expected_hv)) {
-		if (LCAS(&new_bucket->hv,
-			 &expected_hv,
-			 hv,
-			 WITCHHAT_CTR_MIGRATE_HV)) {
-		    break;
-		}
-	    }
+            if (hatrack_bucket_unreserved(expected_hv)) {
+                if (LCAS(&new_bucket->hv,
+                         &expected_hv,
+                         hv,
+                         WITCHHAT_CTR_MIGRATE_HV)) {
+                    break;
+                }
+            }
 
-	    if (!hatrack_hashes_eq(expected_hv, hv)) {
-		bix = (bix + 1) & new_store->last_slot;
-		continue;
+            if (!hatrack_hashes_eq(expected_hv, hv)) {
+                bix = (bix + 1) & new_store->last_slot;
+                continue;
             }
 
             break;
@@ -964,11 +964,11 @@ witchhat_store_migrate(witchhat_store_t *self, mmm_thread_t *thread, witchhat_t 
         expected_record.item  = NULL;
 
         LCAS(&new_bucket->record,
-	     &expected_record,
-	     candidate_record,
-	     WITCHHAT_CTR_MIG_REC);
+             &expected_record,
+             candidate_record,
+             WITCHHAT_CTR_MIG_REC);
 
-	OR2X64L(&bucket->record, WITCHHAT_F_MOVED);
+        OR2X64L(&bucket->record, WITCHHAT_F_MOVED);
     }
 
     expected_used = 0;
@@ -979,27 +979,27 @@ witchhat_store_migrate(witchhat_store_t *self, mmm_thread_t *thread, witchhat_t 
          WITCHHAT_CTR_LEN_INSTALL);
 
     if (LCAS(&top->store_current,
-	     &self,
-	     new_store,
-	     WITCHHAT_CTR_STORE_INSTALL)) {
+             &self,
+             new_store,
+             WITCHHAT_CTR_STORE_INSTALL)) {
         mmm_retire(thread, self);
     }
 
     return top->store_current;
 }
 
-static inline bool
+static bool
 witchhat_help_required(uint64_t count)
 {
     if (count == HATRACK_RETRY_THRESHOLD) {
-	return true;
+        return true;
     }
 
     return false;
 }
 
-
-static inline bool
-witchhat_need_to_help(witchhat_t *self) {
+static bool
+witchhat_need_to_help(witchhat_t *self)
+{
     return (bool)atomic_read(&self->help_needed);
 }

--- a/src/hatrack/hash/woolhat.c
+++ b/src/hatrack/hash/woolhat.c
@@ -44,20 +44,11 @@ enum {
 // Needs to be non-static because tophat needs it; nonetheless, do not
 // export this explicitly; it's effectively a "friend" function not public.
        woolhat_store_t *woolhat_store_new    (uint64_t);
-static void            *woolhat_store_get    (woolhat_store_t *, hatrack_hash_t,
-					      bool *);
-static void            *woolhat_store_put    (woolhat_store_t *, mmm_thread_t *, woolhat_t *,
-					      hatrack_hash_t, void *, bool *,
-					      uint64_t);
-static void            *woolhat_store_replace(woolhat_store_t *, mmm_thread_t *, woolhat_t *,
-					      hatrack_hash_t, void *, bool *,
-					      uint64_t);
-static bool             woolhat_store_add    (woolhat_store_t *, mmm_thread_t *, woolhat_t *,
-					      hatrack_hash_t, void *,
-					      uint64_t);
-static void            *woolhat_store_remove (woolhat_store_t *, mmm_thread_t *, woolhat_t *,
-					      hatrack_hash_t, bool *,
-					      uint64_t);
+static void            *woolhat_store_get    (woolhat_store_t *, hatrack_hash_t, bool *);
+static void            *woolhat_store_put    (woolhat_store_t *, mmm_thread_t *, woolhat_t *, hatrack_hash_t, void *, bool *, uint64_t);
+static void            *woolhat_store_replace(woolhat_store_t *, mmm_thread_t *, woolhat_t *, hatrack_hash_t, void *, bool *, uint64_t);
+static bool             woolhat_store_add    (woolhat_store_t *, mmm_thread_t *, woolhat_t *, hatrack_hash_t, void *, uint64_t);
+static void            *woolhat_store_remove (woolhat_store_t *, mmm_thread_t *, woolhat_t *, hatrack_hash_t, bool *, uint64_t);
 static woolhat_store_t *woolhat_store_migrate(woolhat_store_t *, mmm_thread_t *, woolhat_t *);
 static inline bool      woolhat_help_required(uint64_t);
 static inline bool      woolhat_need_to_help (woolhat_t *);

--- a/src/hatrack/support/counters.c
+++ b/src/hatrack/support/counters.c
@@ -26,12 +26,11 @@
 
 #include <stdio.h>
 
-// clang-format off
-_Atomic uint64_t hatrack_counters[HATRACK_COUNTERS_NUM]            = {};
-uint64_t hatrack_last_counters[HATRACK_COUNTERS_NUM]               = {};
+_Atomic uint64_t hatrack_counters[HATRACK_COUNTERS_NUM]      = {};
+uint64_t         hatrack_last_counters[HATRACK_COUNTERS_NUM] = {};
 
-_Atomic uint64_t hatrack_yn_counters[HATRACK_YN_COUNTERS_NUM][2]   = {};
-uint64_t hatrack_last_yn_counters[HATRACK_YN_COUNTERS_NUM][2]      = {};
+_Atomic uint64_t hatrack_yn_counters[HATRACK_YN_COUNTERS_NUM][2]      = {};
+uint64_t         hatrack_last_yn_counters[HATRACK_YN_COUNTERS_NUM][2] = {};
 
 char *hatrack_counter_names[HATRACK_COUNTERS_NUM] = {
     "mmm alloc calls",
@@ -42,96 +41,93 @@ char *hatrack_counter_names[HATRACK_COUNTERS_NUM] = {
     "hi-a sleep 1 failed",
     "hi-a sleep 2 worked",
     "hi-a sleep 2 failed",
-    "wh help requests"
-};
+    "wh help requests"};
 
 char *hatrack_yn_counter_names[HATRACK_YN_COUNTERS_NUM] = {
-    "linearize epoch eq",       // 0
-    "mmm write commits",        // 1
-    "mmm commit helps",         // 2
-    "lh bucket acquires",       // 3
-    "lh record installs",       // 4
-    "lh record delete",         // 5
-    "lh store creates",         // 6
-    "lh F_MOVING set",          // 7
-    "lh F_MOVED (empty)",       // 8
-    "lh F_MOVED (deleted)",     // 9
-    "lh migrate hash",          // 10
-    "lh migrate record",        // 11
-    "lh F_MOVED (migrate)",     // 12
-    "lh len installed",         // 13
-    "lh store installs",        // 14
-    "lh-a bucket acquires",     // 15
-    "lh-a ptr installs",        // 16
-    "lh-a hist hash installs",  // 17
-    "lh-a record installs",     // 18
-    "lh-a record delete",       // 19
-    "lh-a store creates",       // 20
-    "lh-a F_MOVING set",        // 21
-    "lh-a F_MOVED (empty)",     // 22
-    "lh-a F_MOVED (deleted)",   // 23
-    "lh-a migrate hash",        // 24
-    "lh-a migrate record",      // 25
-    "lh-a move other hash",     // 26
-    "lh-a install new ptr",     // 27
-    "lh-a F_MOVED (migrate)",   // 28
-    "lh-a hist ptr installed",  // 29
-    "lh-a store installs",      // 30
-    "lh-b bucket acquires",     // 31
-    "lh-b ptr installs",        // 32
-    "lh-b hist hash installs",  // 33
-    "lh-b forward installed",   // 34
-    "lh-b record installs",     // 35
-    "lh-b record delete",       // 36
-    "lh-b store creates",       // 37
-    "lh-b F_MOVING set",        // 38
-    "lh-b F_MOVED (empty)",     // 39
-    "lh-b F_MOVED (deleted)",   // 40
-    "lh-b migrate hash",        // 41
-    "lh-b migrate record",      // 42
-    "lh-b move other hash",     // 43
-    "lh-b install new ptr",     // 44
-    "lh-b F_MOVED (migrate)",   // 45
-    "lh-b hist ptr installed",  // 46
-    "lh-b store installs",      // 47
-    "hih bucket acquires",      // 48
-    "hih record installs",      // 49
-    "hih record delete",        // 50
-    "hih store creates",        // 51
-    "hih F_MOVING set",         // 52
-    "hih F_MOVED (empty)",      // 53
-    "hih migrate hash",         // 54
-    "hih migrate record",       // 55
-    "hih F_MOVED (migrate)",    // 56
-    "hih len installed",        // 57
-    "hih store installs",       // 58
-    "hiha woke up to no job",   // 59
-    "wh bucket acquires",       // 60
-    "wh record installs",       // 61
-    "wh record delete",         // 62
-    "wh store creates",         // 63
-    "wh F_MOVING set",          // 64
-    "wh F_MOVED (empty)",       // 65
-    "wh migrate hash",          // 66
-    "wh migrate record",        // 67
-    "wh F_MOVED (migrate)",     // 68
-    "wh len installed",         // 69
-    "wh store installs",        // 70
-    "wool bucket acquires",     // 71
-    "wool record installs",     // 72
-    "wool record delete",       // 73
-    "wool store creates",       // 74
-    "wool F_MOVING set",        // 75
-    "wool F_MOVED (empty)",     // 76
-    "wool F_MOVED (deleted)",   // 77
-    "wool migrate hash",        // 78
-    "wool migrate record",      // 79
-    "wool F_MOVED (migrate)",   // 70
-    "wool len installed",       // 81
-    "wool store installs",      // 82
+    "linearize epoch eq",      // 0
+    "mmm write commits",       // 1
+    "mmm commit helps",        // 2
+    "lh bucket acquires",      // 3
+    "lh record installs",      // 4
+    "lh record delete",        // 5
+    "lh store creates",        // 6
+    "lh F_MOVING set",         // 7
+    "lh F_MOVED (empty)",      // 8
+    "lh F_MOVED (deleted)",    // 9
+    "lh migrate hash",         // 10
+    "lh migrate record",       // 11
+    "lh F_MOVED (migrate)",    // 12
+    "lh len installed",        // 13
+    "lh store installs",       // 14
+    "lh-a bucket acquires",    // 15
+    "lh-a ptr installs",       // 16
+    "lh-a hist hash installs", // 17
+    "lh-a record installs",    // 18
+    "lh-a record delete",      // 19
+    "lh-a store creates",      // 20
+    "lh-a F_MOVING set",       // 21
+    "lh-a F_MOVED (empty)",    // 22
+    "lh-a F_MOVED (deleted)",  // 23
+    "lh-a migrate hash",       // 24
+    "lh-a migrate record",     // 25
+    "lh-a move other hash",    // 26
+    "lh-a install new ptr",    // 27
+    "lh-a F_MOVED (migrate)",  // 28
+    "lh-a hist ptr installed", // 29
+    "lh-a store installs",     // 30
+    "lh-b bucket acquires",    // 31
+    "lh-b ptr installs",       // 32
+    "lh-b hist hash installs", // 33
+    "lh-b forward installed",  // 34
+    "lh-b record installs",    // 35
+    "lh-b record delete",      // 36
+    "lh-b store creates",      // 37
+    "lh-b F_MOVING set",       // 38
+    "lh-b F_MOVED (empty)",    // 39
+    "lh-b F_MOVED (deleted)",  // 40
+    "lh-b migrate hash",       // 41
+    "lh-b migrate record",     // 42
+    "lh-b move other hash",    // 43
+    "lh-b install new ptr",    // 44
+    "lh-b F_MOVED (migrate)",  // 45
+    "lh-b hist ptr installed", // 46
+    "lh-b store installs",     // 47
+    "hih bucket acquires",     // 48
+    "hih record installs",     // 49
+    "hih record delete",       // 50
+    "hih store creates",       // 51
+    "hih F_MOVING set",        // 52
+    "hih F_MOVED (empty)",     // 53
+    "hih migrate hash",        // 54
+    "hih migrate record",      // 55
+    "hih F_MOVED (migrate)",   // 56
+    "hih len installed",       // 57
+    "hih store installs",      // 58
+    "hiha woke up to no job",  // 59
+    "wh bucket acquires",      // 60
+    "wh record installs",      // 61
+    "wh record delete",        // 62
+    "wh store creates",        // 63
+    "wh F_MOVING set",         // 64
+    "wh F_MOVED (empty)",      // 65
+    "wh migrate hash",         // 66
+    "wh migrate record",       // 67
+    "wh F_MOVED (migrate)",    // 68
+    "wh len installed",        // 69
+    "wh store installs",       // 70
+    "wool bucket acquires",    // 71
+    "wool record installs",    // 72
+    "wool record delete",      // 73
+    "wool store creates",      // 74
+    "wool F_MOVING set",       // 75
+    "wool F_MOVED (empty)",    // 76
+    "wool F_MOVED (deleted)",  // 77
+    "wool migrate hash",       // 78
+    "wool migrate record",     // 79
+    "wool F_MOVED (migrate)",  // 70
+    "wool len installed",      // 81
+    "wool store installs",     // 82
 };
-
-// clang-format on
 
 /*
  * Used to output (to stderr) the difference between counters, from

--- a/src/tests/hash/testhat.c
+++ b/src/tests/hash/testhat.c
@@ -154,7 +154,6 @@ testhat_new_size(char *name, char sz)
     return ret;
 }
 
-// clang-format off
 hatrack_vtable_t refhat_vtable = {
     .init    = (hatrack_init_func)refhat_init,
     .init_sz = (hatrack_init_sz_func)refhat_init_size,
@@ -165,7 +164,7 @@ hatrack_vtable_t refhat_vtable = {
     .remove  = (hatrack_remove_func)refhat_remove_mmm,
     .delete  = (hatrack_delete_func)refhat_delete,
     .len     = (hatrack_len_func)refhat_len_mmm,
-    .view    = (hatrack_view_func)refhat_view_mmm
+    .view    = (hatrack_view_func)refhat_view_mmm,
 };
 
 #ifndef HATRACK_NO_PTHREAD
@@ -180,7 +179,7 @@ hatrack_vtable_t dcap_vtable = {
     .remove  = (hatrack_remove_func)duncecap_remove_mmm,
     .delete  = (hatrack_delete_func)duncecap_delete,
     .len     = (hatrack_len_func)duncecap_len_mmm,
-    .view    = (hatrack_view_func)duncecap_view_mmm
+    .view    = (hatrack_view_func)duncecap_view_mmm,
 };
 
 hatrack_vtable_t swimcap_vtable = {
@@ -193,7 +192,7 @@ hatrack_vtable_t swimcap_vtable = {
     .remove  = (hatrack_remove_func)swimcap_remove_mmm,
     .delete  = (hatrack_delete_func)swimcap_delete,
     .len     = (hatrack_len_func)swimcap_len_mmm,
-    .view    = (hatrack_view_func)swimcap_view_mmm
+    .view    = (hatrack_view_func)swimcap_view_mmm,
 };
 
 hatrack_vtable_t newshat_vtable = {
@@ -206,7 +205,7 @@ hatrack_vtable_t newshat_vtable = {
     .remove  = (hatrack_remove_func)newshat_remove_mmm,
     .delete  = (hatrack_delete_func)newshat_delete,
     .len     = (hatrack_len_func)newshat_len_mmm,
-    .view    = (hatrack_view_func)newshat_view_mmm
+    .view    = (hatrack_view_func)newshat_view_mmm,
 };
 
 hatrack_vtable_t ballcap_vtable = {
@@ -219,7 +218,7 @@ hatrack_vtable_t ballcap_vtable = {
     .remove  = (hatrack_remove_func)ballcap_remove_mmm,
     .delete  = (hatrack_delete_func)ballcap_delete,
     .len     = (hatrack_len_func)ballcap_len_mmm,
-    .view    = (hatrack_view_func)ballcap_view_mmm
+    .view    = (hatrack_view_func)ballcap_view_mmm,
 };
 
 #endif
@@ -234,7 +233,7 @@ hatrack_vtable_t hihat_vtable = {
     .remove  = (hatrack_remove_func)hihat_remove_mmm,
     .delete  = (hatrack_delete_func)hihat_delete,
     .len     = (hatrack_len_func)hihat_len_mmm,
-    .view    = (hatrack_view_func)hihat_view_mmm
+    .view    = (hatrack_view_func)hihat_view_mmm,
 };
 
 hatrack_vtable_t hihat_a_vtable = {
@@ -247,7 +246,7 @@ hatrack_vtable_t hihat_a_vtable = {
     .remove  = (hatrack_remove_func)hihat_a_remove_mmm,
     .delete  = (hatrack_delete_func)hihat_a_delete,
     .len     = (hatrack_len_func)hihat_a_len_mmm,
-    .view    = (hatrack_view_func)hihat_a_view_mmm
+    .view    = (hatrack_view_func)hihat_a_view_mmm,
 };
 
 hatrack_vtable_t lohat_vtable = {
@@ -260,7 +259,7 @@ hatrack_vtable_t lohat_vtable = {
     .remove  = (hatrack_remove_func)lohat_remove_mmm,
     .delete  = (hatrack_delete_func)lohat_delete,
     .len     = (hatrack_len_func)lohat_len_mmm,
-    .view    = (hatrack_view_func)lohat_view_mmm
+    .view    = (hatrack_view_func)lohat_view_mmm,
 };
 
 hatrack_vtable_t lohat_a_vtable = {
@@ -273,7 +272,7 @@ hatrack_vtable_t lohat_a_vtable = {
     .remove  = (hatrack_remove_func)lohat_a_remove_mmm,
     .delete  = (hatrack_delete_func)lohat_a_delete,
     .len     = (hatrack_len_func)lohat_a_len_mmm,
-    .view    = (hatrack_view_func)lohat_a_view_mmm
+    .view    = (hatrack_view_func)lohat_a_view_mmm,
 };
 
 hatrack_vtable_t witch_vtable = {
@@ -286,7 +285,7 @@ hatrack_vtable_t witch_vtable = {
     .remove  = (hatrack_remove_func)witchhat_remove_mmm,
     .delete  = (hatrack_delete_func)witchhat_delete,
     .len     = (hatrack_len_func)witchhat_len_mmm,
-    .view    = (hatrack_view_func)witchhat_view_mmm
+    .view    = (hatrack_view_func)witchhat_view_mmm,
 };
 
 hatrack_vtable_t woolhat_vtable = {
@@ -299,7 +298,7 @@ hatrack_vtable_t woolhat_vtable = {
     .remove  = (hatrack_remove_func)woolhat_remove_mmm,
     .delete  = (hatrack_delete_func)woolhat_delete,
     .len     = (hatrack_len_func)woolhat_len_mmm,
-    .view    = (hatrack_view_func)woolhat_view_mmm
+    .view    = (hatrack_view_func)woolhat_view_mmm,
 };
 
 hatrack_vtable_t oldhat_vtable = {
@@ -312,7 +311,7 @@ hatrack_vtable_t oldhat_vtable = {
     .remove  = (hatrack_remove_func)oldhat_remove_mmm,
     .delete  = (hatrack_delete_func)oldhat_delete,
     .len     = (hatrack_len_func)oldhat_len_mmm,
-    .view    = (hatrack_view_func)oldhat_view_mmm
+    .view    = (hatrack_view_func)oldhat_view_mmm,
 };
 
 #ifndef HATRACK_NO_PTHREAD
@@ -327,7 +326,7 @@ hatrack_vtable_t thfmx_vtable = {
     .remove  = (hatrack_remove_func)tophat_remove_mmm,
     .delete  = (hatrack_delete_func)tophat_delete,
     .len     = (hatrack_len_func)tophat_len_mmm,
-    .view    = (hatrack_view_func)tophat_view_mmm
+    .view    = (hatrack_view_func)tophat_view_mmm,
 };
 
 hatrack_vtable_t thfwf_vtable = {
@@ -340,7 +339,7 @@ hatrack_vtable_t thfwf_vtable = {
     .remove  = (hatrack_remove_func)tophat_remove_mmm,
     .delete  = (hatrack_delete_func)tophat_delete,
     .len     = (hatrack_len_func)tophat_len_mmm,
-    .view    = (hatrack_view_func)tophat_view_mmm
+    .view    = (hatrack_view_func)tophat_view_mmm,
 };
 
 hatrack_vtable_t thcmx_vtable = {
@@ -353,7 +352,7 @@ hatrack_vtable_t thcmx_vtable = {
     .remove  = (hatrack_remove_func)tophat_remove_mmm,
     .delete  = (hatrack_delete_func)tophat_delete,
     .len     = (hatrack_len_func)tophat_len_mmm,
-    .view    = (hatrack_view_func)tophat_view_mmm
+    .view    = (hatrack_view_func)tophat_view_mmm,
 };
 
 hatrack_vtable_t thcwf_vtable = {
@@ -366,7 +365,7 @@ hatrack_vtable_t thcwf_vtable = {
     .remove  = (hatrack_remove_func)tophat_remove_mmm,
     .delete  = (hatrack_delete_func)tophat_delete,
     .len     = (hatrack_len_func)tophat_len_mmm,
-    .view    = (hatrack_view_func)tophat_view_mmm
+    .view    = (hatrack_view_func)tophat_view_mmm,
 };
 
 #endif
@@ -381,7 +380,7 @@ hatrack_vtable_t crown_vtable = {
     .remove  = (hatrack_remove_func)crown_remove_mmm,
     .delete  = (hatrack_delete_func)crown_delete,
     .len     = (hatrack_len_func)crown_len_mmm,
-    .view    = (hatrack_view_func)crown_view_mmm
+    .view    = (hatrack_view_func)crown_view_mmm,
 };
 
 hatrack_vtable_t tiara_vtable = {
@@ -394,10 +393,8 @@ hatrack_vtable_t tiara_vtable = {
     .remove  = (hatrack_remove_func)tiara_remove_mmm,
     .delete  = (hatrack_delete_func)tiara_delete,
     .len     = (hatrack_len_func)tiara_len_mmm,
-    .view    = (hatrack_view_func)tiara_view_mmm
+    .view    = (hatrack_view_func)tiara_view_mmm,
 };
-
-// clang-format on
 
 static void
 testhat_init_default_algorithms(void)


### PR DESCRIPTION
This mostly cleans up various .c files that had `clang-format off` directives for something with no `clang-format on` directive following when the reason for disabling formatting no longer applied. This resulted in a fair bit of code having mixes of spaces and tabs. In some cases the `off` directives have been removed completely, but mostly corresponding `on` directives have been added, as appropriate