### PR TITLE
Add a user pointer arg to Hatrack malloc functions

### DIFF
--- a/include/hatrack/malloc.h
+++ b/include/hatrack/malloc.h
@@ -28,7 +28,7 @@
 // memory. The size is a minimum size; the function may return a larger size.
 // The function must return a pointer that is 16-byte aligned. The returned
 // pointer may be NULL if the requested allocation cannot be satisfied.
-typedef void *(*hatrack_malloc_t)(size_t size);
+typedef void *(*hatrack_malloc_t)(size_t size, void *arg);
 
 // hatrack_realloc_t is the signature of a function that is used to resize an
 // existing allocation. The old pointer and size are always provided (oldptr
@@ -42,12 +42,13 @@ typedef void *(*hatrack_malloc_t)(size_t size);
 // case the original pointer remains valid.
 typedef void *(*hatrack_realloc_t)(void  *oldptr,
                                    size_t oldsize,
-                                   size_t newsize);
+                                   size_t newsize,
+                                   void  *arg);
 
 // hatrack_free_t is the signature of a function that is used to deallocate
 // previously allocated memory. The pointer to free is always provided (it will
 // never be NULL).
-typedef void (*hatrack_free_t)(void *ptr, size_t size);
+typedef void (*hatrack_free_t)(void *ptr, size_t size, void *arg);
 
 // hatrack_setmallocfns sets the function pointers to use for malloc, zalloc,
 // realloc, and free operations. The zalloc function is the same as malloc,
@@ -58,7 +59,8 @@ extern void
 hatrack_setmallocfns(hatrack_malloc_t  mallocfn,
                      hatrack_malloc_t  zallocfn,
                      hatrack_realloc_t reallocfn,
-                     hatrack_free_t    freefn);
+                     hatrack_free_t    freefn,
+                     void             *arg);
 
 // hatrack_malloc calls the configured memory allocation function to allocate
 // the requested amount of memory. The returned pointer may be NULL if the

--- a/src/con4m/gc.c
+++ b/src/con4m/gc.c
@@ -81,7 +81,7 @@ c4m_gc_heap_stats(uint64_t *used, uint64_t *available, uint64_t *total)
 }
 
 static void *
-c4m_gc_malloc_wrapper(size_t size)
+c4m_gc_malloc_wrapper(size_t size, void *arg)
 {
     // Hatrack wants a 16-byte aligned pointer. The con4m gc allocator will
     // always produce a 16-byte aligned pointer. The raw allocation header is
@@ -90,13 +90,13 @@ c4m_gc_malloc_wrapper(size_t size)
 }
 
 static void
-c4m_gc_free_wrapper(void *oldptr, size_t size)
+c4m_gc_free_wrapper(void *oldptr, size_t size, void *arg)
 {
     // do nothing; memory is garbage collected
 }
 
 static void *
-c4m_gc_realloc_wrapper(void *oldptr, size_t oldsize, size_t newsize)
+c4m_gc_realloc_wrapper(void *oldptr, size_t oldsize, size_t newsize, void *arg)
 {
     return c4m_gc_resize(oldptr, newsize);
 }
@@ -122,7 +122,8 @@ c4m_initialize_gc()
         hatrack_setmallocfns(c4m_gc_malloc_wrapper,
                              c4m_gc_malloc_wrapper,
                              c4m_gc_realloc_wrapper,
-                             c4m_gc_free_wrapper);
+                             c4m_gc_free_wrapper,
+                             NULL);
 
         hatrack_dict_init(global_roots, HATRACK_DICT_KEY_TYPE_PTR);
     }


### PR DESCRIPTION
This just adds an optional pointer to memory allocation functions for context. The defaults don't use it, but user implementations may.