### PR TITLE
Replace abort w/ hatrack_panic mechanism

### DIFF
--- a/src/hatrack/hash/crown.c
+++ b/src/hatrack/hash/crown.c
@@ -214,11 +214,11 @@ crown_init_size(crown_t *self, char size)
     uint64_t       len;
 
     if (((size_t)size) > (sizeof(intptr_t) * 8)) {
-        abort();
+        hatrack_panic("invalid size in crown_init_size");
     }
 
     if (size < HATRACK_MIN_SIZE_LOG) {
-        abort();
+        hatrack_panic("invalid size in crown_init_size");
     }
 
     len              = 1 << size;

--- a/src/hatrack/hash/dict.c
+++ b/src/hatrack/hash/dict.c
@@ -61,7 +61,7 @@ hatrack_dict_init(hatrack_dict_t *self, uint32_t key_type)
         self->key_type = key_type;
         break;
     default:
-        abort();
+        hatrack_panic("invalid key type for hatrack_dict_init");
     }
 
     self->hash_info.offsets.hash_offset  = 0;
@@ -706,7 +706,7 @@ hatrack_dict_get_hash_value(hatrack_dict_t *self, void *key)
         hv = hash_pointer(loc_to_hash);
         break;
     default:
-        abort();
+        hatrack_panic("invalid key type in hatrack_dict_get_hash_value");
     }
 
     if (offset != (int32_t)HATRACK_DICT_NO_CACHE) {

--- a/src/hatrack/hash/duncecap.c
+++ b/src/hatrack/hash/duncecap.c
@@ -93,9 +93,7 @@ duncecap_reader_exit(duncecap_store_t *store)
 static inline duncecap_store_t *
 duncecap_viewer_enter(duncecap_t *self)
 {
-    if (pthread_mutex_lock(&self->mutex)) {
-        abort();
-    }
+    hatrack_mutex_lock(&self->mutex);
 
     return self->store_current;
 }
@@ -103,9 +101,7 @@ duncecap_viewer_enter(duncecap_t *self)
 static inline void
 duncecap_viewer_exit(duncecap_t *self, duncecap_store_t *unused)
 {
-    if (pthread_mutex_unlock(&self->mutex)) {
-        abort();
-    }
+    hatrack_mutex_unlock(&self->mutex);
 
     return;
 }
@@ -161,11 +157,11 @@ duncecap_init_size(duncecap_t *self, char size)
     uint64_t          len;
 
     if (((size_t)size) > (sizeof(intptr_t) * 8)) {
-        abort();
+        hatrack_panic("invalid size in duncecap_init_size");
     }
 
     if (size < HATRACK_MIN_SIZE_LOG) {
-        abort();
+        hatrack_panic("invalid size in duncecap_init_size");
     }
 
     len                 = 1 << size;
@@ -292,15 +288,11 @@ duncecap_put(duncecap_t *self, hatrack_hash_t hv, void *item, bool *found)
 {
     void *ret;
 
-    if (pthread_mutex_lock(&self->mutex)) {
-        abort();
-    }
+    hatrack_mutex_lock(&self->mutex);
 
     ret = duncecap_store_put(self->store_current, self, hv, item, found);
 
-    if (pthread_mutex_unlock(&self->mutex)) {
-        abort();
-    }
+    hatrack_mutex_unlock(&self->mutex);
 
     return ret;
 }
@@ -335,15 +327,11 @@ duncecap_replace(duncecap_t *self, hatrack_hash_t hv, void *item, bool *found)
 {
     void *ret;
 
-    if (pthread_mutex_lock(&self->mutex)) {
-        abort();
-    }
+    hatrack_mutex_lock(&self->mutex);
 
     ret = duncecap_store_replace(self->store_current, hv, item, found);
 
-    if (pthread_mutex_unlock(&self->mutex)) {
-        abort();
-    }
+    hatrack_mutex_unlock(&self->mutex);
 
     return ret;
 }
@@ -375,15 +363,11 @@ duncecap_add(duncecap_t *self, hatrack_hash_t hv, void *item)
 {
     bool ret;
 
-    if (pthread_mutex_lock(&self->mutex)) {
-        abort();
-    }
+    hatrack_mutex_lock(&self->mutex);
 
     ret = duncecap_store_add(self->store_current, self, hv, item);
 
-    if (pthread_mutex_unlock(&self->mutex)) {
-        abort();
-    }
+    hatrack_mutex_unlock(&self->mutex);
 
     return ret;
 }
@@ -421,15 +405,11 @@ duncecap_remove(duncecap_t *self, hatrack_hash_t hv, bool *found)
 {
     void *ret;
 
-    if (pthread_mutex_lock(&self->mutex)) {
-        abort();
-    }
+    hatrack_mutex_lock(&self->mutex);
 
     ret = duncecap_store_remove(self->store_current, self, hv, found);
 
-    if (pthread_mutex_unlock(&self->mutex)) {
-        abort();
-    }
+    hatrack_mutex_unlock(&self->mutex);
 
     return ret;
 }

--- a/src/hatrack/hash/hihat-a.c
+++ b/src/hatrack/hash/hihat-a.c
@@ -94,11 +94,11 @@ hihat_a_init_size(hihat_t *self, char size)
     uint64_t       len;
 
     if (((size_t)size) > (sizeof(intptr_t) * 8)) {
-        abort();
+        hatrack_panic("invalid size in hihat_a_init_size");
     }
 
     if (size < HATRACK_MIN_SIZE_LOG) {
-        abort();
+        hatrack_panic("invalid size in hihat_a_init_size");
     }
 
     len              = 1 << size;

--- a/src/hatrack/hash/hihat.c
+++ b/src/hatrack/hash/hihat.c
@@ -84,11 +84,11 @@ hihat_init_size(hihat_t *self, char size)
     uint64_t       len;
 
     if (((size_t)size) > (sizeof(intptr_t) * 8)) {
-        abort();
+        hatrack_panic("invalid size in hihat_init_size");
     }
 
     if (size < HATRACK_MIN_SIZE_LOG) {
-        abort();
+        hatrack_panic("invalid size in hihat_init_size");
     }
 
     len              = 1 << size;

--- a/src/hatrack/hash/lohat-a.c
+++ b/src/hatrack/hash/lohat-a.c
@@ -78,11 +78,11 @@ lohat_a_init_size(lohat_a_t *self, char size)
     uint64_t         len;
 
     if (((size_t)size) > (sizeof(intptr_t) * 8)) {
-        abort();
+        hatrack_panic("invalid size in lohat_a_init_size");
     }
 
     if (size < HATRACK_MIN_SIZE_LOG) {
-        abort();
+        hatrack_panic("invalid size in lohat_a_init_size");
     }
 
     len   = 1 << size;

--- a/src/hatrack/hash/lohat.c
+++ b/src/hatrack/hash/lohat.c
@@ -85,11 +85,11 @@ lohat_init_size(lohat_t *self, char size)
     uint64_t       len;
 
     if (((size_t)size) > (sizeof(intptr_t) * 8)) {
-        abort();
+        hatrack_panic("invalid size in lohat_init_size");
     }
 
     if (size < HATRACK_MIN_SIZE_LOG) {
-        abort();
+        hatrack_panic("invalid size in lohat_init_size");
     }
 
     len   = 1 << size;

--- a/src/hatrack/hash/oldhat.c
+++ b/src/hatrack/hash/oldhat.c
@@ -191,11 +191,11 @@ oldhat_init_size(oldhat_t *self, char size)
     uint64_t        len;
 
     if (((size_t)size) > (sizeof(intptr_t) * 8)) {
-        abort();
+        hatrack_panic("invalid size in oldhat_init_size");
     }
 
     if (size < HATRACK_MIN_SIZE_LOG) {
-        abort();
+        hatrack_panic("invalid size in oldhat_init_size");
     }
 
     len   = 1 << size;

--- a/src/hatrack/hash/refhat.c
+++ b/src/hatrack/hash/refhat.c
@@ -70,11 +70,11 @@ refhat_init_size(refhat_t *self, char size)
     uint64_t len;
 
     if (((size_t)size) > (sizeof(intptr_t) * 8)) {
-        abort();
+        hatrack_panic("invalid size in refhat_init_size");
     }
 
     if (size < HATRACK_MIN_SIZE_LOG) {
-        abort();
+        hatrack_panic("invalid size in refhat_init_size");
     }
 
     len                = 1 << size;

--- a/src/hatrack/hash/set.c
+++ b/src/hatrack/hash/set.c
@@ -61,7 +61,7 @@ hatrack_set_init(hatrack_set_t *self, uint32_t item_type)
         self->item_type = item_type;
         break;
     default:
-        abort();
+        hatrack_panic("invalid item_type in hatrack_set_init");
     }
 
     self->hash_info.offsets.hash_offset  = 0;
@@ -580,7 +580,7 @@ hatrack_set_difference_mmm(hatrack_set_t *set1, mmm_thread_t *thread, hatrack_se
     uint64_t            i, j;
 
     if (set1->item_type != set2->item_type) {
-        abort();
+        hatrack_panic("item types do not match in hatrack_set_difference");
     }
 
     ret   = hatrack_set_new(set1->item_type);
@@ -652,7 +652,7 @@ hatrack_set_union_mmm(hatrack_set_t *set1, mmm_thread_t *thread, hatrack_set_t *
     uint64_t            i, j;
 
     if (set1->item_type != set2->item_type) {
-        abort();
+        hatrack_panic("item types do not match in hatrack_set_union");
     }
 
     ret   = hatrack_set_new(set1->item_type);
@@ -753,7 +753,7 @@ hatrack_set_intersection_mmm(hatrack_set_t *set1, mmm_thread_t *thread, hatrack_
     uint64_t            i, j;
 
     if (set1->item_type != set2->item_type) {
-        abort();
+        hatrack_panic("item types do not match in hatrack_set_intersection");
     }
 
     ret   = hatrack_set_new(set1->item_type);
@@ -827,7 +827,7 @@ hatrack_set_disjunction_mmm(hatrack_set_t *set1, mmm_thread_t *thread, hatrack_s
     uint64_t            i, j;
 
     if (set1->item_type != set2->item_type) {
-        abort();
+        hatrack_panic("item types do not match in hatrack_set_disjunction");
     }
 
     ret   = hatrack_set_new(set1->item_type);
@@ -938,7 +938,7 @@ hatrack_set_get_hash_value(hatrack_set_t *self, void *key)
         hv = hash_pointer(loc_to_hash);
         break;
     default:
-        abort();
+        hatrack_panic("invalid item type in hatrack_set_get_hash_value");
     }
 
     if (offset != (int32_t)HATRACK_DICT_NO_CACHE) {
@@ -974,7 +974,8 @@ hatrack_set_hv_sort_cmp(const void *b1, const void *b2)
     }
 
     if (hatrack_hashes_eq(item1->hv, item2->hv)) {
-        abort(); // Shouldn't happen; hash entries should be unique.
+        // Shouldn't happen; hash entries should be unique.
+        hatrack_panic("duplicate hash values in sort comparison");
     }
 
     return -1;

--- a/src/hatrack/hash/swimcap.c
+++ b/src/hatrack/hash/swimcap.c
@@ -104,11 +104,11 @@ swimcap_init_size(swimcap_t *self, char size)
     uint64_t         len;
 
     if (((size_t)size) > (sizeof(intptr_t) * 8)) {
-        abort();
+        hatrack_panic("invalid size in swimcap_init_size");
     }
 
     if (size < HATRACK_MIN_SIZE_LOG) {
-        abort();
+        hatrack_panic("invalid size in swimcap_init_size");
     }
 
     len                 = 1 << size;
@@ -262,15 +262,11 @@ swimcap_put_mmm(swimcap_t *self, mmm_thread_t *thread, hatrack_hash_t hv, void *
 {
     void *ret;
 
-    if (pthread_mutex_lock(&self->write_mutex)) {
-        abort();
-    }
+    hatrack_mutex_lock(&self->write_mutex);
 
     ret = swimcap_store_put(self->store_current, thread, self, hv, item, found);
 
-    if (pthread_mutex_unlock(&self->write_mutex)) {
-        abort();
-    }
+    hatrack_mutex_unlock(&self->write_mutex);
 
     return ret;
 }
@@ -304,15 +300,11 @@ swimcap_replace_mmm(swimcap_t *self, mmm_thread_t *thread, hatrack_hash_t hv, vo
 {
     void *ret;
 
-    if (pthread_mutex_lock(&self->write_mutex)) {
-        abort();
-    }
+    hatrack_mutex_lock(&self->write_mutex);
 
     ret = swimcap_store_replace(self->store_current, thread, hv, item, found);
 
-    if (pthread_mutex_unlock(&self->write_mutex)) {
-        abort();
-    }
+    hatrack_mutex_unlock(&self->write_mutex);
 
     return ret;
 }
@@ -343,15 +335,11 @@ swimcap_add_mmm(swimcap_t *self, mmm_thread_t *thread, hatrack_hash_t hv, void *
 {
     bool ret;
 
-    if (pthread_mutex_lock(&self->write_mutex)) {
-        abort();
-    }
+    hatrack_mutex_lock(&self->write_mutex);
 
     ret = swimcap_store_add(self->store_current, thread, self, hv, item);
 
-    if (pthread_mutex_unlock(&self->write_mutex)) {
-        abort();
-    }
+    hatrack_mutex_unlock(&self->write_mutex);
 
     return ret;
 }
@@ -388,15 +376,11 @@ swimcap_remove_mmm(swimcap_t *self, mmm_thread_t *thread, hatrack_hash_t hv, boo
 {
     void *ret;
 
-    if (pthread_mutex_lock(&self->write_mutex)) {
-        abort();
-    }
+    hatrack_mutex_lock(&self->write_mutex);
 
     ret = swimcap_store_remove(self->store_current, thread, self, hv, found);
 
-    if (pthread_mutex_unlock(&self->write_mutex)) {
-        abort();
-    }
+    hatrack_mutex_unlock(&self->write_mutex);
 
     return ret;
 }
@@ -459,9 +443,7 @@ swimcap_view_mmm(swimcap_t *self, mmm_thread_t *thread, uint64_t *num, bool sort
     uint64_t          alloc_len;
 
 #ifdef SWIMCAP_CONSISTENT_VIEWS
-    if (pthread_mutex_lock(&self->write_mutex)) {
-        abort();
-    }
+    hatrack_mutex_lock(&self->write_mutex);
 #else
     mmm_start_basic_op(thread);
 #endif
@@ -497,9 +479,7 @@ swimcap_view_mmm(swimcap_t *self, mmm_thread_t *thread, uint64_t *num, bool sort
         hatrack_free(view, alloc_len);
 
 #ifdef SWIMCAP_CONSISTENT_VIEWS
-        if (pthread_mutex_unlock(&self->write_mutex)) {
-            abort();
-        }
+        hatrack_mutex_unlock(&self->write_mutex);
 #else
         mmm_end_op(thread);
 #endif
@@ -514,9 +494,7 @@ swimcap_view_mmm(swimcap_t *self, mmm_thread_t *thread, uint64_t *num, bool sort
     }
 
 #ifdef SWIMCAP_CONSISTENT_VIEWS
-    if (pthread_mutex_unlock(&self->write_views)) {
-        abort();
-    }
+    hatrack_mutex_unlock(&self->write_mutex);
 #else
     mmm_end_op(thread);
 #endif

--- a/src/hatrack/hash/tiara.c
+++ b/src/hatrack/hash/tiara.c
@@ -98,11 +98,11 @@ tiara_init_size(tiara_t *self, char size)
     uint64_t       len;
 
     if (((size_t)size) > (sizeof(intptr_t) * 8)) {
-        abort();
+        hatrack_panic("invalid size in tiara_init_size");
     }
 
     if (size < HATRACK_MIN_SIZE_LOG) {
-        abort();
+        hatrack_panic("invalid size in tiara_init_size");
     }
 
     len   = 1 << size;

--- a/src/hatrack/hash/tophat.c
+++ b/src/hatrack/hash/tophat.c
@@ -471,9 +471,7 @@ tophat_put_mmm(tophat_t *self, mmm_thread_t *thread, hatrack_hash_t hv, void *it
          * necessary will have set it, before releasing the lock).  If
          * not, we'll do a migration, and then retry in the new table.
          */
-        if (pthread_mutex_lock(&self->mutex)) {
-            abort();
-        }
+        hatrack_mutex_lock(&self->mutex);
 
         mt_table = atomic_read(&self->mt_table);
 
@@ -481,10 +479,7 @@ tophat_put_mmm(tophat_t *self, mmm_thread_t *thread, hatrack_hash_t hv, void *it
             mt_table = tophat_migrate(self, thread);
         }
 
-        if (pthread_mutex_unlock(&self->mutex)) {
-            abort();
-        }
-
+        hatrack_mutex_unlock(&self->mutex);
         mt_table = atomic_load(&self->mt_table);
 
         return (*self->mt_vtable.put)(mt_table, thread, hv, item, found);
@@ -519,9 +514,7 @@ tophat_put_mmm(tophat_t *self, mmm_thread_t *thread, hatrack_hash_t hv, void *it
                     *found = false;
                 }
 
-                if (pthread_mutex_unlock(&self->mutex)) {
-                    abort();
-                }
+                hatrack_mutex_unlock(&self->mutex);
 
                 return NULL;
             }
@@ -534,9 +527,7 @@ tophat_put_mmm(tophat_t *self, mmm_thread_t *thread, hatrack_hash_t hv, void *it
                 *found = true;
             }
 
-            if (pthread_mutex_unlock(&self->mutex)) {
-                abort();
-            }
+            hatrack_mutex_unlock(&self->mutex);
 
             return ret;
         }
@@ -544,9 +535,7 @@ tophat_put_mmm(tophat_t *self, mmm_thread_t *thread, hatrack_hash_t hv, void *it
             if (ctx->used_count + 1 == ctx->threshold) {
                 tophat_st_migrate(ctx, thread);
 
-                if (pthread_mutex_unlock(&self->mutex)) {
-                    abort();
-                }
+                hatrack_mutex_unlock(&self->mutex);
 
                 return tophat_put_mmm(self, thread, hv, item, found);
             }
@@ -564,9 +553,7 @@ tophat_put_mmm(tophat_t *self, mmm_thread_t *thread, hatrack_hash_t hv, void *it
                 *found = false;
             }
 
-            if (pthread_mutex_unlock(&self->mutex)) {
-                abort();
-            }
+            hatrack_mutex_unlock(&self->mutex);
 
             return NULL;
         }
@@ -601,9 +588,7 @@ tophat_replace_mmm(tophat_t *self, mmm_thread_t *thread, hatrack_hash_t hv, void
     }
 
     if (pthread_mutex_trylock(&self->mutex)) {
-        if (pthread_mutex_lock(&self->mutex)) {
-            abort();
-        }
+        hatrack_mutex_lock(&self->mutex);
 
         mt_table = atomic_read(&self->mt_table);
 
@@ -611,9 +596,7 @@ tophat_replace_mmm(tophat_t *self, mmm_thread_t *thread, hatrack_hash_t hv, void
             mt_table = tophat_migrate(self, thread);
         }
 
-        if (pthread_mutex_unlock(&self->mutex)) {
-            abort();
-        }
+        hatrack_mutex_unlock(&self->mutex);
 
         mt_table = atomic_load(&self->mt_table);
 
@@ -635,9 +618,7 @@ empty:
                     *found = false;
                 }
 
-                if (pthread_mutex_unlock(&self->mutex)) {
-                    abort();
-                }
+                hatrack_mutex_unlock(&self->mutex);
 
                 return NULL;
             }
@@ -651,9 +632,7 @@ empty:
                 *found = true;
             }
 
-            if (pthread_mutex_unlock(&self->mutex)) {
-                abort();
-            }
+            hatrack_mutex_unlock(&self->mutex);
 
             return ret;
         }
@@ -691,9 +670,7 @@ tophat_add_mmm(tophat_t *self, mmm_thread_t *thread, hatrack_hash_t hv, void *it
     }
 
     if (pthread_mutex_trylock(&self->mutex)) {
-        if (pthread_mutex_lock(&self->mutex)) {
-            abort();
-        }
+        hatrack_mutex_lock(&self->mutex);
 
         mt_table = atomic_read(&self->mt_table);
 
@@ -701,9 +678,7 @@ tophat_add_mmm(tophat_t *self, mmm_thread_t *thread, hatrack_hash_t hv, void *it
             mt_table = tophat_migrate(self, thread);
         }
 
-        if (pthread_mutex_unlock(&self->mutex)) {
-            abort();
-        }
+        hatrack_mutex_unlock(&self->mutex);
 
         mt_table = atomic_load(&self->mt_table);
 
@@ -727,15 +702,11 @@ tophat_add_mmm(tophat_t *self, mmm_thread_t *thread, hatrack_hash_t hv, void *it
 
                 ctx->item_count++;
 
-                if (pthread_mutex_unlock(&self->mutex)) {
-                    abort();
-                }
+                hatrack_mutex_unlock(&self->mutex);
 
                 return true;
             }
-            if (pthread_mutex_unlock(&self->mutex)) {
-                abort();
-            }
+            hatrack_mutex_unlock(&self->mutex);
 
             return false;
         }
@@ -744,9 +715,7 @@ tophat_add_mmm(tophat_t *self, mmm_thread_t *thread, hatrack_hash_t hv, void *it
             if (ctx->used_count + 1 == ctx->threshold) {
                 tophat_st_migrate(ctx, thread);
 
-                if (pthread_mutex_unlock(&self->mutex)) {
-                    abort();
-                }
+                hatrack_mutex_unlock(&self->mutex);
 
                 return tophat_add_mmm(self, thread, hv, item);
             }
@@ -760,9 +729,7 @@ tophat_add_mmm(tophat_t *self, mmm_thread_t *thread, hatrack_hash_t hv, void *it
 
             atomic_store(&cur->record, record);
 
-            if (pthread_mutex_unlock(&self->mutex)) {
-                abort();
-            }
+            hatrack_mutex_unlock(&self->mutex);
 
             return true;
         }
@@ -797,9 +764,7 @@ tophat_remove_mmm(tophat_t *self, mmm_thread_t *thread, hatrack_hash_t hv, bool 
     }
 
     if (pthread_mutex_trylock(&self->mutex)) {
-        if (pthread_mutex_lock(&self->mutex)) {
-            abort();
-        }
+        hatrack_mutex_lock(&self->mutex);
 
         mt_table = atomic_read(&self->mt_table);
 
@@ -807,9 +772,7 @@ tophat_remove_mmm(tophat_t *self, mmm_thread_t *thread, hatrack_hash_t hv, bool 
             mt_table = tophat_migrate(self, thread);
         }
 
-        if (pthread_mutex_unlock(&self->mutex)) {
-            abort();
-        }
+        hatrack_mutex_unlock(&self->mutex);
 
         mt_table = atomic_load(&self->mt_table);
 
@@ -830,9 +793,7 @@ tophat_remove_mmm(tophat_t *self, mmm_thread_t *thread, hatrack_hash_t hv, bool 
                     *found = false;
                 }
 
-                if (pthread_mutex_unlock(&self->mutex)) {
-                    abort();
-                }
+                hatrack_mutex_unlock(&self->mutex);
 
                 return NULL;
             }
@@ -850,9 +811,7 @@ tophat_remove_mmm(tophat_t *self, mmm_thread_t *thread, hatrack_hash_t hv, bool 
                 *found = true;
             }
 
-            if (pthread_mutex_unlock(&self->mutex)) {
-                abort();
-            }
+            hatrack_mutex_unlock(&self->mutex);
 
             return ret;
         }
@@ -861,9 +820,7 @@ tophat_remove_mmm(tophat_t *self, mmm_thread_t *thread, hatrack_hash_t hv, bool 
                 *found = false;
             }
 
-            if (pthread_mutex_unlock(&self->mutex)) {
-                abort();
-            }
+            hatrack_mutex_unlock(&self->mutex);
 
             return NULL;
         }
@@ -1009,11 +966,11 @@ tophat_init_base(tophat_t *self, char size)
     tophat_st_ctx_t *table;
 
     if (((size_t)size) > (sizeof(intptr_t) * 8)) {
-        abort();
+        hatrack_panic("invalid size in tophat_init_base");
     }
 
     if (size < HATRACK_MIN_SIZE_LOG) {
-        abort();
+        hatrack_panic("invalid size in tophat_init_base");
     }
 
     table_len         = 1 << size;

--- a/src/hatrack/hash/witchhat.c
+++ b/src/hatrack/hash/witchhat.c
@@ -86,11 +86,11 @@ witchhat_init_size(witchhat_t *self, char size)
     uint64_t          len;
 
     if (((size_t)size) > (sizeof(intptr_t) * 8)) {
-        abort();
+        hatrack_panic("invalid size in witchhat_init_size");
     }
 
     if (size < HATRACK_MIN_SIZE_LOG) {
-        abort();
+        hatrack_panic("invalid size in witchhat_init_size");
     }
 
     len              = 1 << size;

--- a/src/hatrack/hash/woolhat.c
+++ b/src/hatrack/hash/woolhat.c
@@ -135,11 +135,11 @@ woolhat_init_size(woolhat_t *self, char size)
     uint64_t         len;
 
     if (((size_t)size) > (sizeof(intptr_t) * 8)) {
-        abort();
+        hatrack_panic("invalid size in woolhat_init_size");
     }
 
     if (size < HATRACK_MIN_SIZE_LOG) {
-        abort();
+        hatrack_panic("invalid size in woolhat_init_size");
     }
 
     len   = 1 << size;

--- a/src/hatrack/queue/q64.c
+++ b/src/hatrack/queue/q64.c
@@ -70,7 +70,7 @@ q64_init_size(q64_t *self, char size_log)
     }
     else {
         if (size_log < QSIZE_LOG_MIN || size_log > QSIZE_LOG_MAX) {
-            abort();
+            hatrack_panic("invalid size_log value for q64_init_size");
         }
     }
 

--- a/src/hatrack/queue/queue.c
+++ b/src/hatrack/queue/queue.c
@@ -68,7 +68,7 @@ queue_init_size(queue_t *self, char size_log)
     }
     else {
         if (size_log < QSIZE_LOG_MIN || size_log > QSIZE_LOG_MAX) {
-            abort();
+            hatrack_panic("invalid size_log value for queue_init_size");
         }
     }
 

--- a/src/hatrack/support/hatrack_common.c
+++ b/src/hatrack/support/hatrack_common.c
@@ -24,6 +24,9 @@
 #include "hatrack/hatrack_common.h"
 #include "hatrack/malloc.h"
 
+#include <stdlib.h>
+#include <string.h>
+
 void
 hatrack_view_delete(hatrack_view_t *view, uint64_t num)
 {
@@ -43,4 +46,39 @@ hatrack_quicksort_cmp(const void *bucket1, const void *bucket2)
     item2 = (hatrack_view_t *)bucket2;
 
     return item1->sort_epoch - item2->sort_epoch;
+}
+
+[[noreturn]] static void
+hatrack_default_panic(void *arg, const char *msg)
+{
+    extern ssize_t write(int, const void *, size_t) __attribute__((weak));
+    if (write != NULL) {
+        static const char prefix[] = "Hatrack PANIC: ";
+        (void)write(2, prefix, sizeof(prefix) - 1);
+        (void)write(2, msg, strlen(msg));
+        (void)write(2, "\n", 1);
+    }
+
+    // no need to check for NULL here. either abort will be called or we'll
+    // crash with a call to NULL pointer. Either way, we get what we want.
+    [[noreturn]] extern void abort(void) __attribute__((weak));
+    abort();
+}
+
+static hatrack_panic_func hatrack_panic_fn  = hatrack_default_panic;
+static void              *hatrack_panic_arg = NULL;
+
+void
+hatrack_setpanicfn(hatrack_panic_func panicfn, void *arg)
+{
+    hatrack_panic_fn  = panicfn != NULL ? panicfn : hatrack_default_panic;
+    hatrack_panic_arg = arg;
+}
+
+void
+hatrack_panic(const char *msg)
+{
+    hatrack_panic_fn(hatrack_panic_arg, msg);
+    // this should be unreachable, but just in case ...
+    hatrack_default_panic(NULL, msg);
 }


### PR DESCRIPTION
Add `hatrack_panic` and use it in place of `abort`. Also include a means for users of Hatrack to replace the default panic implementation with one of their own.

There are a lot of hits here because of mutex lock/unlock checks that abort. I've replaced these with macros. I went through the diffs after to make sure I didn't screw up any locks/unlocks (I totally did). I fixed the screw ups that I noticed and went through the diffs a second time. Please double check them!
