### PR TITLE
gc: c4m_collect_arena(): fix segfault

### DIFF
--- a/src/con4m/gc.c
+++ b/src/con4m/gc.c
@@ -637,8 +637,10 @@ c4m_collect_arena(c4m_arena_t **ptr_loc)
     hatrack_dict_item_t *roots;
 
     if (r == NULL) {
-        r = c4m_rc_ref(global_roots);
+        r = global_roots;
     }
+
+    c4m_rc_ref(r);
 
     if (cur->grow_next) {
         len <<= 1;


### PR DESCRIPTION
After commit 1e6a017302e4 (#31), running `c4test` could sometimes produce a segfault:

```console
$ build/c4test tests/basic1.c4m
info: Compiling from: tests/basic1.c4m
zsh: segmentation fault (core dumped)  build/c4test tests/basic1.c4m
```

Apply John's [suggested fix][1].

Fixes: #37

[1]: https://github.com/crashappsec/libcon4m/issues/37#issuecomment-2176484687