### PR TITLE
Initial test runner

### DIFF
--- a/doc/reference.md
+++ b/doc/reference.md
@@ -537,29 +537,33 @@ EOS ::= '\n' | ';' <<or, if followed by a '}' or line comment, then ''>>
 - __repr__
 
 # Features to re-add from old con4m
-- FFI
 - VM save restore
 - Arg parsing
 - Libraries
-- Actually collect garbage.
 - Doc API.
-- Folding
-- Casting
 - Checkpointing
 - Hot loading
 - Finish data types (date, ip, and extra hatrack stuff)
+- Test harness
+- Final mile: specs
+- Final mile: params
+- Auto-import standard library.
+- Callbacks
+- Tuple unpacking
+- Len, etc.
 
 # Items for afterward
+- Objects
+- Folding
+- Casting
 - Varargs functions
 - Clean up unused instructions in VM
 - Remove the two-words-per-stack-slot thing; it's not needed anymore.
-- Test harness
-- Objects
 - automatic logfd + optional server for log messages
 - REPL
 - Keyword arguments
 - 'maybe' types / nil
-- Aspects
+- Aspects (before / after / around pattern(sig) when x) 
 - Casting
 - (Possibly) re-add := literals
 - Threading
@@ -567,6 +571,7 @@ EOS ::= '\n' | ';' <<or, if followed by a '}' or line comment, then ''>>
 - Pretty printing w/ type annotations
 - Language server
 - Checks based on PDG
+- Full-program info on unused fields & fns.
 
 # Features removed (considered for adding back in)
 Also, the language accepts ":=", which has the special syntax of

--- a/include/compiler/errors.h
+++ b/include/compiler/errors.h
@@ -1,8 +1,11 @@
 #pragma once
 #include "con4m.h"
 
-extern c4m_str_t         *c4m_format_error_message(c4m_compile_error *, bool);
-extern c4m_grid_t        *c4m_format_errors(c4m_compile_ctx *);
+extern c4m_str_t   *c4m_format_error_message(c4m_compile_error *, bool);
+extern c4m_grid_t  *c4m_format_errors(c4m_compile_ctx *);
+extern c4m_xlist_t *c4m_compile_extract_all_error_codes(c4m_compile_ctx *);
+extern c4m_utf8_t  *c4m_err_code_to_str(c4m_compile_error_t);
+
 extern c4m_compile_error *c4m_base_add_error(c4m_xlist_t *,
                                              c4m_compile_error_t,
                                              c4m_token_t *,

--- a/include/con4m/base.h
+++ b/include/con4m/base.h
@@ -23,6 +23,7 @@
 #include <netdb.h>
 #include <dlfcn.h>
 #include <pwd.h>
+#include <dirent.h>
 
 #include <sys/select.h>
 #include <sys/types.h>

--- a/include/con4m/datatypes/vm.h
+++ b/include/con4m/datatypes/vm.h
@@ -100,9 +100,6 @@ typedef enum : uint8_t {
     // value. The type of the immediate value is encoded in the instruction's
     // type_info.
     C4M_ZPushImm       = 0x07,
-    // Push the type of a value onto the stack. The value to operate on is
-    // determined as described in the above comment about address encodings.
-    C4M_ZPushSType     = 0x08,
     // For an object on top of the stack, will retrieve and push the object's
     // type. Note that the top of the stack must not be a raw value type;
     // if it's not a by-reference type, box it first.
@@ -130,6 +127,8 @@ typedef enum : uint8_t {
     // implementation (ffi function index), name offset, and type info,
     // respectively. The ZRunCallback instruction is used to run the callback,
     // which is run as an FFI function.
+    //
+    // Currently unused.
     C4M_ZPushFfiPtr    = 0x0E,
     // Create a callback and push it onto the stack. The instruction's arg,
     // immediate, and type_info fields are encoded into the callback as the
@@ -147,11 +146,6 @@ typedef enum : uint8_t {
     // Pops the top value from the stack. This is the same as C4M_ZMoveSp with
     // an adjustment of -1.
     C4M_ZPop           = 0x20,
-    // Stores the value at the top of the stack to the value address encoded in
-    // the instruction. The storage address is determined as described in the
-    // above comment about address encodings. The value assigned from the stack
-    // is not popped.
-    C4M_ZStoreTop      = 0x21,
     // Stores the encoded immediate value into the value address encoded in the
     // instruction. The storage address is determined as described in the above
     // comment about address encodings.
@@ -159,6 +153,7 @@ typedef enum : uint8_t {
     // Unpack the elements of a tuple, storing each one into the lvalue on the
     // stack, popping each lvalue as its assigned. The number of assignments to
     // perform is encoded in the instruction's arg field.
+    // currently unused.
     C4M_ZUnpack        = 0x23,
     // Swap the two top values on the stack.
     C4M_ZSwap          = 0x24,
@@ -215,11 +210,7 @@ typedef enum : uint8_t {
     // from the callback. Otherwise, the callback is the same as a native call
     // via C4M_Z0Call, except it uses the index from the callback.
     C4M_ZRunCallback   = 0x37,
-    // which currently always gets stored in 64 bits, and must be a value type.
-    // Unmarshals the data stored in the static data area beginning at the
-    // offset encoded into the instruction's immediate field. The length of the
-    // marhsalled data is encoded in the instruction's arg field. The resulting
-    // object is pushed onto the stack.
+    // Unused; will redo when adding objects.
     C4M_ZSObjNew       = 0x38,
     // Box a literal, which requires supplying the type for the object.
     C4M_ZBox           = 0x40,
@@ -279,12 +270,6 @@ typedef enum : uint8_t {
     // Initialze module parameters. The number of parameters is encoded in the
     // instruction's arg field. This is only used during module initialization.
     C4M_ZModuleEnter   = 0x83,
-    // Pops the top stack value and tests it. The value is expected to be either
-    // a string or NULL. If it is a string and is not an empty string, it will
-    // be used as an error message and evalutation will stop. This is basically
-    // a specialized assert used during module initialization to validate
-    // module parameters.
-    C4M_ZParamCheck    = 0x84,
     // Adjust the stack pointer down by the amount encoded in the instruction's
     // arg field. This means specifically that the arg field is subtracted from
     // sp, so a single pop would encode -1 as the adjustment.
@@ -537,6 +522,10 @@ typedef struct {
     c4m_xlist_t  *ffi_info;
     int           ffi_info_entries;
     bool          using_attrs;
+#ifdef C4M_DEV
+    c4m_buf_t    *print_buf;
+    c4m_stream_t *print_stream;
+#endif
 } c4m_vm_t;
 
 typedef struct {

--- a/include/con4m/format.h
+++ b/include/con4m/format.h
@@ -10,3 +10,4 @@ extern c4m_utf8_t *c4m_cstr_array_format(char *, int, c4m_utf8_t **);
     _c4m_cstr_format(fmt, PP_NARG(__VA_ARGS__) __VA_OPT__(, ) __VA_ARGS__)
 #define c4m_str_format(fmt, ...) \
     _c4m_str_format(fmt, PP_NARG(__VA_ARGS__) __VA_OPT__(, ) __VA_ARGS__)
+#define c4m_printf(fmt, ...) c4m_print(c4m_cstr_format(fmt, __VA_ARGS__))

--- a/include/con4m/path.h
+++ b/include/con4m/path.h
@@ -1,11 +1,28 @@
 #pragma once
 #include "con4m.h"
 
-c4m_utf8_t *c4m_resolve_path(c4m_utf8_t *);
-c4m_utf8_t *c4m_path_tilde_expand(c4m_utf8_t *);
-c4m_utf8_t *c4m_get_user_dir(c4m_utf8_t *);
-c4m_utf8_t *c4m_get_current_directory(c4m_utf8_t *);
-c4m_utf8_t *c4m_path_join(c4m_xlist_t *);
+typedef enum {
+    C4M_FK_NOT_FOUND       = 0,
+    C4M_FK_IS_REG_FILE     = S_IFREG,
+    C4M_FK_IS_DIR          = S_IFDIR,
+    C4M_FK_IS_FLINK        = S_IFLNK,
+    C4M_FK_IS_DLINK        = S_IFLNK | S_IFDIR,
+    C4M_FK_IS_SOCK         = S_IFSOCK,
+    C4M_FK_IS_CHR_DEVICE   = S_IFCHR,
+    C4M_FK_IS_BLOCK_DEVICE = S_IFBLK,
+    C4M_FK_IS_FIFO         = S_IFIFO,
+    C4M_FK_OTHER           = ~0,
+} c4m_file_kind;
+
+c4m_utf8_t   *c4m_resolve_path(c4m_utf8_t *);
+c4m_utf8_t   *c4m_path_tilde_expand(c4m_utf8_t *);
+c4m_utf8_t   *c4m_get_user_dir(c4m_utf8_t *);
+c4m_utf8_t   *c4m_get_current_directory(c4m_utf8_t *);
+c4m_utf8_t   *c4m_path_join(c4m_xlist_t *);
+c4m_file_kind c4m_get_file_kind(c4m_utf8_t *);
+c4m_xlist_t  *_c4m_path_walk(c4m_utf8_t *, ...);
+
+#define c4m_path_walk(x, ...) _c4m_path_walk(x, KFUNC(__VA_ARGS__))
 
 static inline c4m_utf8_t *
 c4m_get_home_directory()

--- a/include/con4m/set.h
+++ b/include/con4m/set.h
@@ -48,3 +48,15 @@ c4m_set_disjunction(c4m_set_t *s1, c4m_set_t *s2)
     hatrack_set_disjunction(s1, s2, result);
     return result;
 }
+
+static inline c4m_dict_t *
+c4m_dict(c4m_type_t *t1, c4m_type_t *t2)
+{
+    return c4m_new(c4m_tspec_dict(t1, t2));
+}
+
+static inline c4m_set_t *
+c4m_set(c4m_type_t *t)
+{
+    return c4m_new(c4m_tspec_set(t));
+}

--- a/include/con4m/string.h
+++ b/include/con4m/string.h
@@ -28,6 +28,8 @@ extern c4m_xlist_t        *c4m_str_xsplit(c4m_str_t *, c4m_str_t *);
 extern struct flexarray_t *c4m_str_split(c4m_str_t *, c4m_str_t *);
 extern bool                c4m_str_starts_with(const c4m_str_t *,
                                                const c4m_str_t *);
+extern bool                c4m_str_ends_with(const c4m_str_t *,
+                                             const c4m_str_t *);
 // This is in richlit.c
 extern c4m_utf8_t         *c4m_rich_lit(char *);
 

--- a/include/con4m/switchboard.h
+++ b/include/con4m/switchboard.h
@@ -34,12 +34,10 @@ extern void         c4m_sb_init_party_input_buf(c4m_switchboard_t *,
                                                 char *,
                                                 size_t,
                                                 bool,
-                                                bool,
                                                 bool);
 extern c4m_party_t *c4m_sb_new_party_input_buf(c4m_switchboard_t *,
                                                char *,
                                                size_t,
-                                               bool,
                                                bool,
                                                bool);
 extern void         c4m_sb_party_input_buf_new_string(c4m_party_t *,

--- a/src/con4m/compiler/check_pass.c
+++ b/src/con4m/compiler/check_pass.c
@@ -1900,7 +1900,7 @@ check_literal(pass2_ctx *ctx)
     c4m_pnode_t *pnode  = get_pnode(ctx->node);
     c4m_str_t   *litmod = pnode->extra_info;
 
-    if (litmod != NULL) {
+    if (litmod != NULL && litmod->data) {
         litmod = c4m_to_utf8(litmod);
     }
 

--- a/src/con4m/compiler/codegen.c
+++ b/src/con4m/compiler/codegen.c
@@ -1671,6 +1671,7 @@ gen_sym_decl(gen_ctx *ctx)
     int                last = ctx->cur_node->num_kids - 1;
     c4m_pnode_t       *kid  = get_pnode(ctx->cur_node->children[last]);
     c4m_pnode_t       *psym;
+    c4m_tree_node_t   *cur = ctx->cur_node;
     c4m_scope_entry_t *sym;
 
     if (kid->kind == c4m_nt_assign) {
@@ -1682,8 +1683,9 @@ gen_sym_decl(gen_ctx *ctx)
             return;
         }
 
-        ctx->lvalue = true;
-        gen_one_kid(ctx, last);
+        ctx->cur_node = cur->children[last]->children[0];
+        gen_one_node(ctx);
+        ctx->cur_node = cur;
         gen_sym_load(ctx, sym, true);
         emit(ctx, C4M_ZAssignToLoc);
     }

--- a/src/con4m/compiler/parse.c
+++ b/src/con4m/compiler/parse.c
@@ -1215,9 +1215,9 @@ extern_signature(parse_ctx *ctx)
 
     if (tok_kind(ctx) == c4m_tt_rparen) {
         consume(ctx);
-        end_node(ctx);
         expect(ctx, c4m_tt_arrow);
         extern_sig_item(ctx, c4m_nt_lit_tspec_return_type);
+        end_node(ctx);
 
         return;
     }

--- a/src/con4m/gc.c
+++ b/src/con4m/gc.c
@@ -644,8 +644,10 @@ c4m_collect_arena(c4m_arena_t **ptr_loc)
     hatrack_dict_item_t *roots;
 
     if (r == NULL) {
-        r = c4m_rc_ref(global_roots);
+        r = global_roots;
     }
+
+    c4m_rc_ref(r);
 
     if (cur->grow_next) {
         len <<= 1;

--- a/src/con4m/hex.c
+++ b/src/con4m/hex.c
@@ -67,9 +67,10 @@ add_offset(char   **optr,
 #define ASCIICHAR()                        \
     if (*lineptr < 32 || *lineptr > 126) { \
         *outptr++ = '.';                   \
+        lineptr++;                         \
     }                                      \
     else {                                 \
-        *outptr++ = *lineptr;              \
+        *outptr++ = *lineptr++;            \
     }
 
 char *

--- a/src/con4m/init.c
+++ b/src/con4m/init.c
@@ -6,10 +6,17 @@
 char **c4m_stashed_argv;
 char **c4m_stashed_envp;
 
+// A few builtins here; will break this out soon.
 uint64_t
 c4m_clz(uint64_t n)
 {
     return __builtin_clzll(n);
+}
+
+uint64_t
+c4m_rand()
+{
+    return c4m_rand64();
 }
 
 static void
@@ -18,6 +25,7 @@ c4m_register_builtins()
     c4m_add_static_function(c4m_new_utf8("c4m_clz"), c4m_clz);
     c4m_add_static_function(c4m_new_utf8("c4m_gc_remove_hold"),
                             c4m_gc_remove_hold);
+    c4m_add_static_function(c4m_new_utf8("c4m_rand"), c4m_rand);
 }
 
 __attribute__((constructor)) void

--- a/src/con4m/path.c
+++ b/src/con4m/path.c
@@ -260,14 +260,14 @@ c4m_get_file_kind(c4m_utf8_t *p)
     case S_IFLNK:
         if (stat(p->data, &file_info) != 0) {
             return C4M_FK_NOT_FOUND;
-            switch (file_info.st_mode & S_IFMT) {
-            case S_IFREG:
-                return C4M_FK_IS_FLINK;
-            case S_IFDIR:
-                return C4M_FK_IS_DLINK;
-            default:
-                return C4M_FK_OTHER;
-            }
+        }
+        switch (file_info.st_mode & S_IFMT) {
+        case S_IFREG:
+            return C4M_FK_IS_FLINK;
+        case S_IFDIR:
+            return C4M_FK_IS_DLINK;
+        default:
+            return C4M_FK_OTHER;
         }
     default:
         return C4M_FK_OTHER;

--- a/src/con4m/string.c
+++ b/src/con4m/string.c
@@ -397,6 +397,9 @@ _c4m_str_join(const c4m_xlist_t *l, const c4m_str_t *joiner, ...)
     }
 
     if (!add_trailing) {
+        uint64_t wrong_cp  = ~result->codepoints;
+        result->codepoints = ~(wrong_cp - joinlen);
+
         c4m_utf32_t *line = c4m_to_utf32((c4m_str_t *)c4m_xlist_get(l,
                                                                     n_parts,
                                                                     NULL));
@@ -521,7 +524,6 @@ utf8_init(c4m_utf8_t *s, va_list args)
     else {
         if (length < 0) {
             s->data = 0;
-            abort();
             C4M_CRAISE("length cannot be < 0 for string initialization");
         }
         s->data = c4m_gc_raw_alloc(length + 1, NULL);
@@ -860,6 +862,24 @@ c4m_str_starts_with(const c4m_str_t *s1, const c4m_str_t *s2)
     }
 
     return u32_starts_with(s1, c4m_to_utf32(s2));
+}
+
+bool
+c4m_str_ends_with(const c4m_str_t *s1, const c4m_str_t *s2)
+{
+    int l1 = c4m_str_codepoint_len(s1);
+    int l2 = c4m_str_codepoint_len(s2);
+
+    if (l2 > l1) {
+        return false;
+    }
+
+    c4m_utf32_t *u1 = c4m_to_utf32(s1);
+    c4m_utf32_t *u2 = c4m_to_utf32(s2);
+
+    u1 = c4m_str_slice(u1, l1 - l2, -1);
+
+    return c4m_str_eq(u1, u2);
 }
 
 c4m_utf8_t *
@@ -1255,6 +1275,16 @@ c4m_str_lit(c4m_utf8_t          *s_u8,
 bool
 c4m_str_eq(c4m_str_t *s1, c4m_str_t *s2)
 {
+    if (!s1) {
+        if (!s2) {
+            return true;
+        }
+        return false;
+    }
+    if (!s2) {
+        return false;
+    }
+
     bool s1_is_u32 = c4m_str_is_u32(s1);
     bool s2_is_u32 = c4m_str_is_u32(s2);
 

--- a/src/con4m/subproc.c
+++ b/src/con4m/subproc.c
@@ -759,9 +759,6 @@ c4m_subproc_close(c4m_subproc_t *ctx)
 {
     c4m_subproc_reset_terminal(ctx);
     c4m_sb_destroy(&ctx->sb, false);
-
-    c4m_deferred_cb_t *cbs = ctx->deferred_cbs;
-    c4m_deferred_cb_t *next;
 }
 
 /*

--- a/src/con4m/subproc.c
+++ b/src/con4m/subproc.c
@@ -97,7 +97,6 @@ c4m_subproc_pass_to_stdin(c4m_subproc_t *ctx,
                                 str,
                                 len,
                                 true,
-                                true,
                                 close_fd);
 
     if (ctx->run) {
@@ -187,7 +186,7 @@ c4m_subproc_set_io_callback(c4m_subproc_t *ctx,
         return false;
     }
 
-    c4m_deferred_cb_t *cbinfo = malloc(sizeof(c4m_deferred_cb_t));
+    c4m_deferred_cb_t *cbinfo = c4m_gc_alloc(c4m_deferred_cb_t);
 
     cbinfo->next  = ctx->deferred_cbs;
     cbinfo->which = which;
@@ -492,7 +491,7 @@ c4m_subproc_do_exec(c4m_subproc_t *ctx)
 c4m_party_t *
 c4m_subproc_new_party_callback(c4m_switchboard_t *ctx, c4m_sb_cb_t cb)
 {
-    c4m_party_t *result = (c4m_party_t *)calloc(sizeof(c4m_party_t), 1);
+    c4m_party_t *result = (c4m_party_t *)c4m_gc_alloc(c4m_party_t);
     c4m_sb_init_party_callback(ctx, result, cb);
 
     return result;
@@ -763,13 +762,6 @@ c4m_subproc_close(c4m_subproc_t *ctx)
 
     c4m_deferred_cb_t *cbs = ctx->deferred_cbs;
     c4m_deferred_cb_t *next;
-
-    while (cbs) {
-        next = cbs->next;
-        free(cbs->to_free);
-        free(cbs);
-        cbs = next;
-    }
 }
 
 /*

--- a/src/con4m/switchboard.c
+++ b/src/con4m/switchboard.c
@@ -197,7 +197,7 @@ c4m_sb_new_party_listener(c4m_switchboard_t *ctx,
                           bool               stop_when_closed,
                           bool               close_on_destroy)
 {
-    c4m_party_t *result = (c4m_party_t *)calloc(sizeof(c4m_party_t), 1);
+    c4m_party_t *result = (c4m_party_t *)c4m_gc_alloc(c4m_party_t);
     c4m_sb_init_party_listener(ctx,
                                result,
                                sockfd,
@@ -267,7 +267,7 @@ c4m_sb_new_party_fd(c4m_switchboard_t *ctx,
                     bool               close_on_destroy,
                     bool               proxy_close)
 {
-    c4m_party_t *result = (c4m_party_t *)calloc(sizeof(c4m_party_t), 1);
+    c4m_party_t *result = (c4m_party_t *)c4m_gc_alloc(c4m_party_t);
     c4m_sb_init_party_fd(ctx,
                          result,
                          fd,
@@ -291,14 +291,12 @@ c4m_sb_init_party_input_buf(c4m_switchboard_t *ctx,
                             char              *input,
                             size_t             len,
                             bool               dup,
-                            bool               free,
                             bool               close_fd_when_done)
 {
     char *to_set = input;
 
     if (dup) {
-        free   = true;
-        to_set = (char *)calloc(len + 1, 1);
+        to_set = (char *)c4m_gc_alloc(len + 1);
         memcpy(to_set, input, len);
     }
     party->open_for_read     = true;
@@ -309,7 +307,6 @@ c4m_sb_init_party_input_buf(c4m_switchboard_t *ctx,
     c4m_party_instr_t *sobj  = get_sstr_obj(party);
     sobj->strbuf             = to_set;
     sobj->len                = len;
-    sobj->free_on_close      = free;
     sobj->close_fd_when_done = close_fd_when_done;
 
     register_loner(ctx, party);
@@ -320,16 +317,14 @@ c4m_sb_new_party_input_buf(c4m_switchboard_t *ctx,
                            char              *input,
                            size_t             len,
                            bool               dup,
-                           bool               free,
                            bool               close_fd_when_done)
 {
-    c4m_party_t *result = (c4m_party_t *)calloc(sizeof(c4m_party_t), 1);
+    c4m_party_t *result = (c4m_party_t *)c4m_gc_alloc(c4m_party_t);
     c4m_sb_init_party_input_buf(ctx,
                                 result,
                                 input,
                                 len,
                                 dup,
-                                free,
                                 close_fd_when_done);
 
     return result;
@@ -345,17 +340,13 @@ c4m_sb_party_input_buf_new_string(c4m_party_t *party,
     if (party->c4m_party_type != C4M_PT_STRING || !party->can_read_from_it) {
         return;
     }
-    c4m_party_instr_t *sobj = get_sstr_obj(party);
-    if (sobj->free_on_close && sobj->strbuf) {
-        free(sobj->strbuf);
-    }
+    c4m_party_instr_t *sobj  = get_sstr_obj(party);
     sobj->len                = len;
     sobj->close_fd_when_done = close_fd_when_done;
 
     if (dup) {
-        sobj->strbuf = (char *)calloc(len + 1, 1);
+        sobj->strbuf = c4m_gc_alloc(len + 1);
         memcpy(sobj->strbuf, input, len);
-        sobj->free_on_close = true;
     }
     else {
         sobj->strbuf = input;
@@ -396,7 +387,7 @@ c4m_sb_init_party_output_buf(c4m_switchboard_t *ctx,
     party->c4m_party_type   = C4M_PT_STRING;
 
     c4m_party_outstr_t *dobj = get_dstr_obj(party);
-    dobj->strbuf             = (char *)calloc(PIPE_BUF, n);
+    dobj->strbuf             = (char *)c4m_gc_array_alloc(PIPE_BUF, n);
     dobj->len                = n * PIPE_BUF;
     dobj->step               = party->info.wstrinfo.len;
     dobj->tag                = tag;
@@ -408,7 +399,7 @@ c4m_sb_init_party_output_buf(c4m_switchboard_t *ctx,
 c4m_party_t *
 c4m_sb_new_party_output_buf(c4m_switchboard_t *ctx, char *tag, size_t buflen)
 {
-    c4m_party_t *result = (c4m_party_t *)calloc(sizeof(c4m_party_t), 1);
+    c4m_party_t *result = (c4m_party_t *)c4m_gc_alloc(c4m_party_t);
     c4m_sb_init_party_output_buf(ctx, result, tag, buflen);
 
     return result;
@@ -451,7 +442,7 @@ c4m_sb_monitor_pid(c4m_switchboard_t *ctx,
                    c4m_party_t       *stderr_fd_party,
                    bool               shutdown)
 {
-    c4m_monitor_t *monitor = (c4m_monitor_t *)calloc(sizeof(c4m_monitor_t), 1);
+    c4m_monitor_t *monitor = (c4m_monitor_t *)c4m_gc_alloc(c4m_monitor_t);
 
     monitor->pid                  = pid;
     monitor->stdin_fd_party       = stdin_fd_party;
@@ -504,7 +495,8 @@ add_heap(c4m_switchboard_t *ctx)
     c4m_sb_heap_t *old        = ctx->heap;
     int            elem_space = ctx->heap_elems * sizeof(c4m_sb_msg_t);
 
-    ctx->heap           = calloc(elem_space + sizeof(c4m_sb_heap_t), 1);
+    ctx->heap           = c4m_gc_raw_alloc(elem_space + sizeof(c4m_sb_heap_t),
+                                 GC_SCAN_ALL);
     ctx->heap->next     = old;
     ctx->heap->cur_cell = 0;
 }
@@ -1445,10 +1437,13 @@ handle_loop_end(c4m_switchboard_t *ctx)
     }
 }
 
+#if 0
 /*
  * Used only to make sure we don't free registered readers when
  * they're also registered writers; we wait until we process the
  * registered writer list.
+ *
+ * No longer needed w/ GC.
  */
 static bool
 is_registered_writer(c4m_switchboard_t *ctx, c4m_party_t *target)
@@ -1464,29 +1459,18 @@ is_registered_writer(c4m_switchboard_t *ctx, c4m_party_t *target)
 
     return false;
 }
+#endif
 
 /*
- * Dealloc any memory we're responsible for.
+ * With GC, this is currently just about closing file descriptors.
  *
  * Note that this does NOT free the switchboard object,
  * just any internal data structures.
  */
-#undef free
+
 void
 c4m_sb_destroy(c4m_switchboard_t *ctx, bool free_parties)
 {
-    while (ctx->heap) {
-        c4m_sb_heap_t *to_free = ctx->heap;
-        ctx->heap              = ctx->heap->next;
-        free(to_free);
-    }
-
-    while (ctx->pid_watch_list) {
-        c4m_monitor_t *to_free = ctx->pid_watch_list;
-        ctx->pid_watch_list    = ctx->pid_watch_list->next;
-        free(to_free);
-    }
-
     c4m_party_t *cur, *next;
 
     cur = ctx->parties_for_reading;
@@ -1496,53 +1480,18 @@ c4m_sb_destroy(c4m_switchboard_t *ctx, bool free_parties)
             if (cur->c4m_party_type & (C4M_PT_FD | C4M_PT_LISTENER)) {
                 close(c4m_sb_party_fd(cur));
             }
+            cur = cur->next_reader;
         }
-
-        c4m_party_fd_t     *fdobj = get_fd_obj(cur);
-        c4m_subscription_t *sub   = fdobj->subscribers;
-
-        while (sub) {
-            c4m_subscription_t *next_sub = sub->next;
-            free(sub);
-            sub = next_sub;
-        }
-
-        if (cur->c4m_party_type == C4M_PT_STRING) {
-            c4m_party_instr_t *sstr = get_sstr_obj(cur);
-            if (sstr->strbuf != NULL) {
-                free(sstr->strbuf);
-            }
-        }
-        next = cur->next_reader;
-
-        if (free_parties) {
-            if (!cur->can_write_to_it || !is_registered_writer(ctx, cur)) {
-                free(cur);
-            }
-        }
-        cur = next;
     }
 
     cur = ctx->parties_for_writing;
+
     while (cur) {
         if (cur->close_on_destroy && cur->c4m_party_type == C4M_PT_FD) {
             close(c4m_sb_party_fd(cur));
         }
         next = cur->next_writer;
-        if (free_parties) {
-            free(cur);
-        }
-        cur = next;
-    }
-
-    if (free_parties) {
-        cur = ctx->party_loners;
-
-        while (cur) {
-            next = cur->next_loner;
-            free(cur);
-            cur = next;
-        }
+        cur  = next;
     }
 }
 
@@ -1619,20 +1568,11 @@ c4m_sb_result_get_capture(c4m_capture_result_t *ctx,
 }
 
 /*
- * The tags are borrowed, so we don't free. If you call this, then
- * you're asking to free the capture string copies and the array of
- * captures, but the actual c4m_capture_result_t object wasn't allocated by
- * this API, so we don't own it and this does not try to free it.
+ * A noop w/ GC.
  */
 void
 c4m_sb_result_destroy(c4m_capture_result_t *ctx)
 {
-    for (int i = 0; i < ctx->num_captures; i++) {
-        if (ctx->captures[i].contents) {
-            free(ctx->captures[i].contents);
-        }
-    }
-    free(ctx->captures);
 }
 
 /*

--- a/src/tests/test.c
+++ b/src/tests/test.c
@@ -1,17 +1,146 @@
 #define C4M_USE_INTERNAL_API
 #include "con4m.h"
 
-c4m_style_t style1;
-c4m_style_t style2;
-size_t      term_width;
+size_t term_width;
 
-C4M_STATIC_ASCII_STR(str_test,
-                     "Welcome to the testing center. First order of "
-                     "business: This is a static string, stored in static "
-                     "memory. However, we have not set any styling "
-                     "information on it.\n");
-c4m_stream_t *sout;
-c4m_stream_t *serr;
+static bool dev_mode = false;
+
+typedef struct {
+    c4m_utf8_t  *expected_output;
+    c4m_xlist_t *expected_errors;
+    bool         ignore_output;
+} c4m_test_kat;
+
+static void
+err_basic_usage(c4m_utf8_t *fname)
+{
+    c4m_printf(
+        "[red]error:[/][em]{}[/]: Bad test case format. The second doc  "
+        "string may have 0 or 1 [em]$output[/] sections and 0 or 1 "
+        "[em]$errors[/] sections ONLY. If neither are provided, "
+        "then the harness expects no errors and ignores output.\n"
+        "There may be nothing else in the doc string except whitespace.\n"
+        "\[i]nNote: If you want to explicitly test for no output, then "
+        "provide `$output:` with nothing following.",
+        fname);
+
+    exit(0);
+}
+
+static void
+extract_output(c4m_test_kat *kat, c4m_utf32_t *s, int64_t start, int64_t end)
+{
+    s                    = c4m_str_slice(s, start, end);
+    kat->expected_output = c4m_to_utf8(c4m_str_strip(s));
+}
+
+static void
+extract_errors(c4m_test_kat *kat, c4m_utf32_t *s, int64_t start, int64_t end)
+{
+    s                    = c4m_str_slice(s, start, end);
+    kat->expected_errors = c4m_xlist(c4m_tspec_utf8());
+    c4m_xlist_t *split   = c4m_str_xsplit(s, c4m_new_utf8("\n"));
+    int          l       = c4m_xlist_len(split);
+
+    for (int i = 0; i < l; i++) {
+        s = c4m_str_strip(c4m_xlist_get(split, i, NULL));
+
+        if (!c4m_str_codepoint_len(s)) {
+            continue;
+        }
+
+        c4m_xlist_append(kat->expected_errors, c4m_to_utf8(s));
+    }
+}
+
+static c4m_test_kat *
+c4m_parse_kat(c4m_str_t *path, c4m_str_t *s)
+{
+    s = c4m_str_strip(s);
+
+    c4m_test_kat *result = c4m_gc_alloc(c4m_test_kat);
+    c4m_utf8_t   *output = c4m_new_utf8("$output:");
+    c4m_utf8_t   *errors = c4m_new_utf8("$errors:");
+    int64_t       outix  = c4m_str_find(s, output);
+    int64_t       errix  = c4m_str_find(s, errors);
+
+    if (outix == -1 && errix == -1) {
+        if (c4m_str_codepoint_len(s) != 0) {
+            err_basic_usage(path);
+            return NULL;
+        }
+        return result;
+    }
+
+    if (outix == -1) {
+        if (errix != 0) {
+            err_basic_usage(path);
+            return NULL;
+        }
+        extract_errors(result, s, 9, -1);
+        result->ignore_output = 1;
+        return result;
+    }
+
+    if (errix == -1) {
+        if (outix != 0) {
+            err_basic_usage(path);
+            return NULL;
+        }
+        extract_output(result, s, 9, -1);
+        return result;
+    }
+
+    if (outix != 0 && errix != 0) {
+        err_basic_usage(path);
+        return NULL;
+    }
+
+    if (errix != 0) {
+        extract_output(result, s, 9, errix);
+        extract_errors(result, s, errix + 9, -1);
+    }
+    else {
+        extract_errors(result, s, 9, outix);
+        extract_output(result, s, outix + 9, -1);
+    }
+
+    return result;
+}
+
+static c4m_test_kat *
+c4m_extract_kat(c4m_utf8_t *path)
+{
+    c4m_file_compile_ctx *ctx = c4m_gc_alloc(c4m_file_compile_ctx);
+    c4m_stream_t         *s   = c4m_file_instream(path, C4M_T_UTF8);
+
+    c4m_lex(ctx, s);
+
+    bool have_doc1 = false;
+    int  l         = c4m_xlist_len(ctx->tokens);
+
+    for (int i = 0; i < l; i++) {
+        c4m_token_t *t = c4m_xlist_get(ctx->tokens, i, NULL);
+
+        switch (t->kind) {
+        case c4m_tt_space:
+        case c4m_tt_newline:
+        case c4m_tt_line_comment:
+        case c4m_tt_long_comment:
+            continue;
+        case c4m_tt_string_lit:
+            if (!have_doc1) {
+                have_doc1 = true;
+                continue;
+            }
+            return c4m_parse_kat(path, c4m_token_raw_content(t));
+        default:
+            return NULL;
+        }
+    }
+
+    return NULL;
+}
 
 static void
 collect_and_print_stats()
@@ -44,842 +173,387 @@ collect_and_print_stats()
             c4m_box_u64((used - live) / 1024)));
 }
 
-void
-test1()
+static void
+show_dev_compile_info(c4m_compile_ctx *ctx)
 {
-    style1 = c4m_lookup_text_style("h1");
-    style2 = c4m_lookup_text_style("h2");
-    style2 = c4m_add_upper_case(style2);
-
-    c4m_str_t *s1 = c4m_new(c4m_tspec_utf8(),
-                            c4m_kw("cstring",
-                                   c4m_ka("\ehello,"),
-                                   "style",
-                                   c4m_ka(style1)));
-
-    c4m_str_t *s2 = c4m_new(c4m_tspec_utf8(),
-                            c4m_kw("cstring", c4m_ka(" world!")));
-    c4m_str_t *s3 = c4m_new(c4m_tspec_utf8(),
-                            c4m_kw("cstring", c4m_ka(" magic?\n")));
-
-    c4m_ansi_render(s1, sout);
-    c4m_ansi_render(s2, sout);
-    c4m_ansi_render(s3, sout);
-
-    s1 = c4m_to_utf32(s1);
-    c4m_str_set_style(s3, style2);
-    s2 = c4m_to_utf32(s2);
-    s3 = c4m_to_utf32(s3);
-
-    c4m_ansi_render(s1, sout);
-    c4m_ansi_render(s2, sout);
-    c4m_ansi_render(s3, sout);
-
-    c4m_utf32_t *s = c4m_str_concat(s1, s2);
-    s              = c4m_str_concat(s, s3);
-
-    c4m_ansi_render(s, sout);
-    printf("That was at %p\n", s);
-
-    c4m_break_info_t *g;
-
-    g = c4m_get_grapheme_breaks(s, 1, 10);
-
-    for (int i = 0; i < g->num_breaks; i++) {
-        printf("%d ", g->breaks[i]);
-    }
-
-    printf("\n");
-
-    g = c4m_get_all_line_break_ops(s);
-    for (int i = 0; i < g->num_breaks; i++) {
-        printf("%d ", g->breaks[i]);
-    }
-
-    printf("\n");
-
-    g = c4m_get_line_breaks(s);
-    for (int i = 0; i < g->num_breaks; i++) {
-        printf("%d ", g->breaks[i]);
-    }
-
-    printf("\n");
-
-    collect_and_print_stats();
-
-    printf("s is now at: %p\n Let's render s again.\n", s);
-    c4m_ansi_render(s, sout);
-}
-
-c4m_str_t *
-test2()
-{
-    c4m_utf8_t *w1 = c4m_new(
-        c4m_tspec_utf8(),
-        c4m_kw("cstring",
-               c4m_ka("Once upon a time, there was a ")));
-    c4m_utf8_t *w2 = c4m_new(
-        c4m_tspec_utf8(),
-        c4m_kw("cstring",
-               c4m_ka("thing I cared about. But then ")));
-    c4m_utf8_t *w3 = c4m_new(
-        c4m_tspec_utf8(),
-        c4m_kw("cstring",
-               c4m_ka("I stopped caring. I don't really "
-                      "remember what it was, though. Do ")));
-    c4m_utf8_t *w4 = c4m_new(
-        c4m_tspec_utf8(),
-        c4m_kw("cstring",
-               c4m_ka("you? No, I didn't think so, because it "
-                      "wasn't really all that "
-                      "interesting, to be quite honest. "
-                      "Maybe someday I'll find something "
-                      "interesting to care about, besides my "
-                      "family. Oh yeah, that's "
-                      "what it was, my family! Oh, wait, no, "
-                      "they're either not interesting, "
-                      "or I don't care about them.\n")));
-    c4m_utf8_t *w5 = c4m_new(
-        c4m_tspec_utf8(),
-        c4m_kw("cstring",
-               c4m_ka("Basically AirTags for Software")));
-    c4m_utf8_t *w6 = c4m_new(
-        c4m_tspec_utf8(),
-        c4m_kw("cstring", c4m_ka("\n")));
-
-    c4m_str_set_style(w2, style1);
-    c4m_str_set_style(w3, style2);
-    c4m_str_set_style(w5, style1);
-
-    c4m_utf32_t *to_wrap;
-
-    to_wrap = c4m_str_concat(w1, w2);
-    to_wrap = c4m_str_concat(to_wrap, w3);
-    to_wrap = c4m_str_concat(to_wrap, w4);
-    to_wrap = c4m_str_concat(to_wrap, w5);
-    to_wrap = c4m_str_concat(to_wrap, w6);
-
-    c4m_utf8_t *dump1 = c4m_hex_dump(to_wrap->styling,
-                                     c4m_alloc_style_len(to_wrap),
-                                     c4m_kw("start_offset",
-                                            c4m_ka(to_wrap->styling),
-                                            "width",
-                                            c4m_ka(80),
-                                            "prefix",
-                                            c4m_ka("Style dump\n")));
-
-    c4m_utf8_t *dump2 = c4m_hex_dump(to_wrap,
-                                     to_wrap->byte_len,
-                                     c4m_kw("start_offset",
-                                            c4m_ka((uint64_t)to_wrap),
-                                            "width",
-                                            c4m_ka(80),
-                                            "prefix",
-                                            c4m_ka("String Dump\n")));
-
-    c4m_ansi_render(dump1, serr);
-    c4m_ansi_render(dump2, serr);
-
-    c4m_ansi_render_to_width(to_wrap, term_width, 0, sout);
-    collect_and_print_stats();
-    return to_wrap;
-}
-
-void
-test_rand64()
-{
-    uint64_t random = 0;
-
-    random = c4m_rand64();
-    printf("Random value: %16llx\n", (unsigned long long)random);
-    assert(random != 0);
-}
-
-void
-test3(c4m_str_t *to_slice)
-{
-    // c4m_ansi_render(c4m_str_slice(to_slice, 10, 50), sout);
-    c4m_ansi_render_to_width(c4m_str_slice(to_slice, 10, 50),
-                             term_width,
-                             0,
-                             sout);
-    printf("\n");
-    c4m_ansi_render_to_width(c4m_str_slice(to_slice, 40, 100),
-                             term_width,
-                             0,
-                             sout);
-    printf("\n");
-}
-
-void
-test4()
-{
-    c4m_utf8_t *w1 = c4m_new(
-        c4m_tspec_utf8(),
-        c4m_kw("cstring",
-               c4m_ka("Once upon a time, there was a ")));
-    c4m_utf8_t *w2 = c4m_new(
-        c4m_tspec_utf8(),
-        c4m_kw("cstring",
-               c4m_ka("thing I cared about. But then ")));
-    c4m_utf8_t *w3 = c4m_new(
-        c4m_tspec_utf8(),
-        c4m_kw("cstring",
-               c4m_ka("I stopped caring. I don't really "
-                      "remember what it was, though. Do ")));
-    c4m_utf8_t *w4 = c4m_new(
-        c4m_tspec_utf8(),
-        c4m_kw("cstring",
-               c4m_ka("you? No, I didn't think so, because it "
-                      "wasn't really all that interesting, to "
-                      "be quite honest. Maybe someday I'll "
-                      "find something interesting to care "
-                      "about, besides my family. Oh yeah, "
-                      "that's what it was, my family! Oh, "
-                      "wait, no, they're either not "
-                      "interesting, or I don't care about "
-                      "them.\n")));
-    c4m_utf8_t *w5 = c4m_new(c4m_tspec_utf8(),
-                             c4m_kw("cstring",
-                                    c4m_ka("Basically AirTags for Software")));
-    c4m_utf8_t *w6 = c4m_new(c4m_tspec_utf8(), c4m_kw("cstring", c4m_ka("\n")));
-
-    c4m_dict_t *d = c4m_new(c4m_tspec_dict(c4m_tspec_utf8(),
-                                           c4m_tspec_ref()));
-
-    hatrack_dict_put(d, w1, "w1");
-    hatrack_dict_put(d, w2, "w2");
-    hatrack_dict_put(d, w3, "w3");
-    hatrack_dict_put(d, w4, "w4");
-    hatrack_dict_put(d, w5, "w5");
-    hatrack_dict_put(d, w6, "w6");
-
-    uint64_t num;
-
-    hatrack_dict_item_t *view = hatrack_dict_items_sort(d, &num);
-
-    for (uint64_t i = 0; i < num; i++) {
-        c4m_ansi_render((c4m_str_t *)(view[i].key), serr);
-    }
-
-    collect_and_print_stats();
-}
-
-void
-table_test()
-{
-    c4m_utf8_t *test1 = c4m_new(c4m_tspec_utf8(),
-                                c4m_kw("cstring",
-                                       c4m_ka("Some example 🤯 🤯 🤯"
-                                              " Let's make it a fairly "
-                                              "long 🤯 example, so it will "
-                                              "be sure to need some reynolds' "
-                                              "wrap.")));
-    c4m_utf8_t *test2 = c4m_new(c4m_tspec_utf8(),
-                                c4m_kw("cstring",
-                                       c4m_ka("Some other example.")));
-    c4m_utf8_t *test3 = c4m_new(c4m_tspec_utf8(),
-                                c4m_kw("cstring",
-                                       c4m_ka("Example 3.")));
-    c4m_utf8_t *test4 = c4m_new(c4m_tspec_utf8(),
-                                c4m_kw("cstring",
-                                       c4m_ka("Defaults.")));
-    c4m_utf8_t *test5 = c4m_new(c4m_tspec_utf8(),
-                                c4m_kw("cstring",
-                                       c4m_ka("Last one.")));
-    c4m_grid_t *g     = c4m_new(c4m_tspec_grid(),
-                            c4m_kw("start_rows",
-                                   c4m_ka(4),
-                                   "start_cols",
-                                   c4m_ka(3),
-                                   "header_rows",
-                                   c4m_ka(1)));
-    c4m_utf8_t *hdr   = c4m_new(c4m_tspec_utf8(),
-                              c4m_kw("cstring",
-                                     c4m_ka("Yes, this is a table.")));
-
-    c4m_grid_add_row(g, c4m_to_str_renderable(hdr, "td"));
-    c4m_grid_add_cell(g, test1);
-    c4m_grid_add_cell(g, test2);
-    c4m_grid_add_cell(g, test4);
-    c4m_grid_set_cell_contents(g, 2, 2, test3);
-    c4m_grid_set_cell_contents(g, 2, 1, test5);
-    c4m_grid_add_col_span(g, c4m_to_str_renderable(test1, "td"), 3, 0, 2);
-    c4m_grid_set_cell_contents(g, 2, 0, c4m_empty_string());
-    // If we don't explicitly set this, there can be some render issues
-    // when there's not enough room.
-    c4m_grid_set_cell_contents(g, 3, 2, c4m_empty_string());
-    c4m_str_set_style(test1, style1);
-    c4m_str_set_style(test2, style2);
-    c4m_str_set_style(test3, style1);
-    c4m_str_set_style(test5, style2);
-    c4m_new(c4m_tspec_render_style(),
-            c4m_kw("flex_units", c4m_ka(3), "tag", c4m_ka("col1")));
-    c4m_new(c4m_tspec_render_style(),
-            c4m_kw("flex_units", c4m_ka(2), "tag", c4m_ka("col3")));
-    //    c4m_new(c4m_tspec_render_style(), "width_pct", 10., "tag", "col1");
-    //    c4m_new(c4m_tspec_render_style(), "width_pct", 30., "tag", "col3");
-    c4m_set_column_style(g, 0, "col1");
-    c4m_set_column_style(g, 2, "col3");
-
-    // Ordered / unordered lists.
-    c4m_utf8_t  *ol1 = c4m_new(c4m_tspec_utf8(),
-                              c4m_kw("cstring",
-                                     c4m_ka("This is a good point, one that you "
-                                             "haven't heard before.")));
-    c4m_utf8_t  *ol2 = c4m_new(c4m_tspec_utf8(),
-                              c4m_kw("cstring",
-                                     c4m_ka("This is a point that's also valid,"
-                                             " but you already know it.")));
-    c4m_utf8_t  *ol3 = c4m_new(c4m_tspec_utf8(),
-                              c4m_kw("cstring",
-                                     c4m_ka("This is a small point.")));
-    c4m_utf8_t  *ol4 = c4m_new(c4m_tspec_utf8(),
-                              c4m_kw("cstring", c4m_ka("Conclusion.")));
-    flexarray_t *l   = c4m_new(c4m_tspec_list(c4m_tspec_utf8()),
-                             c4m_kw("length", c4m_ka(12)));
-
-    flexarray_set(l, 0, ol1);
-    flexarray_set(l, 1, ol2);
-    flexarray_set(l, 2, ol3);
-    flexarray_set(l, 3, ol4);
-    flexarray_set(l, 4, ol1);
-    flexarray_set(l, 5, ol2);
-    flexarray_set(l, 6, ol3);
-    flexarray_set(l, 7, ol4);
-    flexarray_set(l, 8, ol1);
-    flexarray_set(l, 9, ol2);
-    flexarray_set(l, 0xa, ol3);
-    flexarray_set(l, 0xb, ol4);
-
-    c4m_grid_t *ol = c4m_ordered_list(l);
-    c4m_grid_t *ul = c4m_unordered_list(l);
-
-    c4m_grid_stripe_rows(ol);
-
-    c4m_grid_t *flow = c4m_grid_flow(3, g, ul, ol);
-    c4m_grid_add_cell(flow, test1);
-    c4m_ansi_render(c4m_value_obj_to_str(flow), sout);
-}
-
-void
-sha_test()
-{
-    c4m_utf8_t *test1 = c4m_new(c4m_tspec_utf8(),
-                                c4m_kw("cstring",
-                                       c4m_ka("Some example 🤯 🤯 🤯"
-                                              " Let's make it a fairly long 🤯 "
-                                              "example, so it will be sure to need"
-                                              " some reynolds' wrap.")));
-
-    c4m_sha_t *ctx = c4m_new(c4m_tspec_hash());
-    c4m_sha_string_update(ctx, test1);
-    c4m_buf_t *b = c4m_sha_finish(ctx);
-
-    printf("Sha256 is: ");
-    c4m_ansi_render(c4m_value_obj_repr(b), sout);
-    printf("\n");
-}
-
-void
-type_tests()
-{
-    c4m_type_t *t1 = c4m_tspec_int();
-    c4m_type_t *t2 = c4m_tspec_grid();
-    c4m_type_t *t3 = c4m_tspec_dict(t1, t2);
-
-    c4m_ansi_render(c4m_value_obj_repr(t3), sout);
-    printf("\n");
-
-    c4m_type_t *t4 = c4m_new_typevar(c4m_global_type_env);
-    c4m_type_t *t5 = c4m_new_typevar(c4m_global_type_env);
-    c4m_type_t *t6 = c4m_tspec_dict(t4, t5);
-
-    c4m_ansi_render(c4m_value_obj_repr(t6), sout);
-    printf("\n");
-    c4m_ansi_render(c4m_value_obj_repr(c4m_merge_types(t3, t6)), sout);
-    printf("\n");
-}
-
-void
-c4m_stream_tests()
-{
-    c4m_utf8_t   *n  = c4m_new(c4m_tspec_utf8(),
-                            c4m_kw("cstring",
-                                   c4m_ka("../meson.build")));
-    c4m_stream_t *s1 = c4m_new(c4m_tspec_stream(),
-                               c4m_kw("filename", c4m_ka(n)));
-    c4m_buf_t    *b  = c4m_new(c4m_tspec_buffer(),
-                           c4m_kw("length", c4m_ka(16)));
-    c4m_stream_t *s2 = c4m_new(c4m_tspec_stream(),
-                               c4m_kw("buffer",
-                                      c4m_ka(b),
-                                      "write",
-                                      c4m_ka(1)));
-
-    c4m_style_t sty = c4m_add_bold(c4m_add_italic(c4m_new_style()));
-
-    while (true) {
-        c4m_utf8_t *s = c4m_stream_read(s1, 16);
-
-        if (c4m_len(s) == 0) {
-            break;
-        }
-
-        c4m_stream_write_object(s2, s);
-    }
-
-    c4m_print(c4m_hex_dump(b->data, b->byte_len));
-    c4m_utf8_t *s = c4m_buf_to_utf8_string(b);
-
-    c4m_str_set_style(s, sty);
-    c4m_print(s);
-}
-
-extern c4m_color_info_t color_data[];
-
-void
-marshal_test()
-{
-    c4m_utf8_t   *contents = c4m_new(c4m_tspec_utf8(),
-                                   c4m_kw("cstring",
-                                          c4m_ka("This is a test of marshal.\n")));
-    c4m_buf_t    *b        = c4m_new(c4m_tspec_buffer(),
-                           c4m_kw("length", c4m_ka(16)));
-    c4m_stream_t *s        = c4m_new(c4m_tspec_stream(),
-                              c4m_kw("buffer",
-                                     c4m_ka(b),
-                                     "write",
-                                     c4m_ka(1),
-                                     "read",
-                                     c4m_ka(0)));
-
-    c4m_marshal(contents, s);
-    c4m_stream_close(s);
-
-    s = c4m_new(c4m_tspec_stream(), c4m_kw("buffer", c4m_ka(b)));
-
-    c4m_utf8_t *new_str = c4m_unmarshal(s);
-
-    c4m_ansi_render(new_str, sout);
-}
-
-#if 0
-// This works, and now is in color.c locally.
-#include "/tmp/color.c"
-
-void
-marshal_test2()
-{
-    c4m_dict_t *d = c4m_new(c4m_tspec_dict(c4m_tspec_utf8(), c4m_tspec_int()));
-    int n;
-
-    for (n = 0; color_data[n].name != NULL; n++) {
-	c4m_utf8_t  *color = c4m_new(c4m_tspec_utf8(),
-				   c4m_kw("cstring",
-					  c4m_ka(color_data[n].name)));
-	int64_t rgb    = (int64_t)color_data[n].rgb;
-
-	hatrack_dict_put(d, color, (void *)rgb);
-    }
-
-    printf("Writing test color dictionary to /tmp/color.c\n");
-    c4m_dump_c_static_instance_code(d, "color_table",
-				c4m_new(c4m_tspec_utf8(),
-					  c4m_kw("cstring",
-					     c4m_ka("/tmp/color.c"))));
-
-    for (int64_t i = 0; i < n - 1; i++) {
-	char   *ckey = color_data[i].name;
-	if (ckey == NULL) {
-	    continue;
-	}
-	c4m_utf8_t *key  = c4m_new(c4m_tspec_utf8(),
-				   c4m_kw("cstring", karg(ckey)));
-	int64_t val  = c4m_lookup_color(key);
-	printf("%s: %06llx\n", key->data, val);
-    }
-}
-#endif
-
-void
-create_dict_lit()
-{
-    c4m_dict_t *d = c4m_new(c4m_tspec_dict(c4m_tspec_utf8(), c4m_tspec_int()));
-
-    hatrack_dict_add(d, c4m_new_utf8("no"), (void *)1LLU);
-    hatrack_dict_add(d, c4m_new_utf8("b"), (void *)2LLU);
-    hatrack_dict_add(d, c4m_new_utf8("bold"), (void *)2LLU);
-    hatrack_dict_add(d, c4m_new_utf8("i"), (void *)3LLU);
-    hatrack_dict_add(d, c4m_new_utf8("italic"), (void *)3LLU);
-    hatrack_dict_add(d, c4m_new_utf8("italics"), (void *)3LLU);
-    hatrack_dict_add(d, c4m_new_utf8("st"), (void *)4LLU);
-    hatrack_dict_add(d, c4m_new_utf8("strike"), (void *)4LLU);
-    hatrack_dict_add(d, c4m_new_utf8("strikethru"), (void *)4LLU);
-    hatrack_dict_add(d, c4m_new_utf8("strikethrough"), (void *)4LLU);
-    hatrack_dict_add(d, c4m_new_utf8("u"), (void *)5LLU);
-    hatrack_dict_add(d, c4m_new_utf8("underline"), (void *)5LLU);
-    hatrack_dict_add(d, c4m_new_utf8("uu"), (void *)6LLU);
-    hatrack_dict_add(d, c4m_new_utf8("2u"), (void *)6LLU);
-    hatrack_dict_add(d, c4m_new_utf8("r"), (void *)7LLU);
-    hatrack_dict_add(d, c4m_new_utf8("reverse"), (void *)7LLU);
-    hatrack_dict_add(d, c4m_new_utf8("inverse"), (void *)7LLU);
-    hatrack_dict_add(d, c4m_new_utf8("invert"), (void *)7LLU);
-    hatrack_dict_add(d, c4m_new_utf8("inv"), (void *)7LLU);
-    hatrack_dict_add(d, c4m_new_utf8("t"), (void *)8LLU);
-    hatrack_dict_add(d, c4m_new_utf8("title"), (void *)8LLU);
-    hatrack_dict_add(d, c4m_new_utf8("l"), (void *)9LLU);
-    hatrack_dict_add(d, c4m_new_utf8("lower"), (void *)9LLU);
-    hatrack_dict_add(d, c4m_new_utf8("up"), (void *)10LLU);
-    hatrack_dict_add(d, c4m_new_utf8("upper"), (void *)10LLU);
-    hatrack_dict_add(d, c4m_new_utf8("on"), (void *)11LLU);
-    hatrack_dict_add(d, c4m_new_utf8("fg"), (void *)12LLU);
-    hatrack_dict_add(d, c4m_new_utf8("foreground"), (void *)12LLU);
-    hatrack_dict_add(d, c4m_new_utf8("bg"), (void *)13LLU);
-    hatrack_dict_add(d, c4m_new_utf8("background"), (void *)13LLU);
-    hatrack_dict_add(d, c4m_new_utf8("color"), (void *)14LLU);
-
-    c4m_dump_c_static_instance_code(d,
-                                    "style_keywords",
-                                    c4m_new_utf8("/tmp/style_keys.c"));
-}
-
-void
-c4m_rich_lit_test()
-{
-    c4m_utf8_t *test;
-
-    test = c4m_rich_lit("H[atomic lime]ello, [jazzberry]world!");
-    c4m_print(test);
-
-    test = c4m_rich_lit("[atomic lime]Hello, [jazzberry]world[/]!");
-    c4m_print(test);
-
-    test = c4m_rich_lit("[atomic lime %jazzberry]Hello, world[/]!");
-    c4m_print(test);
-
-    test = c4m_rich_lit("[jazzberry %atomic lime]Hello, world![/]");
-    c4m_print(test);
-
-    test = c4m_rich_lit(
-        "[bold italic jazzberry %atomic lime]Hello,[/jazzberry atomic lime] "
-        "world!");
-    c4m_print(test);
-
-    test = c4m_rich_lit(
-        "[bold italic jazzberry %atomic lime]Hello,"
-        "[/jazzberry atomic lime bold] world!");
-    c4m_print(test);
-
-    test = c4m_rich_lit(
-        "[bold italic jazzberry %atomic lime]Hello,"
-        "[-jazzberry atomic lime bold italic + underline] world??");
-    c4m_print(test);
-
-    test = c4m_rich_lit(
-        "[bold italic jazzberry %atomic lime]Hello,[/ bold] "
-        "world!");
-    c4m_print(test);
-
-    test = c4m_rich_lit(
-        "[bold italic u jazzberry %atomic lime]Hello,[/bold] "
-        "world!\n\n");
-    c4m_print(test);
-
-    test = c4m_rich_lit(
-        "[bold italic u jazzberry %atomic lime]Hello,[/bold] "
-        "world![/]\n\n");
-    c4m_print(test);
-
-    test = c4m_rich_lit(
-        "[bold italic atomic lime %jazzberry]Hello,[/bold    ] "
-        "world!");
-    c4m_print(test);
-
-    test = c4m_rich_lit("[h2]Hello, world!");
-    c4m_print(test);
-
-    test = c4m_rich_lit("[h2]Hello, [i u]world[/i u], it is me![/]");
-    c4m_print(test);
-
-    c4m_print(test, test, c4m_kw("no_color", c4m_ka(true), "sep", c4m_ka('&')));
-
-    test = c4m_rich_lit("[em]Hi c.[/em]");
-    c4m_print(test);
-}
-
-bool
-test_tree_search(int64_t kind_as_64, c4m_tree_node_t *node)
-{
-    c4m_node_kind_t kind  = (c4m_node_kind_t)(unsigned int)kind_as_64;
-    c4m_pnode_t    *pnode = c4m_tree_get_contents(node);
-
-    if (kind == c4m_nt_error) {
-        return true;
-    }
-
-    return kind == pnode->kind;
-}
-
-#if 1
-void
-test_compiler()
-{
-    c4m_xlist_t     *files  = c4m_get_program_arguments();
-    int64_t          l      = c4m_xlist_len(files);
-    c4m_utf8_t      *joiner = c4m_new_utf8("../tests/");
-    c4m_utf8_t      *slash  = c4m_get_slash_const();
-    c4m_compile_ctx *ctx;
-
-    if (l < 1) {
+    if (!dev_mode) {
         return;
     }
 
-    c4m_add_static_function(c4m_new_utf8("strndup"), strndup);
+    c4m_print(c4m_format_tokens(ctx->entry_point));
 
-    for (int64_t i = 0; i < l; i++) {
-        c4m_utf8_t *fname = c4m_xlist_get(files, i, NULL);
-        c4m_utf8_t *path;
+    for (int i = 0; i < c4m_xlist_len(ctx->module_ordering); i++) {
+        c4m_file_compile_ctx *f = c4m_xlist_get(ctx->module_ordering,
+                                                i,
+                                                NULL);
 
-        if (c4m_str_find(fname, slash) == -1) {
-            path = c4m_str_concat(joiner, fname);
+        c4m_print(c4m_cstr_format("[h1]Processing module {}", f->path));
+        if (ctx->entry_point->parse_tree) {
+            c4m_print(c4m_format_parse_tree(ctx->entry_point));
         }
         else {
-            path = fname;
+            continue;
         }
 
-        c4m_print(c4m_cstr_format("[atomic lime]info:[/] Compiling from: {}",
-                                  fname));
-
-        ctx = c4m_compile_from_entry_point(path);
-        // c4m_print(c4m_format_tokens(ctx->entry_point));
-
-        for (int i = 0; i < c4m_xlist_len(ctx->module_ordering); i++) {
-            c4m_file_compile_ctx *f = c4m_xlist_get(ctx->module_ordering,
-                                                    i,
-                                                    NULL);
-
-#if 1
-            c4m_print(c4m_cstr_format("[h1]Processing module {}", f->path));
-            if (ctx->entry_point->parse_tree) {
-                c4m_print(c4m_format_parse_tree(ctx->entry_point));
-            }
-            else {
-                continue;
-            }
-
-            if (ctx->entry_point->cfg) {
-                c4m_print(c4m_cstr_format("[h1]Toplevel CFG for {}", f->path));
-                c4m_print(c4m_cfg_repr(ctx->entry_point->cfg));
-            }
-            else {
-                continue;
-            }
-
-            for (int j = 0; j < c4m_xlist_len(f->fn_def_syms); j++) {
-                c4m_scope_entry_t *sym  = c4m_xlist_get(f->fn_def_syms,
-                                                       j,
-                                                       NULL);
-                c4m_fn_decl_t     *decl = sym->value;
-                c4m_print(c4m_cstr_format("[h1]CFG for Function {}{}",
-                                          sym->name,
-                                          sym->type));
-                c4m_print(c4m_cfg_repr(decl->cfg));
-                c4m_print(c4m_cstr_format("[h2]Function Scope for {}{}",
-                                          sym->name,
-                                          sym->type));
-                c4m_print(c4m_format_scope(decl->signature_info->fn_scope));
-            }
-
-            c4m_print(c4m_rich_lit("[h2]Global Scope"));
-            c4m_print(c4m_format_scope(ctx->final_globals));
-            c4m_print(c4m_rich_lit("[h2]Module Scope"));
-            c4m_print(c4m_format_scope(ctx->entry_point->module_scope));
-#endif
+        if (ctx->entry_point->cfg) {
+            c4m_print(c4m_cstr_format("[h1]Toplevel CFG for {}", f->path));
+            c4m_print(c4m_cfg_repr(ctx->entry_point->cfg));
+        }
+        else {
+            continue;
         }
 
-        c4m_grid_t *err_output = c4m_format_errors(ctx);
-
-        if (err_output != NULL) {
-            c4m_print(err_output);
+        for (int j = 0; j < c4m_xlist_len(f->fn_def_syms); j++) {
+            c4m_scope_entry_t *sym  = c4m_xlist_get(f->fn_def_syms,
+                                                   j,
+                                                   NULL);
+            c4m_fn_decl_t     *decl = sym->value;
+            c4m_print(c4m_cstr_format("[h1]CFG for Function {}{}",
+                                      sym->name,
+                                      sym->type));
+            c4m_print(c4m_cfg_repr(decl->cfg));
+            c4m_print(c4m_cstr_format("[h2]Function Scope for {}{}",
+                                      sym->name,
+                                      sym->type));
+            c4m_print(c4m_format_scope(decl->signature_info->fn_scope));
         }
 
-        c4m_print(c4m_cstr_format("[atomic lime]info:[/] Done processing: {}",
-                                  fname));
+        c4m_print(c4m_rich_lit("[h2]Global Scope"));
+        c4m_print(c4m_format_scope(ctx->final_globals));
+        c4m_print(c4m_rich_lit("[h2]Module Scope"));
+        c4m_print(c4m_format_scope(ctx->entry_point->module_scope));
+    }
+}
 
-        if (c4m_got_fatal_compiler_error(ctx)) {
-            return;
+static void
+show_dev_disasm(c4m_vm_t *vm, c4m_zmodule_info_t *m)
+{
+    c4m_print(c4m_disasm(vm, m));
+    c4m_print(c4m_cstr_format("Module [em]{}[/] disassembly done.",
+                              m->path));
+    c4m_print(c4m_rich_lit("[h2]Module Source Code"));
+    c4m_print(m->source);
+}
+
+c4m_dict_t *
+build_file_list()
+{
+    bool          fatal      = false;
+    c4m_xlist_t  *argv       = c4m_get_program_arguments();
+    c4m_xlist_t  *to_recurse = c4m_xlist(c4m_tspec_utf8());
+    c4m_dict_t   *result     = c4m_dict(c4m_tspec_utf8(), c4m_tspec_ref());
+    c4m_utf8_t   *test_dir   = c4m_get_env(c4m_new_utf8("CON4M_TEST_DIR"));
+    c4m_utf8_t   *ext        = c4m_new_utf8(".c4m");
+    c4m_test_kat *kat;
+
+    int n = c4m_xlist_len(argv);
+
+    if (test_dir == NULL) {
+        test_dir = c4m_new_utf8("../tests/");
+    }
+
+    test_dir = c4m_resolve_path(test_dir);
+
+    if (!n) {
+        n    = 1;
+        argv = c4m_xlist(c4m_tspec_utf8());
+        c4m_xlist_append(argv, test_dir);
+    }
+
+    for (int i = 0; i < n; i++) {
+        c4m_utf8_t *s = c4m_to_utf8(c4m_xlist_get(argv, i, NULL));
+        s             = c4m_resolve_path(s);
+        switch (c4m_get_file_kind(s)) {
+        case C4M_FK_IS_REG_FILE:
+        case C4M_FK_IS_FLINK:
+            // Don't worry about the extension if the explicitly
+            // passed a file name.
+            kat = c4m_extract_kat(s);
+            hatrack_dict_put(result, s, kat);
+            continue;
+        case C4M_FK_IS_DIR:
+        case C4M_FK_IS_DLINK:
+            c4m_xlist_append(to_recurse, s);
+            continue;
+        case C4M_FK_NOT_FOUND:
+            c4m_printf("[red]error:[/] No such file or directory: {}", s);
+            fatal = true;
+            continue;
+        default:
+            c4m_printf("[red]error:[/] Cannot process special file: {}", s);
+            fatal = true;
+            continue;
+        }
+    }
+
+    if (fatal) {
+        exit(-1);
+    }
+
+    n = c4m_xlist_len(to_recurse);
+    for (int i = 0; i < n; i++) {
+        int          num_hits = 0;
+        c4m_utf8_t  *path     = c4m_xlist_get(to_recurse, i, NULL);
+        c4m_xlist_t *files    = c4m_path_walk(path,
+                                           c4m_kw("follow_links",
+                                                  c4m_ka(true)));
+
+        int walk_len = c4m_xlist_len(files);
+        for (int j = 0; j < walk_len; j++) {
+            c4m_utf8_t *one = c4m_xlist_get(files, j, NULL);
+            if (c4m_str_ends_with(one, ext)) {
+                kat = c4m_extract_kat(one);
+                // When scanning dirs, if we have test cases that span
+                // multiple files, we don't want to process multiple
+                // times redundantly, so we only add ones w/ kat info.
+                if (kat == NULL) {
+                    continue;
+                }
+
+                num_hits++;
+                hatrack_dict_put(result, one, kat);
+            }
         }
 
-        c4m_vm_t *vm = c4m_generate_code(ctx);
+        if (num_hits == 0) {
+            c4m_printf("[yellow]warning[/]: No con4m files found in dir: {}",
+                       path);
+        }
+    }
 
-#if 1
+    return result;
+}
+
+static void
+show_err_diffs(c4m_utf8_t *fname, c4m_xlist_t *expected, c4m_xlist_t *actual)
+{
+    c4m_compile_error_t err;
+    c4m_utf8_t         *errstr;
+
+    c4m_printf("[red]FAIL[/]: test [i]{}[/]: error mismatch.", fname);
+
+    if (!expected || c4m_xlist_len(expected) == 0) {
+        c4m_printf("[h1]Expected no errors.");
+    }
+    else {
+        c4m_printf("[h1]Expected errors:");
+
+        int n = c4m_xlist_len(expected);
+
+        for (int i = 0; i < n; i++) {
+            errstr = c4m_xlist_get(expected, i, NULL);
+            c4m_printf("[em]{}", errstr);
+        }
+    }
+
+    if (!actual || c4m_xlist_len(actual) == 0) {
+        c4m_printf("[h2]Got no errors.");
+    }
+    else {
+        c4m_printf("[h2]Actual errors:");
+
+        int n = c4m_xlist_len(actual);
+
+        for (int i = 0; i < n; i++) {
+            uint64_t u64     = (uint64_t)c4m_xlist_get(actual, i, NULL);
+            err              = (c4m_compile_error_t)u64;
+            c4m_utf8_t *code = c4m_err_code_to_str(err);
+            c4m_printf("[em]{}", code);
+        }
+    }
+}
+
+static bool
+compare_results(c4m_utf8_t      *fname,
+                c4m_test_kat    *kat,
+                c4m_compile_ctx *ctx,
+                c4m_buf_t       *outbuf)
+{
+    bool ret = true;
+
+    if (kat == NULL) {
+        return ret;
+    }
+
+    if (kat->expected_output) {
+        if (c4m_buffer_len(outbuf) == 0) {
+            if (!c4m_str_codepoint_len(kat->expected_output)) {
+                goto next_comparison;
+            }
+empty_err:
+            ret = false;
+            c4m_printf(
+                "[red]FAIL[/]: test [i]{}[/]: program expected output "
+                "but did not compile. Expected output:\n {}",
+                fname,
+                kat->expected_output);
+        }
+        else {
+            c4m_utf8_t *output = c4m_buf_to_utf8_string(outbuf);
+            output             = c4m_to_utf8(c4m_str_strip(output));
+
+            if (c4m_str_codepoint_len(output) == 0) {
+                goto empty_err;
+            }
+            if (!c4m_str_eq(output, kat->expected_output)) {
+                ret = false;
+
+                c4m_printf(
+                    "[red]FAIL[/]: test [i]{}[/]: output mismatch.",
+                    fname);
+                c4m_printf(
+                    "[h1]Expected output[/]\n{}\n[h1]Actual[/]\n{}\n",
+                    kat->expected_output,
+                    output);
+                c4m_printf(
+                    "[h2]Expected (Hex)[/]\n{}\n[h2]Actual (Hex)[/]\n{}\n",
+                    c4m_hex_dump(kat->expected_output->data,
+                                 c4m_str_byte_len(kat->expected_output)),
+                    c4m_hex_dump(output->data, c4m_str_byte_len(output)));
+            }
+        }
+    }
+
+next_comparison:;
+    c4m_xlist_t *actual_errs  = c4m_compile_extract_all_error_codes(ctx);
+    int          num_expected = 0;
+    int          num_actual   = c4m_xlist_len(actual_errs);
+
+    if (kat->expected_errors != NULL) {
+        num_expected = c4m_xlist_len(kat->expected_errors);
+    }
+
+    if (num_expected != num_actual) {
+        ret = false;
+        show_err_diffs(fname, kat->expected_errors, actual_errs);
+    }
+    else {
+        for (int i = 0; i < num_expected; i++) {
+            c4m_compile_error_t c1;
+            c4m_utf8_t         *c2;
+
+            c1 = (uint64_t)c4m_xlist_get(actual_errs, i, NULL);
+            c2 = c4m_xlist_get(kat->expected_errors, i, NULL);
+            c2 = c4m_to_utf8(c4m_str_strip(c2));
+
+            if (!c4m_str_eq(c4m_err_code_to_str(c1), c2)) {
+                ret = false;
+                show_err_diffs(fname, kat->expected_errors, actual_errs);
+                break;
+            }
+        }
+    }
+
+    return ret;
+}
+
+bool
+test_compiler(c4m_utf8_t *fname, c4m_test_kat *kat)
+{
+    c4m_compile_ctx *ctx;
+
+    c4m_printf("[atomic lime]info:[/] Compiling: {}", fname);
+
+    ctx = c4m_compile_from_entry_point(fname);
+
+    show_dev_compile_info(ctx);
+
+    c4m_grid_t *err_output = c4m_format_errors(ctx);
+
+    if (err_output != NULL) {
+        c4m_print(err_output);
+    }
+
+    c4m_printf("[atomic lime]info:[/] Done processing: {}", fname);
+
+    if (c4m_got_fatal_compiler_error(ctx)) {
+        return compare_results(fname, kat, ctx, NULL);
+    }
+
+    c4m_vm_t *vm = c4m_generate_code(ctx);
+
+    if (dev_mode) {
         for (int i = 0; i < c4m_xlist_len(ctx->module_ordering); i++) {
             c4m_zmodule_info_t *m;
             m = c4m_xlist_get(vm->obj->module_contents, i, NULL);
-            c4m_print(c4m_disasm(vm, m));
-            c4m_print(c4m_cstr_format("Module [em]{}[/] disassembly done.",
-                                      m->path));
-            c4m_print(c4m_rich_lit("[h2]Module Source Code"));
-            c4m_print(m->source);
+            show_dev_disasm(vm, m);
         }
-#endif
-
-        c4m_print(c4m_rich_lit("[h6]****STARTING PROGRAM EXECUTION*****[/]"));
-        c4m_vmthread_t *thread = c4m_vmthread_new(vm);
-        c4m_vmthread_run(thread);
-        c4m_print(c4m_rich_lit("[h6]****PROGRAM EXECUTION FINISHED*****[/]\n"));
-        // TODO: We need to mark unlocked types with sub-variables at some point,
-        // so they don't get clobbered.
-        //
-        // E.g.,  (dict[`x, list[int]]) -> int
-
-        // c4m_clean_environment();
-        // c4m_print(c4m_format_global_type_environment());
     }
-}
-#else
-#define test_compiler(...)
-#endif
 
-void
-test_format()
-{
-    c4m_str_t *s;
-    s = c4m_cstr_format("Test 0");
-    c4m_print(s);
+    c4m_printf("[h6]****STARTING PROGRAM EXECUTION*****[/]");
+    c4m_vmthread_t *thread = c4m_vmthread_new(vm);
+    c4m_vmthread_run(thread);
+    c4m_printf("[h6]****PROGRAM EXECUTION FINISHED*****[/]\n");
+    // TODO: We need to mark unlocked types with sub-variables at some point,
+    // so they don't get clobbered.
+    //
+    // E.g.,  (dict[`x, list[int]]) -> int
 
-    s = c4m_cstr_format("[red]Test 1:[/] [brown]{:c}[/] : [blue]{}[/] [i]woo.[/]",
-                        c4m_box_u64(100),
-                        c4m_rich_lit("Hello"));
-    c4m_print(s);
-    s = c4m_cstr_format("[red]Test 2:[/] [brown]{:d}[/] : [red]{:}[/]",
-                        c4m_box_u64(100),
-                        c4m_box_u64(100));
-    c4m_print(s);
+    // c4m_clean_environment();
+    // c4m_print(c4m_format_global_type_environment());
 
-    s = c4m_cstr_format("[red]Test 3:[/] {1} : [blue]{0:n}[/]\n",
-                        c4m_box_u64(100),
-                        c4m_rich_lit("Hello"));
-    c4m_print(s);
-    s = c4m_cstr_format("[red]Test 4:[/] [blue]{}[/][atomic lime]{}[/]foo\n",
-                        c4m_rich_lit("Hello"),
-                        c4m_rich_lit("Sir "));
-    c4m_print(s);
+    return compare_results(fname, kat, ctx, vm->print_buf);
 }
 
 void
-test_path()
+add_static_symbols()
 {
-    c4m_utf8_t *user = c4m_get_user_name();
-
-    c4m_utf8_t *tests[] = {
-        c4m_new_utf8("/"),
-        c4m_cstr_format("/home/{}/dev/libcon4m/", user),
-        c4m_cstr_format("~{}/dev/libcon4m/", user),
-        c4m_cstr_format("~{}/dev/libcon4m/../con4m////src//", user),
-        c4m_cstr_format("~{}/dev/libcon4m/.././con4m/././///src//", user),
-        c4m_new_utf8(""),
-        c4m_new_utf8("~"),
-        NULL,
-    };
-
-    c4m_utf8_t *one;
-    int         i = 0;
-
-    c4m_print(c4m_cstr_format("[h2]Path resolution tests"));
-
-    while ((one = tests[i++]) != NULL) {
-        c4m_print(c4m_cstr_format(
-            "[h4]Test #{}:[/]\n[u]input:[/] [i]{}[/]\n[u]output:[/] [em]{}\n",
-            c4m_box_u64(i),
-            one,
-            c4m_resolve_path(one)));
-    }
+    c4m_add_static_function(c4m_new_utf8("strndup"), strndup);
 }
-
-#undef STACK_SCAN_TEST
 
 int
 main(int argc, char **argv, char **envp)
 {
-#ifdef STACK_SCAN_TEST
-    uint64_t top, bottom;
-#endif
+    add_static_symbols();
 
     c4m_init(argc, argv, envp);
+    int num_errs     = 0;
+    int num_tests    = 0;
+    int no_exception = 1;
 
-    sout = c4m_get_stdout();
-    serr = c4m_get_stderr();
+    if (c4m_get_env(c4m_new_utf8("CON4M_DEV"))) {
+        dev_mode = true;
+    }
 
     C4M_TRY
     {
         c4m_install_default_styles();
         c4m_terminal_dimensions(&term_width, NULL);
+        c4m_dict_t          *targets = build_file_list();
+        uint64_t             n;
+        hatrack_dict_item_t *items = hatrack_dict_items_sort(targets, &n);
 
-        if (argc == 1) {
-            c4m_ansi_render_to_width(str_test, term_width, 0, sout);
-            test_rand64();
-            // Test basic string and single threaded GC.
-            test1();
-            // style1 = apply_bg_color(style1, "alice blue");
-            c4m_str_t *to_slice = test2();
-            test3(to_slice);
-            to_slice = NULL;
-            test4();
-            table_test();
+        for (uint64_t i = 0; i < n; i++) {
+            c4m_utf8_t   *fname = items[i].key;
+            c4m_test_kat *kat   = items[i].value;
 
-            printf("Sample style: %.16llx\n", (unsigned long long)style1);
-            sha_test();
+            if (kat != NULL) {
+                num_tests++;
+            }
 
-            type_tests();
-            c4m_stream_tests();
-            marshal_test();
-            // marshal_test2();
-            create_dict_lit();
-            c4m_rich_lit_test();
-            c4m_print(c4m_box_u32((int32_t)-1));
-            c4m_print(c4m_box_i32((int32_t)-1));
-
-            test_format();
-            test_path();
-        }
-        test_compiler();
-        if (argc == 1) {
-            // C4M_STATIC_ASCII_STR(local_test, "Goodbye!");
-            // c4m_print((c4m_obj_t *)local_test);
-            c4m_print((c4m_obj_t *)c4m_new_utf8("Goodbye!"));
-            C4M_CRAISE("Except maybe not!");
+            if (!test_compiler(fname, kat)) {
+                num_errs++;
+            }
         }
     }
     C4M_EXCEPT
     {
+        no_exception = -1;
         printf("An exception was raised before exit:\n");
         c4m_print(c4m_repr_exception_stack_no_vm(c4m_new_utf8("Error: ")));
         C4M_JUMP_TO_TRY_END();
     }
     C4M_TRY_END;
-    if (argc == 1) {
-        c4m_stream_puts(serr, "This theoretically should run.\n");
-    }
 
-#ifdef STACK_SCAN_TEST
-    c4m_get_stack_scan_region(&top, &bottom);
-
-    uint64_t q = bottom - top;
-
-    // Give ourselves something to see where the real start is.
-    bottom        = 0x4141414141414141;
-    c4m_utf8_t *s = c4m_hex_dump((void *)top, q, top, 80, "");
-    c4m_stream_puts(sout, s->data);
-    c4m_stream_putc(sout, '\n');
-
-    bottom = top + q;
-    printf("(start) = %p; (end) = %p (%llu bytes)\n",
-           (void *)top,
-           (void *)bottom,
-           (unsigned long long)q);
-#endif
+    c4m_printf("Passed [em]{}[/] out of [em]{}[/] run tests.",
+               c4m_box_u64(num_tests - num_errs),
+               c4m_box_u64(num_tests));
 
     collect_and_print_stats();
+
+    if (!num_errs && !no_exception) {
+        exit(-127);
+    }
+
+    exit(num_errs * no_exception);
 }

--- a/tests/basic1.c4m
+++ b/tests/basic1.c4m
@@ -1,1 +1,8 @@
+"""
+Initial hello world test, covers basic int operators and the assert statement.
+Should not produce output.
+"""
+"""
+$output:
+"""
 assert 4 - 1 == 3

--- a/tests/basic10.c4m
+++ b/tests/basic10.c4m
@@ -1,7 +1,15 @@
+"""
+Basic test of augmented assignment.
+"""
+"""
+$output:
+45
+"""
+
 x = 0
 
 for i in 0 to 10 {
   x  += i
 }
 
-print x
+print(x)

--- a/tests/basic11.c4m
+++ b/tests/basic11.c4m
@@ -1,5 +1,14 @@
+"""
+Test of basic array item reads / writes for ints.
+"""
+"""
+$output:
+5
+[0, 1, 5, 3, 4, 5]
+"""
+
 l = [0, 1, 2, 3, 4, 5]
 l[2] = 5
 x = l[2]
-print x
-print l
+print(x)
+print(l)

--- a/tests/basic12.c4m
+++ b/tests/basic12.c4m
@@ -1,6 +1,14 @@
+"""
+Initial test of simple slices.
+"""
+"""
+$output:
+[0, 888, 4, 5]
+"""
+
 l = [0, 1, 2, 3, 4, 5]
 
 # Should result in [0, -1, 4, 5]
 l[1:4] = [888]
 
-print l
+print(l)

--- a/tests/basic13.c4m
+++ b/tests/basic13.c4m
@@ -1,14 +1,22 @@
-"Test basic unary stuff."
+"""
+Test basic unary operations.
+"""
+"""
+$output:
+100
+-100
+false
+"""
 
 x = 100
 
-print x
+print(x)
 
 if x % 2 {
-    print x
+    print(x)
 }
 else {
-    print -x
+    print(-x)
 }
 
-print not not 0 + 100 - 100
+print(not not 0 + 100 - 100)

--- a/tests/basic14.c4m
+++ b/tests/basic14.c4m
@@ -1,7 +1,28 @@
+"""
+Initial tests for native function declaration and calls.
+
+`f()` should be generic, and thus the actuals should be properly boxed
+/ unboxed.
+
+The calls to `sum1` should not be boxed, and, because it is a `once`
+function, should be properly memoized, meaning it should always return
+the same thing.
+"""
+"""
+$errors:
+def_without_use
+
+$output:
+12
+12
+7
+7
+"""
+
 m = "foo"
 
 func f(x) {
-  print x
+  print(x)
   return x // Deleting this should cause an error on the assignment.
 }
 
@@ -9,13 +30,13 @@ func f(x) {
 private once sum1(a, b, c)
 {
     var m = a + b + c + 1
-    return c
+    
+    return m 
 }
 
 y = f(12)
 
-print y
-
+print(y)
 print(sum1(1,2,3))
 # Should eventually give a warning about it being called w/
 # different arguments.

--- a/tests/basic15.c4m
+++ b/tests/basic15.c4m
@@ -1,6 +1,14 @@
+"""
+Initial test of an external function.
+"""
+"""
+$output:
+4
+"""
+
 extern c4m_clz(i64) -> i64 {
   local: clz(x: int) -> int
 }
 
-print clz(0x0fffffffffffffff)
+print(clz(0x0fffffffffffffff))
 

--- a/tests/basic16.c4m
+++ b/tests/basic16.c4m
@@ -1,7 +1,15 @@
+"""
+A more complicated FFI test, particularly testing whether
+con4m strings are properly translated.
+"""
+"""
+$output:
+Hello,
+"""
+
 extern strndup(cstring, csize_t) -> cstring {
   local: test(s: string, n: int) -> string
 }
 
 x = "Hello, world!"
-print x
-print(test(x, 4))
+print(test(x, 6))

--- a/tests/basic17.c4m
+++ b/tests/basic17.c4m
@@ -1,0 +1,13 @@
+"""
+Just print a random value; basic idea is to test proper behavior of the
+test harness if 'output' key is not provided.
+
+Also tests FFI with 0 arguments.
+"""
+"""
+"""
+extern c4m_rand() -> i64 {
+  local: random() -> int
+}
+
+print(random());

--- a/tests/basic2.c4m
+++ b/tests/basic2.c4m
@@ -1,2 +1,10 @@
+"""
+Initial test for const declaration; asm was manually inspected to make
+sure the value was pushed as an immediate, instead of being stored in
+the const pool.
+"""
+"""
+$output:
+"""
 const x = 3
 assert 4 - 1 == x

--- a/tests/basic3.c4m
+++ b/tests/basic3.c4m
@@ -1,1 +1,10 @@
-print "hello, world!"
+"""
+Initial test of basic objects. Manually checked the generated code to
+make sure the string goes in the const pool properly.
+"""
+"""
+$output: 
+hello, world!
+"""
+
+print("hello, world!")

--- a/tests/basic4.c4m
+++ b/tests/basic4.c4m
@@ -1,4 +1,13 @@
-print "hello, world!"
+"""
+Basic test for generic types; the integer should end up boxed, where
+the string should not be.
+"""
+"""
+$output:
+hello, world!
+3
+"""
+print("hello, world!")
 const x = 3
 assert 4 - 1 == x
-print x
+print(x)

--- a/tests/basic5.c4m
+++ b/tests/basic5.c4m
@@ -1,9 +1,18 @@
+"""
+Initial test of basic conditionals. Also manually inspected to make
+sure that the string constant only is added once into the constant
+pool (they should have the same offset).
+"""
+"""
+$output: 
+hello, world!
+"""
 const x = 3
 
 
 if 4 - 1 != x {
-    print "hello, world!" # Make sure both 'hello' consts have the same offset.
-    print "Con4m sucks."
+    print("hello, world!")
+    print("Con4m sucks.")
 } else {
-    print "hello, world!"
+    print("hello, world!")
 }

--- a/tests/basic6.c4m
+++ b/tests/basic6.c4m
@@ -1,23 +1,68 @@
+"""
+Basic test of ranged loops, and the magic loop variables ($i and $last).
+
+Currently, there's a bug here where the block scope of the loop index
+should be limited to loop bodies, but is not.
+
+This results in warnings, that we're currently accepting. So in the
+long term, this test will change, as it actually should not warn.
+"""
+"""
+$output: 
+5
+6
+7
+8
+9
+---
+0
+1
+2
+3
+4
+---
+5
+5
+5
+5
+5
+---
+100
+5
+100
+5
+100
+5
+100
+5
+100
+5
+
+$errors:
+shadowed_var
+shadowed_var
+shadowed_var
+"""
+
 for i in 5 to 10 {
-    print i
+    print(i)
+}
+
+print("---")
+
+for i in 5 to 10 {
+    print($i)
 }
 
 print "---"
 
 for i in 5 to 10 {
-    print $i
-}
-
-print "---"
-
-for i in 5 to 10 {
-    print $last
+    print($last)
 }
 
 print "---"
 
 for i in 100 to 105 {
-    #x = i - $i
-    print i - $i
-    print $last
+    print(i - $i)
+    print($last)
 }

--- a/tests/basic7.c4m
+++ b/tests/basic7.c4m
@@ -1,1 +1,8 @@
-print ["1", "2", "3", "four"]
+"""
+Basic test of arrays.
+"""
+"""
+$output: 
+["1", "2", "3", "four"]
+"""
+print(["1", "2", "3", "four"])

--- a/tests/basic8.c4m
+++ b/tests/basic8.c4m
@@ -1,1 +1,12 @@
-print "[h2]Hello,[/] [h5]world!"'r
+# Note that, because of the kludge for capturing output here,
+# ANSI don't currently show up in our stream.
+
+"""
+Basic test of rich string literals and literal modifiers.
+"""
+"""
+$output:
+Hello, world!
+"""
+
+print("[h2]Hello,[/] [h5]world!"'r)

--- a/tests/basic9.c4m
+++ b/tests/basic9.c4m
@@ -1,8 +1,15 @@
-x = 0
+"""
+Initial test for simple assignment.
+"""
+"""
+$output: 
+45
+"""
 
+x = 0
 
 for i in 0 to 10 {
   x  = x + i
 }
 
-print x
+print(x)

--- a/tests/docstrings.c4m
+++ b/tests/docstrings.c4m
@@ -2,8 +2,10 @@
 This is my module.
 Here is one of its two doc strings.
 """
-"Here's it's other doc."
-
+"""
+$output: 
+"""
+/*
 extern callecho(ptr) -> cvoid {
   "This has some docs too."
   
@@ -33,3 +35,4 @@ func fib(x) {
 
 x = fib(10)
 assert x == 55
+*/


### PR DESCRIPTION
When you run `dev test`, if you do not provide an argument, it assumes that it should run over the entire tests directory.

If you do provide arguments, you can provide a list of files or directories.

When you specify a directory, it will be selective about what it runs:

1. It only looks at files with a '.c4m' extension.
2. It requires there to be a test spec for the file (see below).
3. It *does* recurse provided paths.

As part of supporting this, I added:


```
c4m_file_kind c4m_get_file_kind(c4m_utf8_t *);

// The keyword args require the syntax of my kw arg implementation, 
// just wanted to express more naturally. e.g., kw("recurse", c4m_ka(true),) 

c4m_xlist_t *
c4m_path_walk(c4m_utf8_t *, bool recurse = true, bool yield_links = false,
              bool yield_dirs = false, bool ignore_special = true,
              bool follow_links = false);
```

The former returns one of these constants:
```
typedef enum {
    C4M_FK_NOT_FOUND       = 0,
    C4M_FK_IS_REG_FILE     = S_IFREG,
    C4M_FK_IS_DIR          = S_IFDIR,
    C4M_FK_IS_FLINK        = S_IFLNK,
    C4M_FK_IS_DLINK        = S_IFLNK | S_IFDIR,
    C4M_FK_IS_SOCK         = S_IFSOCK,
    C4M_FK_IS_CHR_DEVICE   = S_IFCHR,
    C4M_FK_IS_BLOCK_DEVICE = S_IFBLK,
    C4M_FK_IS_FIFO         = S_IFIFO,
    C4M_FK_OTHER           = ~0,
} c4m_file_kind;
```
Also, the harness looks for two environment variables:

1. The tremendous amount of debug info now only shows up if you have `CON4M_DEV` set (ignores value). 
2. The default search location is pulled from `CON4M_TEST_DIR` if provided.

The test specification goes in the SECOND of the two doc strings in a con4m file. If you provide an explicit file name and it does not have a second doc string, it is compiled and run, but not treated as a test case.

The test runner currently allows two possible items in the test spec (both may exist):

1. `$output:`
Matches the basic output from the builtin `print`. The builtin print is meant to be temporary while developing though; once I have kw args done in the language, I'll re-implement it. And I also will, at that point, change the runner to use my subprocess library.
2. `$errors:`
Matches against an ordered list of expected error codes.

`$errors:` is always checked, and if you leave it out, the runner assumes it should see no errors/warnings.
`$output:` is also optional; if you leave it out, the output will not be checked. Eventually I may add some pattern matching here instead. But it's good enough for now.

For tests that don't output, but that should be checked (i.e., they output error info if there's an error), you can specify `$output:` with nothing after it.

The output and the contents of each of the two spec items get stripped before comparison.

Fixes: https://github.com/crashappsec/libcon4m/issues/37