### PR TITLE
Add basic test for printing variable and list

### DIFF
--- a/tests/basic20.c4m
+++ b/tests/basic20.c4m
@@ -1,0 +1,13 @@
+"""
+Test of initializing a variable and a list, then printing both.
+"""
+"""
+$output:
+1
+[2]
+"""
+
+x = 1
+l = [2]
+print(x)
+print(l)


### PR DESCRIPTION
Add a test for

```text
x = 1
l = [2]
print(x)
print(l)
```

that as of 9e41c6cd27e400a6ffe422c1af5e320d9329330f, produces incorrect behavior locally:

```console
$ c4test ../tests/basic20.c4m
FAIL: test /foo/libcon4m/tests/basic20.c4m: output mismatch.
Expected output
1
[2]
Actual
118800407190880
[2]
```

This test is a simplification of `basic11.c4m`, to isolate the incorrect behavior there.

Refs: https://github.com/crashappsec/libcon4m/issues/41#issuecomment-2186159881