### PR TITLE
.github: add CI job for x86_64 linux + clang 18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,9 +48,11 @@ jobs:
           sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 100
           gcc --version
 
-      - name: On Linux + Clang, set CC env var
+      - name: On Linux + Clang, fix missing LLVMgold.so and set CC env var
         if: runner.os == 'Linux' && matrix.cc == 'clang'
         run: |
+          sudo apt-get update
+          sudo apt-get install llvm-18-linker-tools
           echo "CC=${{ matrix.cc }}" >> "${GITHUB_ENV}"
           clang --version
 


### PR DESCRIPTION
Just re-creating https://github.com/crashappsec/libcon4m/pull/62 against `main` with no other changes. It was already nearly mergeable, and it looks like it was closed due to base branch being deleted. But please let me know if there's a reason for us not wanting to merge this.

To-do:

- [x] If we're continuing to enable LTO in CI, fix missing `LLVMGold.so` (edit: looks like an [upstream bug](https://bugs.launchpad.net/ubuntu/+source/llvm-toolchain-18/+bug/2064187))

---

Before this PR, libcon4m CI had:

- x86_64 Linux + GCC 14 (the latest stable release)
- aarch64 macOS + clang 15

Add a CI job for x86_64 Linux + Clang 18 (the latest stable release).

This is useful to help:

- Make compiler-specific issues more obvious. At one point, https://github.com/crashappsec/libcon4m/pull/60 crashed with Linux + GCC 14 and not Linux + Clang 18.
- Get the latest diagnostics in CI.
- Enforce that upcoming libcon4m PRs build with the latest stable release of Clang. It's better for CI to fail in a PR in this repo than fail later in e.g. a PR in chalk that bumps libcon4m. Recent compiler releases are in the habit lately of erroring for common things that used to be warnings. See e.g.:
   - [chalk itself currently doesn't build with recent compiler versions](https://github.com/crashappsec/chalk/issues/290)
   - [Gentoo's guide on porting to Clang 16 and GCC 14](https://wiki.gentoo.org/wiki/Modern_C_porting)
   - [Nim's generated C code wouldn't compile with GCC 14](https://forum.nim-lang.org/t/11587)
   - [The 2024-07-03 Nim 2.0.8 release was partly to fix that](https://nim-lang.org/blog/2024/07/03/version-208-released.html)

Note that this new CI job [currently produces](https://github.com/crashappsec/libcon4m/actions/runs/9781989624/job/27007338232#step:8:172) about 2200 lines of `-Watomic-alignment` warnings, but that will be fixed by https://github.com/crashappsec/libcon4m/pull/76.

Closes: https://github.com/crashappsec/libcon4m/issues/52
Refs: https://github.com/crashappsec/libcon4m/issues/61
Refs: https://github.com/crashappsec/libcon4m/issues/63
Refs: https://github.com/crashappsec/libcon4m/issues/66
Refs: https://github.com/crashappsec/libcon4m/issues/68