### PR TITLE
meson: suppress clang's `-Watomic-alignment` warnings on x86_64

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -29,6 +29,10 @@ c_args        = ['-Wextra',
                   '-fno-omit-frame-pointer',
                   ]
 
+if (host_machine.cpu_family() == 'x86_64' and cc.get_id() == 'clang')
+  c_args    = c_args + ['-Wno-atomic-alignment']
+endif
+
 if (host_machine.system() == 'darwin')
   using_osx  = true
   link_args  = ['-target',


### PR DESCRIPTION
Running `./dev build` on x86_64 with Clang would by default (see manuals for [Clang 7][1] and [Clang 18][2]) produce about 2200 lines of -Watomic-alignment warnings, like:

```text
../src/hatrack/hash/crown.c:416:25: warning: large atomic operation may incur significant performance penalty; the access size (16 bytes) exceeds the max lock-free size (8  bytes) [-Watomic-alignment]
  416 |         record        = atomic_read(&cur->record);
      |                         ^
../include/hatrack/hatomic.h:35:24: note: expanded from macro 'atomic_read'
   35 | #define atomic_read(x) atomic_load_explicit(x, memory_order_relaxed)
      |                        ^
/usr/lib/clang/17/include/stdatomic.h:141:30: note: expanded from macro 'atomic_load_explicit'
  141 | #define atomic_load_explicit __c11_atomic_load
      |                              ^
```

But it's intentional that we use the emulation where it's not supported in hardware. Suppress those warnings.

Closes: https://github.com/crashappsec/libcon4m/issues/68

[1]: https://releases.llvm.org/7.0.0/tools/clang/docs/DiagnosticsReference.html#watomic-alignment
[2]: https://releases.llvm.org/18.1.8/tools/clang/docs/DiagnosticsReference.html#watomic-alignment