### PR TITLE
Full memory checking for GC'd heap

### DIFF
--- a/dev
+++ b/dev
@@ -184,6 +184,7 @@ case $1 in
     build)   meson_build build --buildtype=plain
              ;;
     debug)   meson_build debug --buildtype=debug
+             meson configure debug -Duse_ubsan=true -Duse_asan=true -Duse_memcheck=true
              debug_it
              ;;
     release) meson_build release --buildtype=release

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -158,7 +158,7 @@ Additionally, type names are all contextual keywords.
 The following are punctuation tokens that will eat one trailing newline:
 
 ```
-+ += - -= -> * *= / /= % %= < <= << <<= > >= >> >>= ! != , . { [ ( & &= | |= ^ ^= = :
++ += - -= -> * *= / /= % %= < <= << <<= > >= >> >>= ! != , . { [ ( & &= | |= ^ ^= = 
 ```
 
 The following punctuation tokens do NOT eat a following newline:

--- a/include/compiler/datatypes/parse.h
+++ b/include/compiler/datatypes/parse.h
@@ -137,7 +137,5 @@ typedef struct {
     //   call_resolution_t; this one is NOT pre-alloc'd for us.
     // - For breaks, continues, returns, it will hold the c4m_loop_info_t
     //   (the pnode_t not the tree node) that constitutes the jump target.
-    // -
-
-    bool have_value;
+    bool                have_value;
 } c4m_pnode_t;

--- a/include/compiler/parse.h
+++ b/include/compiler/parse.h
@@ -52,7 +52,7 @@ c4m_node_get_loc_str(c4m_tree_node_t *n)
 static inline c4m_utf8_t *
 c4m_node_list_join(c4m_list_t *nodes, c4m_str_t *joiner, bool trailing)
 {
-    int64_t      n      = c4m_list_len(nodes);
+    int64_t     n      = c4m_list_len(nodes);
     c4m_list_t *strarr = c4m_new(c4m_type_list(c4m_type_utf8()));
 
     for (int64_t i = 0; i < n; i++) {
@@ -80,15 +80,14 @@ c4m_node_simp_literal(c4m_tree_node_t *n)
     return tok->literal_value;
 }
 
-
 typedef struct c4m_pass1_ctx {
     c4m_tree_node_t      *cur_tnode;
     c4m_pnode_t          *cur;
     c4m_spec_t           *spec;
     c4m_file_compile_ctx *file_ctx;
     c4m_scope_t          *static_scope;
+    c4m_list_t           *extern_decls;
     bool                  in_func;
-    c4m_list_t          *extern_decls;
 } c4m_pass1_ctx;
 
 static inline c4m_tree_node_t *
@@ -119,6 +118,9 @@ c4m_node_down(c4m_pass1_ctx *ctx, int i)
         return false;
     }
 
+    if (n->children[i]->parent != n) {
+        c4m_print_parse_node(n->children[i]);
+    }
     assert(n->children[i]->parent == n);
     c4m_set_current_node(ctx, n->children[i]);
 

--- a/include/con4m.h
+++ b/include/con4m.h
@@ -1,7 +1,8 @@
 #pragma once
 
+// #define C4M_FULL_MEMCHECK
 // #define C4M_DEBUG
-#define C4M_GC_STATS
+// #define C4M_GC_STATS
 // #define C4M_TRACE_GC
 
 // #define C4M_GCT_MOVE        1
@@ -20,13 +21,17 @@
 
 // This won't work on systems that require aligned pointers.
 // #define C4M_PARANOID_STACK_SCAN
+// #define C4M_PARSE_DEBUG
 
 // UBSan hates our underflow check.
-#define C4M_OMIT_UNDERFLOW_CHECKS
-
+// #define C4M_OMIT_UNDERFLOW_CHECKS
 #ifdef C4M_NO_DEV_MODE
 #undef C4M_DEV
+#undef C4M_PARSE_DEBUG
 #else
+#ifdef C4M_PARSE_DEBUG
+#define C4M_DEV
+#endif
 #define C4M_DEV
 #endif
 

--- a/include/con4m/datatypes/objects.h
+++ b/include/con4m/datatypes/objects.h
@@ -64,7 +64,6 @@ typedef struct {
 struct c4m_base_obj_t {
     c4m_dt_info_t     *base_data_type;
     struct c4m_type_t *concrete_type;
-    __uint128_t        cached_hash;
     // The exposed object data.
     uint64_t           data[];
 };

--- a/include/con4m/datatypes/strings.h
+++ b/include/con4m/datatypes/strings.h
@@ -8,7 +8,9 @@
  **/
 
 #define C4M_STR_HASH_KEY_POINTER_OFFSET 0
-#define C4M_HASH_CACHE_OFFSET           (-2 * (int32_t)sizeof(uint64_t))
+#define C4M_HASH_CACHE_OBJ_OFFSET           (-4 * (int32_t)sizeof(uint64_t))
+#define C4M_HASH_CACHE_RAW_OFFSET           (-2 * (int32_t)sizeof(uint64_t))
+
 typedef struct c4m_str_t {
     char             *data;
     c4m_style_info_t *styling;

--- a/include/con4m/gc.h
+++ b/include/con4m/gc.h
@@ -334,7 +334,13 @@ void _c4m_memcheck_object(c4m_obj_t, char *, int);
 #define c4m_memcheck_object(x)
 #endif
 
-#if __has_feature(address_sanitizer) || defined(__SANITIZE_ADDRESS__)
+#if defined(__has_feature)
+#if __has_feature(address_sanitizer)
+#define __SANITIZE_ADDRESS__
+#endif
+#endif
+
+#if defined(__SANITIZE_ADDRESS__)
 void __asan_poison_memory_region(void const volatile *addr, size_t size);
 void __asan_unpoison_memory_region(void const volatile *addr, size_t size);
 

--- a/include/con4m/type.h
+++ b/include/con4m/type.h
@@ -547,7 +547,6 @@ c4m_type_is_box(c4m_type_t *t)
 static inline c4m_type_t *
 c4m_type_unbox(c4m_type_t *t)
 {
-    assert(c4m_type_is_box(t));
     return (c4m_type_t *)t->details->tsi;
 }
 

--- a/meson.build
+++ b/meson.build
@@ -62,17 +62,27 @@ if (get_option('buildtype') == 'release')
    link_args = link_args + ['-flto']
 endif
 
-
-
-if (get_option('buildtype') == 'debug')
+if (get_option('use_asan') == true)
   c_args = c_args + ['-fsanitize=address',
-                     '-fsanitize=undefined',
-                     '-fsanitize-recover=all',
+                     '-fsanitize-recover=all'
                      ]
   link_args = link_args + ['-fsanitize=address',
-                           '-fsanitize=undefined',
                            '-fsanitize-recover=all'
                            ]
+endif
+
+if (get_option('use_ubsan') == true)
+  c_args = c_args + ['-fsanitize=undefined',
+                   '-fsanitize-recover=all'
+                   ]
+endif
+
+if (get_option('use_memcheck') == true)
+  c_args = c_args + ['-DC4M_FULL_MEMCHECK']
+endif
+
+if (get_option('show_gc_stats') == true)
+  c_args = c_args + ['-DC4M_GC_STATS']
 endif
 
 
@@ -226,12 +236,14 @@ libhat = static_library('hatrack',
                         c_args : c_args,
                         link_args : link_args)
 
-# library('con4m-dll',
-#         lib_src,
-#         include_directories : incdir,
-#         dependencies : all_deps,
-#         c_args : c4m_c_args,
-#         link_args: link_args)
+if get_option('build_con4m_dll') == true
+  library('con4m-dll',
+          lib_src,
+          include_directories : incdir,
+          dependencies : all_deps,
+          c_args : c4m_c_args,
+          link_args: link_args)
+endif
 
 executable('c4test', test_src,
                       include_directories : incdir,
@@ -240,9 +252,11 @@ executable('c4test', test_src,
                       link_args : exe_link_args,
                       link_with : libc4m)
 
-# executable('hash', hash_test_src,
-#            include_directories : incdir,
-#            dependencies : all_deps,
-#            link_args : exe_link_args,
-#            link_with : libhat,
-#            c_args : exe_c_args)
+if get_option('build_hatrack') == true
+  executable('hash', hash_test_src,
+             include_directories : incdir,
+             dependencies : all_deps,
+             link_args : exe_link_args,
+             link_with : libhat,
+             c_args : exe_c_args)
+endif

--- a/meson.options
+++ b/meson.options
@@ -1,0 +1,7 @@
+option('use_asan', type: 'boolean', value: false)
+option('use_ubsan', type: 'boolean', value: false)
+option('build_hatrack', type: 'boolean', value: false)
+option('use_memcheck', type: 'boolean', value: false)
+option('build_con4m_dll', type: 'boolean', value: false)
+# Currently, if this isn't on, there's an issue.
+option('show_gc_stats', type: 'boolean', value: true)

--- a/src/con4m/compiler/cfg.c
+++ b/src/con4m/compiler/cfg.c
@@ -9,7 +9,7 @@ typedef struct {
 typedef struct {
     c4m_file_compile_ctx *file_ctx;
     c4m_dict_t           *du_info;
-    c4m_list_t          *sometimes_info;
+    c4m_list_t           *sometimes_info;
 } cfg_ctx;
 
 static c4m_symbol_t *
@@ -29,10 +29,10 @@ sym_cmp(c4m_symbol_t *sym1, c4m_symbol_t *sym2)
 }
 
 static bool
-cfg_propogate_def(cfg_ctx           *ctx,
-                  c4m_symbol_t *sym,
-                  c4m_cfg_node_t    *n,
-                  c4m_list_t       *deps)
+cfg_propogate_def(cfg_ctx        *ctx,
+                  c4m_symbol_t   *sym,
+                  c4m_cfg_node_t *n,
+                  c4m_list_t     *deps)
 {
     c4m_dict_t *du_info;
 
@@ -61,9 +61,9 @@ cfg_propogate_def(cfg_ctx           *ctx,
 }
 
 static bool
-cfg_propogate_use(cfg_ctx           *ctx,
-                  c4m_symbol_t *sym,
-                  c4m_cfg_node_t    *n)
+cfg_propogate_use(cfg_ctx        *ctx,
+                  c4m_symbol_t   *sym,
+                  c4m_cfg_node_t *n)
 {
     c4m_dict_t *du_info;
 
@@ -85,8 +85,8 @@ cfg_propogate_use(cfg_ctx           *ctx,
     new->last_def = NULL;
 
     for (unsigned int i = 0; i < x; i++) {
-        c4m_symbol_t *s   = view[i].key;
-        c4m_cfg_node_t    *cfg = view[i].value;
+        c4m_symbol_t   *s   = view[i].key;
+        c4m_cfg_node_t *cfg = view[i].value;
 
         if (!strcmp(s->name->data, sym->name->data)) {
             new->last_def = cfg;
@@ -109,7 +109,7 @@ static void
 cfg_copy_du_info(cfg_ctx        *ctx,
                  c4m_cfg_node_t *node,
                  c4m_dict_t    **new_dict,
-                 c4m_list_t   **new_sometimes)
+                 c4m_list_t    **new_sometimes)
 {
     c4m_dict_t *copy = c4m_dict(c4m_type_ref(), c4m_type_ref());
     uint64_t    n;
@@ -139,8 +139,8 @@ cfg_copy_du_info(cfg_ctx        *ctx,
         int l          = c4m_list_len(old);
         for (int i = 0; i < l; i++) {
             c4m_list_add_if_unique(*new_sometimes,
-                                    c4m_list_get(old, i, NULL),
-                                    (bool (*)(void *, void *))sym_cmp);
+                                   c4m_list_get(old, i, NULL),
+                                   (bool (*)(void *, void *))sym_cmp);
         }
     }
 }
@@ -159,15 +159,15 @@ check_for_fn_exit_errors(c4m_file_compile_ctx *file, c4m_fn_decl_t *fn_decl)
         return;
     }
 
-    c4m_scope_t       *fn_scope  = fn_decl->signature_info->fn_scope;
-    c4m_symbol_t *ressym    = c4m_symbol_lookup(fn_scope,
-                                                  NULL,
-                                                  NULL,
-                                                  NULL,
-                                                  result_text);
-    c4m_cfg_node_t    *node      = fn_decl->cfg;
-    c4m_cfg_node_t    *exit_node = node->contents.block_entrance.exit_node;
-    c4m_cfg_status_t  *status    = hatrack_dict_get(exit_node->liveness_info,
+    c4m_scope_t      *fn_scope  = fn_decl->signature_info->fn_scope;
+    c4m_symbol_t     *ressym    = c4m_symbol_lookup(fn_scope,
+                                             NULL,
+                                             NULL,
+                                             NULL,
+                                             result_text);
+    c4m_cfg_node_t   *node      = fn_decl->cfg;
+    c4m_cfg_node_t   *exit_node = node->contents.block_entrance.exit_node;
+    c4m_cfg_status_t *status    = hatrack_dict_get(exit_node->liveness_info,
                                                 ressym,
                                                 NULL);
 
@@ -235,9 +235,9 @@ check_block_for_errors(cfg_ctx *ctx, c4m_cfg_node_t *node)
     case c4m_cfg_use:
 
         if (node->use_without_def) {
-            c4m_symbol_t  *sym;
+            c4m_symbol_t       *sym;
             bool                sometimes = false;
-            c4m_symbol_t  *check;
+            c4m_symbol_t       *check;
             c4m_compile_error_t err;
 
             sym = node->contents.flow.dst_symbol;
@@ -298,10 +298,10 @@ typedef union {
 static void
 cfg_merge_aux_entries_to_top(cfg_ctx *ctx, c4m_cfg_node_t *node)
 {
-    c4m_list_t       *inbounds = node->contents.block_entrance.inbound_links;
-    c4m_cfg_node_t    *exit     = node->contents.block_entrance.exit_node;
-    c4m_dict_t        *exit_du  = exit->liveness_info;
-    c4m_symbol_t *sym;
+    c4m_list_t     *inbounds = node->contents.block_entrance.inbound_links;
+    c4m_cfg_node_t *exit     = node->contents.block_entrance.exit_node;
+    c4m_dict_t     *exit_du  = exit->liveness_info;
+    c4m_symbol_t   *sym;
 
     if (inbounds == NULL) {
         return;
@@ -373,8 +373,8 @@ cfg_merge_aux_entries_to_top(cfg_ctx *ctx, c4m_cfg_node_t *node)
     for (int i = 0; i < c4m_list_len(not_unique); i++) {
         void *item = c4m_list_get(not_unique, i, NULL);
         c4m_list_add_if_unique(exit->sometimes_live,
-                                item,
-                                (bool (*)(void *, void *))sym_cmp);
+                               item,
+                               (bool (*)(void *, void *))sym_cmp);
     }
 }
 
@@ -389,7 +389,7 @@ process_branch_exit(cfg_ctx *ctx, c4m_cfg_node_t *node)
     c4m_dict_t            *merged    = c4m_new(c4m_type_dict(c4m_type_ref(),
                                                c4m_type_ref()));
     c4m_cfg_node_t        *exit_node;
-    c4m_symbol_t     *sym;
+    c4m_symbol_t          *sym;
     hatrack_dict_item_t   *view;
     c4m_cfg_status_t      *status;
     c4m_cfg_status_t      *old_status;
@@ -399,7 +399,7 @@ process_branch_exit(cfg_ctx *ctx, c4m_cfg_node_t *node)
     for (int i = 0; i < bi->num_branches; i++) {
         exit_node = bi->branch_targets[i]->contents.block_entrance.exit_node;
 
-        c4m_dict_t  *duinfo = exit_node->liveness_info;
+        c4m_dict_t *duinfo = exit_node->liveness_info;
         c4m_list_t *stinfo = exit_node->sometimes_live;
 
         // TODO: fix this.
@@ -487,8 +487,8 @@ process_branch_exit(cfg_ctx *ctx, c4m_cfg_node_t *node)
     for (int i = 0; i < c4m_list_len(not_unique); i++) {
         void *item = c4m_list_get(not_unique, i, NULL);
         c4m_list_add_if_unique(node->sometimes_live,
-                                item,
-                                (bool (*)(void *, void *))sym_cmp);
+                               item,
+                               (bool (*)(void *, void *))sym_cmp);
     }
 }
 
@@ -652,8 +652,8 @@ cfg_process_node(cfg_ctx *ctx, c4m_cfg_node_t *node, c4m_cfg_node_t *parent)
 
         for (int i = 0; i < c4m_list_len(node->contents.flow.deps); i++) {
             c4m_symbol_t *sym = c4m_list_get(node->contents.flow.deps,
-                                                   i,
-                                                   NULL);
+                                             i,
+                                             NULL);
             cfg_propogate_use(ctx, sym, node);
         }
         cfg_process_node(ctx, node->contents.flow.next_node, node);
@@ -675,15 +675,15 @@ cfg_process_node(cfg_ctx *ctx, c4m_cfg_node_t *node, c4m_cfg_node_t *parent)
 
         for (uint64_t i = 0; i < n; i++) {
             c4m_list_add_if_unique(ta->sometimes_live,
-                                    v[i],
-                                    (bool (*)(void *, void *))sym_cmp);
+                                   v[i],
+                                   (bool (*)(void *, void *))sym_cmp);
         }
 
         c4m_list_t *old = node->sometimes_live;
         for (int64_t i = 0; i < c4m_list_len(old); i++) {
             c4m_list_add_if_unique(ta->sometimes_live,
-                                    c4m_list_get(old, i, NULL),
-                                    (bool (*)(void *, void *))sym_cmp);
+                                   c4m_list_get(old, i, NULL),
+                                   (bool (*)(void *, void *))sym_cmp);
         }
 
         return NULL;
@@ -720,7 +720,7 @@ c4m_cfg_analyze(c4m_file_compile_ctx *file_ctx, c4m_dict_t *du_info)
 
     for (uint64_t i = 0; i < nparams; i++) {
         c4m_module_param_info_t *param = view[i];
-        c4m_symbol_t       *sym   = param->linked_symbol;
+        c4m_symbol_t            *sym   = param->linked_symbol;
 
         cfg_propogate_def(&ctx, sym, NULL, NULL);
     }
@@ -735,13 +735,13 @@ c4m_cfg_analyze(c4m_file_compile_ctx *file_ctx, c4m_dict_t *du_info)
 
     c4m_cfg_node_t *modexit = file_ctx->cfg->contents.block_entrance.exit_node;
     c4m_dict_t     *moddefs = modexit->liveness_info;
-    c4m_list_t    *stdefs  = modexit->sometimes_live;
+    c4m_list_t     *stdefs  = modexit->sometimes_live;
 
     for (int i = 0; i < n; i++) {
-        ctx.du_info             = moddefs;
-        ctx.sometimes_info      = stdefs;
-        c4m_symbol_t *sym  = c4m_list_get(file_ctx->fn_def_syms, i, NULL);
-        c4m_fn_decl_t     *decl = sym->value;
+        ctx.du_info         = moddefs;
+        ctx.sometimes_info  = stdefs;
+        c4m_symbol_t  *sym  = c4m_list_get(file_ctx->fn_def_syms, i, NULL);
+        c4m_fn_decl_t *decl = sym->value;
 
         cfg_process_node(&ctx, decl->cfg, NULL);
         check_block_for_errors(&ctx, decl->cfg);
@@ -752,8 +752,8 @@ c4m_cfg_analyze(c4m_file_compile_ctx *file_ctx, c4m_dict_t *du_info)
         for (int i = 0; i < c4m_list_len(stdefs); i++) {
             void *item = c4m_list_get(stdefs, i, NULL);
             c4m_list_add_if_unique(cleanup,
-                                    item,
-                                    (bool (*)(void *, void *))sym_cmp);
+                                   item,
+                                   (bool (*)(void *, void *))sym_cmp);
         }
         modexit->sometimes_live = stdefs;
     }

--- a/src/con4m/compiler/check_pass.c
+++ b/src/con4m/compiler/check_pass.c
@@ -1172,15 +1172,18 @@ handle_if(pass2_ctx *ctx)
         handle_else(ctx, else_match);
     }
     ctx->cfg = c4m_cfg_exit_block(ctx->cfg, branch_enter, NULL);
-
     ctx->cfg = c4m_cfg_exit_block(ctx->cfg, enter, saved);
 }
 
 static bool
-range_runs_check(c4m_tree_node_t *n)
+range_runs_check(pass2_ctx *ctx, c4m_tree_node_t *n)
 {
     c4m_pnode_t *pnode1 = c4m_get_pnode(n->children[0]);
     c4m_pnode_t *pnode2 = c4m_get_pnode(n->children[1]);
+
+    if (c4m_type_is_error(get_pnode_type(n))) {
+        return false;
+    }
 
     if (!pnode1->value || !pnode2->value) {
         return false;
@@ -1409,7 +1412,7 @@ handle_for(pass2_ctx *ctx)
     // the items are constant integers and not the same, we will
     // always run the loop.
 
-    if (!li->ranged || !range_runs_check(container_node)) {
+    if (!li->ranged || !range_runs_check(ctx, container_node)) {
         bstart   = c4m_cfg_enter_block(ctx->cfg, n);
         ctx->cfg = c4m_cfg_exit_block(bstart, bstart, n);
     }

--- a/src/con4m/compiler/codegen.c
+++ b/src/con4m/compiler/codegen.c
@@ -1718,7 +1718,7 @@ gen_binary_assign(gen_ctx *ctx)
         gen_tcall(ctx, C4M_BI_INDEX_SET, ctx->cur_pnode->type);
         break;
     default:
-        // TODO: disallow slice assignments and tuple assignments here..
+        // TODO: disallow slice assignments and tuple assignments here.
         c4m_unreachable();
     }
 }

--- a/src/con4m/compiler/lex.c
+++ b/src/con4m/compiler/lex.c
@@ -1011,8 +1011,8 @@ line_comment:
             else {
             */
             TOK(c4m_tt_colon);
-            skip_optional_newline(state);
-            //            }
+            // skip_optional_newline(state);
+            //             }
             continue;
         case '=':
             if (peek(state) == '=') {

--- a/src/con4m/grid.c
+++ b/src/con4m/grid.c
@@ -57,6 +57,7 @@ styled_repeat(c4m_codepoint_t c, uint32_t width, c4m_style_t style)
 static inline c4m_utf32_t *
 get_styled_pad(uint32_t width, c4m_style_t style)
 {
+    assert(width < 200);
     return styled_repeat(' ', width, style);
 }
 
@@ -559,7 +560,7 @@ static int16_t *
 calculate_col_widths(c4m_grid_t *grid, int16_t width, int16_t *render_width)
 {
     size_t              term_width;
-    int16_t            *result = c4m_gc_array_value_alloc(uint16_t,
+    int16_t            *result = c4m_gc_array_value_alloc(uint64_t,
                                                grid->num_cols);
     int16_t             sum    = get_column_render_overhead(grid);
     c4m_render_style_t *props;
@@ -1514,7 +1515,8 @@ grid_add_cell_contents(c4m_grid_t *grid,
                                                            NULL));
             if (!c4m_str_codepoint_len(piece)) {
                 c4m_style_t pad_style = c4m_get_pad_style(grid_style(grid));
-                piece                 = get_styled_pad(col_widths[i],
+                assert(col_widths[i] < 1024);
+                piece = get_styled_pad(col_widths[i],
                                        pad_style);
             }
             c4m_list_set(lines, i, c4m_str_concat(s, piece));

--- a/src/con4m/kargs.c
+++ b/src/con4m/kargs.c
@@ -40,7 +40,6 @@ c4m_pass_kargs(int nargs, ...)
     }
 
     nargs >>= 1;
-
     c4m_karg_info_t *kargs = c4m_new(c4m_type_kargs(), nargs);
 
     for (int i = 0; i < nargs; i++) {

--- a/src/con4m/list.c
+++ b/src/con4m/list.c
@@ -555,8 +555,6 @@ c4m_list_set_slice(c4m_list_t *list,
     list->data      = (int64_t **)newdata;
     list->append_ix = start;
 
-    printf("Setting length of list to %d\n", list->length);
-
     read_end(new);
     unlock_list(list);
 }

--- a/src/con4m/object.c
+++ b/src/con4m/object.c
@@ -18,7 +18,7 @@ const c4m_dt_info_t c4m_base_type_info[C4M_NUM_BUILTIN_DTS] = {
     [C4M_T_BOOL] = {
         .name      = "bool",
         .typeid    = C4M_T_BOOL,
-        .alloc_len = 4,
+        .alloc_len = 1,
         .vtable    = &c4m_bool_type,
         .dt_kind   = C4M_DT_KIND_primitive,
         .hash_fn   = HATRACK_DICT_KEY_TYPE_INT,
@@ -424,7 +424,7 @@ _c4m_new(c4m_type_t *type, ...)
     c4m_obj_t        result;
     va_list          args;
     c4m_dt_info_t   *tinfo     = type->details->base_type;
-    uint64_t         alloc_len = tinfo->alloc_len + sizeof(c4m_obj_t);
+    uint64_t         alloc_len = tinfo->alloc_len + sizeof(c4m_base_obj_t);
     c4m_vtable_entry init_fn   = tinfo->vtable->methods[C4M_BI_CONSTRUCTOR];
 
 #if defined(C4M_GC_STATS) || defined(C4M_DEBUG)

--- a/src/con4m/set.c
+++ b/src/con4m/set.c
@@ -6,7 +6,8 @@ static void
 c4m_set_init(c4m_set_t *set, va_list args)
 {
     size_t         hash_fn;
-    c4m_type_t    *stype = c4m_get_my_type(set);
+    c4m_type_t    *stype     = c4m_get_my_type(set);
+    bool           using_obj = false;
     c4m_dt_info_t *info;
 
     if (stype != NULL) {
@@ -16,6 +17,11 @@ c4m_set_init(c4m_set_t *set, va_list args)
     }
     else {
         hash_fn = (uint32_t)va_arg(args, size_t);
+    }
+
+    if (hash_fn == HATRACK_DICT_KEY_TYPE_PTR) {
+        using_obj = true;
+        hash_fn   = HATRACK_DICT_KEY_TYPE_OBJ_PTR;
     }
 
     hatrack_set_init(set, hash_fn);
@@ -32,10 +38,17 @@ c4m_set_init(c4m_set_t *set, va_list args)
     case HATRACK_DICT_KEY_TYPE_OBJ_PTR:
     case HATRACK_DICT_KEY_TYPE_OBJ_INT:
     case HATRACK_DICT_KEY_TYPE_OBJ_REAL:
-        hatrack_set_set_cache_offset(set, C4M_HASH_CACHE_OFFSET);
+	if (using_obj) {
+	    hatrack_set_set_cache_offset(set, C4M_HASH_CACHE_OBJ_OFFSET);
+	}
+	else {
+	    hatrack_set_set_cache_offset(set, C4M_HASH_CACHE_RAW_OFFSET);
+	}
         break;
     default:
-        // nada.
+	    hatrack_set_set_cache_offset(set, C4M_HASH_CACHE_RAW_OFFSET);
+	break;
+
     }
 }
 

--- a/src/con4m/streams.c
+++ b/src/con4m/streams.c
@@ -492,6 +492,7 @@ void
 c4m_stream_write_object(c4m_stream_t *stream, c4m_obj_t obj, bool ansi)
 {
     if (stream->flags & C4M_F_STREAM_CLOSED) {
+        abort();
         C4M_CRAISE("Stream is already closed.");
     }
 

--- a/src/con4m/string.c
+++ b/src/con4m/string.c
@@ -1,16 +1,5 @@
 #include "con4m.h"
 
-// The object header has 4 words that we don't need to scan (there is
-// a heap pointer in there, but it points to something definitely
-// always available from the roots).
-//
-// Our pointer shows in our second word. Therefore, the 6th most
-// significant bit gets set here.
-const uint64_t c4m_pmap_str[2] = {
-    0x0000000000000001,
-    0x0400000000000000,
-};
-
 C4M_STATIC_ASCII_STR(c4m_empty_string_const, "");
 C4M_STATIC_ASCII_STR(c4m_newline_const, "\n");
 C4M_STATIC_ASCII_STR(c4m_crlf_const, "\r\n");
@@ -434,8 +423,9 @@ c4m_to_utf8(const c4m_utf32_t *inp)
     // Allocates 4 bytes per codepoint; this is an overestimate in
     // cases where UTF8 codepoints are above U+00ff. But nbd.
 
-    c4m_utf8_t      *res    = c4m_new(c4m_type_utf8(),
+    c4m_utf8_t *res = c4m_new(c4m_type_utf8(),
                               c4m_kw("length", c4m_ka(inp->byte_len)));
+
     c4m_codepoint_t *p      = (c4m_codepoint_t *)inp->data;
     uint8_t         *outloc = (uint8_t *)res->data;
     int              l;
@@ -694,6 +684,7 @@ c4m_utf8_repeat(c4m_codepoint_t cp, int64_t num)
     char       *p      = res->data;
 
     res->codepoints = l;
+    res->byte_len   = blen;
 
     for (int i = 0; i < blen; i++) {
         p[i] = buf[buf_ix++];

--- a/src/con4m/tree.c
+++ b/src/con4m/tree.c
@@ -175,7 +175,7 @@ c4m_tree_str_transform(c4m_tree_node_t *t, c4m_str_t *(*fn)(void *))
         return NULL;
     }
 
-    c4m_str_t       *str    = fn(c4m_tree_get_contents(t));
+    c4m_str_t       *str    = c4m_to_utf8(fn(c4m_tree_get_contents(t)));
     c4m_tree_node_t *result = c4m_new(c4m_type_tree(c4m_type_utf8()),
                                       c4m_kw("contents", c4m_ka(str)));
 

--- a/src/con4m/types.c
+++ b/src/con4m/types.c
@@ -1664,16 +1664,19 @@ c4m_initialize_global_types()
 
         c4m_base_obj_t *envstore;
         // This needs to not be c4m_new'd.
-        c4m_type_universe        = c4m_gc_raw_alloc(sizeof(c4m_type_universe_t),
-                                             C4M_GC_SCAN_ALL);
-        envstore                 = c4m_gc_alloc(c4m_dict_t);
-        c4m_dict_t *store        = (c4m_dict_t *)envstore->data;
+        // clang-format off
+        c4m_type_universe = c4m_gc_raw_alloc(sizeof(c4m_type_universe_t),
+					     C4M_GC_SCAN_ALL);
+        envstore          = c4m_gc_raw_alloc(sizeof(c4m_dict_t) +
+					     sizeof(c4m_base_obj_t),
+					     C4M_GC_SCAN_ALL);
+        // clang-format on
+        c4m_dict_t     *store    = (c4m_dict_t *)envstore->data;
         c4m_type_universe->store = store;
-
         // We don't set the heading info up fully, so this dict
         // won't be directly marshalable unless / until we do.
         hatrack_dict_init(store, HATRACK_DICT_KEY_TYPE_INT);
-
+        c4m_memcheck_object(store);
         // Set up the type we need internally for containers.
 
         tobj = c4m_gc_raw_alloc(tslen, c4m_type_set_gc_bits);

--- a/src/con4m/vm.c
+++ b/src/con4m/vm.c
@@ -1634,7 +1634,7 @@ c4m_vm_reset(c4m_vm_t *vm)
                                              NULL);
 
         vm->module_allocations[n] = c4m_gc_array_alloc(c4m_value_t,
-                                                       m->module_var_size);
+                                                       m->module_var_size + 8);
     }
 
     vm->attrs        = c4m_new(c4m_type_dict(c4m_type_utf8(),

--- a/src/hatrack/hash/crown-internal.h
+++ b/src/hatrack/hash/crown-internal.h
@@ -10,7 +10,7 @@ typedef uint32_t hop_t;
 
 #else
 
-#define CROWN_HOME_BIT 0x8000000000000000
+#define CROWN_HOME_BIT 0x8000000000000000ULL
 
 typedef uint64_t hop_t;
 
@@ -19,10 +19,10 @@ typedef uint64_t hop_t;
 #endif
 
 enum64(crown_flag_t,
-       CROWN_F_MOVING   = 0x8000000000000000,
-       CROWN_F_MOVED    = 0x4000000000000000,
-       CROWN_F_INITED   = 0x2000000000000000,
-       CROWN_EPOCH_MASK = 0x1fffffffffffffff);
+       CROWN_F_MOVING   = 0x8000000000000000ULL,
+       CROWN_F_MOVED    = 0x4000000000000000ULL,
+       CROWN_F_INITED   = 0x2000000000000000ULL,
+       CROWN_EPOCH_MASK = 0x1fffffffffffffffULL);
 
 /* These need to be non-static because tophat and hatrack_dict both
  * need them, so that they can call in without a second call to

--- a/src/hatrack/hash/crown.c
+++ b/src/hatrack/hash/crown.c
@@ -546,6 +546,23 @@ crown_store_new(uint64_t size)
     return store;
 }
 
+#if defined(__clang__)
+/* UBScan can sometimes complain about the line:
+ * bit_to_set = CROWN_HOME_BIT >> i;
+ *
+ * This will happen in more full tables.  However, this is a
+ * non-issue.
+ *
+ * Yes, when we get to the end of the cache, we do shift right by
+ * 64, and they're right that it's technically undefined. But
+ * until we find a platform where that doesn't result in 0, I
+ * would much rather avoid adding the extra test; this has the
+ * desired effect of setting `map` to 0 when we're done checking
+ * all bits of the cache, at which point we fall back to full
+ * linear probes.
+ */
+__attribute__((no_sanitize("all")))
+#endif
 void *
 crown_store_get(crown_store_t *self, hatrack_hash_t hv1, bool *found)
 {
@@ -709,6 +726,10 @@ not_found:
  *  would be fine if you know your table is going to be sparsely
  *  populated.
  */
+#if defined(__clang__)
+// See the comment on crown_store_get.
+__attribute__((no_sanitize("all")))
+#endif
 void *
 crown_store_put(crown_store_t *self,
                 mmm_thread_t  *thread,
@@ -890,6 +911,10 @@ found_bucket:
     return item;
 }
 
+#if defined(__clang__)
+// See the comment on crown_store_get.
+__attribute__((no_sanitize("all")))
+#endif
 void *
 crown_store_replace(crown_store_t *self,
                     mmm_thread_t  *thread,
@@ -1012,6 +1037,10 @@ migrate_and_retry:
  * The bucket logic implementation is basically identical. Please
  * see above for exposition.
  */
+#if defined(__clang__)
+// See the comment on crown_store_get.
+__attribute__((no_sanitize("all")))
+#endif
 bool
 crown_store_add(crown_store_t *self,
                 mmm_thread_t  *thread,
@@ -1153,6 +1182,10 @@ found_bucket:
  * result, the bucket acquisition logic is the same as with replace,
  * and effectively identical to "get".  Please see above for details.
  */
+#if defined(__clang__)
+// See the comment on crown_store_get.
+__attribute__((no_sanitize("all")))
+#endif
 void *
 crown_store_remove(crown_store_t *self,
                    mmm_thread_t  *thread,
@@ -1284,6 +1317,10 @@ migrate_and_retry:
  * ALL threads that write to the new store during migration will be
  * trying to write the exact same things in the exact same order.
  */
+#if defined(__clang__)
+// See the comment on crown_store_get.
+__attribute__((no_sanitize("all")))
+#endif
 static crown_store_t *
 crown_store_migrate(crown_store_t *self, mmm_thread_t *thread, crown_t *top)
 {

--- a/tests/shr.c4m
+++ b/tests/shr.c4m
@@ -1,0 +1,10 @@
+"""
+Make sure shift right on a signed integer works as expected.
+"""
+"""
+$output:
+-1
+"""
+x = -1
+x >>= 0
+print(x)

--- a/tests/typeof.c4m
+++ b/tests/typeof.c4m
@@ -1,4 +1,5 @@
 global x: `t
+y = 14
 
 typeof x {
     case int:
@@ -14,3 +15,4 @@ typeof x {
         y = -1
   }
 z = false
+print(y)

--- a/tests/valueof.c4m
+++ b/tests/valueof.c4m
@@ -9,6 +9,5 @@ func fib(x) {
   }
 }
 
-x = fib(10)
-assert x == 55
-assert repr(x) == "55"
+print(fib(10))
+


### PR DESCRIPTION
1. I added explicit support for ASAN poisoning, but it was not partic…ularly valuable in any way, so I:
2. Added a tremendous amount of heap checking.
4. I used this to find and fix:

Hash value caching moved from the con4m object header into the alloc header. This way, any GC'd pointer will have its hash value cached. Not doing it that way was an oversight. And, as a result, occasionally something would be in a dict or set, but the hash value was based on its OLD pointer value, so a collection would give the same value a new hash. Not many things like this are used as keys right now, but one was the module worklist at the top level, so if a collect happened at the wrong time, you could end up in an infinite loop, because some module was never going to get removed from the set (but could always be retrieved from it). To test this out, I lowered the starting heap size all the way down to 1K to try to trigger the problem as much as possible (tho the heap doubles in size if, after the previous collect, there's deemed not sufficient space). Amazingly it didn't slow things down.

Heap checking (enabled in debug builds) includes:

1. Full sweep of the heap after collection looking for garbage that might not be garbage.
2. Guards AFTER each allocation (already existed before).
3. Checking of guards during collections.
4. A ring buffer of recent allocs; guards are checked after each allocation for anything in the ring buffer.

Also along the way:
- Don't exit the longjmp context before throwing an error....
- Get parsing working on switch statements again; next get need to fix the code gen (codegen still not done; coming next).
- Use __builtin_frame_address(0) instead of a local variable.
- Setup initial con4m-specific meson options

Closes #71 