### PR TITLE
Switch statement code generation

### DIFF
--- a/dev
+++ b/dev
@@ -158,7 +158,7 @@ function libcon4m_run_tests {
 }
 
 function libcon4m_dev_clean {
-    for item in build debug release cicd .meson_last; do
+    for item in build debug release cicd; do
         if [[ -d ${item} ]]; then
             log Cleaning ${item}
             cd ${item}
@@ -166,6 +166,11 @@ function libcon4m_dev_clean {
             cd ..
         fi
     done
+
+    if [[ -f .meson_last ]]; then
+        rm .meson_last
+    fi
+
     log "Done!"
 }
 

--- a/include/compiler/datatypes/nodeinfo.h
+++ b/include/compiler/datatypes/nodeinfo.h
@@ -20,6 +20,7 @@ typedef struct {
 } c4m_control_info_t;
 
 typedef struct {
+    c4m_control_info_t branch_info;
     // switch() and typeof() can be labeled, but do not have automatic
     // variables, so they don't ever get renamed. That's why `label`
     // lives inside of branch_info, but the rest of this is in the
@@ -39,7 +40,6 @@ typedef struct {
     c4m_symbol_t      *lvar_2;
     c4m_symbol_t      *shadowed_lvar_1;
     c4m_symbol_t      *shadowed_lvar_2;
-    c4m_control_info_t branch_info;
     bool               ranged;
     unsigned int       gen_ix       : 1;
     unsigned int       gen_named_ix : 1;

--- a/include/con4m/datatypes/vm.h
+++ b/include/con4m/datatypes/vm.h
@@ -212,20 +212,24 @@ typedef enum : uint8_t {
     // Unused; will redo when adding objects.
     C4M_ZSObjNew       = 0x38,
     // Box a literal, which requires supplying the type for the object.
-    C4M_ZBox           = 0x40,
+    C4M_ZBox           = 0x3e,
     // Unbox a value literal into its actual value.
-    C4M_ZUnbox         = 0x41,
+    C4M_ZUnbox         = 0x3f,
     // Compare (and pop) two types to see if they're comptable.
-    C4M_ZTypeCmp       = 0x42,
+    C4M_ZTypeCmp       = 0x40,
     // Compare (and pop) two values to see if they're equal. Note that
     // this is not the same as checking for object equality; this assumes
     // primitive type or reference.
-    C4M_ZCmp           = 0x43,
-    C4M_ZLt            = 0x44,
-    C4M_ZLte           = 0x45,
+    C4M_ZCmp           = 0x41,
+    C4M_ZLt            = 0x42,
+    C4M_ZULt           = 0x43,
+    C4M_ZLte           = 0x44,
+    C4M_ZULte          = 0x45,
     C4M_ZGt            = 0x46,
-    C4M_ZGte           = 0x47,
-    C4M_ZNeq           = 0x48,
+    C4M_ZUGt           = 0x47,
+    C4M_ZGte           = 0x48,
+    C4M_ZUGte          = 0x49,
+    C4M_ZNeq           = 0x4A,
     // Do a GTE comparison without popping.
     C4M_ZGteNoPop      = 0x4D,
     // Do an equality comparison without popping.
@@ -259,23 +263,42 @@ typedef enum : uint8_t {
     // Exits the current call frame, returning the current state back to the
     // originating location, which is the instruction immediately following the
     // C4M_Z0Call instruction that created this frame.
-    C4M_ZRet           = 0x80,
+    C4M_ZRet           = 0x60,
     // Exits the current stack frame, returning the current state back to the
     // originating location, which is the instruction immediately following the
     // C4M_ZCallModule instruction that created this frame.
-    C4M_ZModuleRet     = 0x81,
+    C4M_ZModuleRet     = 0x61,
     // Halt the current program immediately.
-    C4M_ZHalt          = 0x82,
+    C4M_ZHalt          = 0x62,
     // Initialze module parameters. The number of parameters is encoded in the
     // instruction's arg field. This is only used during module initialization.
-    C4M_ZModuleEnter   = 0x83,
+    C4M_ZModuleEnter   = 0x63,
     // Adjust the stack pointer down by the amount encoded in the instruction's
     // arg field. This means specifically that the arg field is subtracted from
     // sp, so a single pop would encode -1 as the adjustment.
-    C4M_ZMoveSp        = 0x85,
+    C4M_ZMoveSp        = 0x65,
     // Test the top stack value. If it is non-zero, pop it and continue running
     // the program. Otherwise, print an assertion failure and stop running the
     // program.
+    // Math operations have signed and unsigned variants. We can go from
+    // signed to unsigned where it makes sense by adding 0x10.
+    // Currently, we do not do this for bit ops, they are just all unsigned.
+    C4M_ZAdd           = 0x70,
+    C4M_ZSub           = 0x71,
+    C4M_ZMul           = 0x72,
+    C4M_ZDiv           = 0x73,
+    C4M_ZMod           = 0x74,
+    C4M_ZBXOr          = 0x75,
+    C4M_ZShl           = 0x76,
+    C4M_ZShr           = 0x77,
+    C4M_ZBOr           = 0x78,
+    C4M_ZBAnd          = 0x79,
+    C4M_ZBNot          = 0x7A,
+    C4M_ZUAdd          = 0x80, // Same as ZAdd
+    C4M_ZUSub          = 0x81, // Same as ZSub
+    C4M_ZUMul          = 0x82,
+    C4M_ZUDiv          = 0x83,
+    C4M_ZUMod          = 0x84,
     C4M_ZAssert        = 0xA0,
     // Set the specified attribute to be "lock on write". Triggers an error if
     // the attribute is already set to lock on write. This instruction expects
@@ -292,25 +315,6 @@ typedef enum : uint8_t {
     // pop, the left operand will get replaced without additional
     // movement.
     //
-    // Math operations have signed and unsigned variants. We can go from
-    // signed to unsigned where it makes sense by adding 0x10.
-    // Currently, we do not do this for bit ops, they are just all unsigned.
-    C4M_ZAdd           = 0xC0,
-    C4M_ZSub           = 0xC1,
-    C4M_ZMul           = 0xC2,
-    C4M_ZDiv           = 0xC3,
-    C4M_ZMod           = 0xC4,
-    C4M_ZBXOr          = 0xC5,
-    C4M_ZShl           = 0xC6,
-    C4M_ZShr           = 0xC7,
-    C4M_ZBOr           = 0xC8,
-    C4M_ZBAnd          = 0xC9,
-    C4M_ZBNot          = 0xCA,
-    C4M_ZUAdd          = 0xD0,
-    C4M_ZUSub          = 0xD1,
-    C4M_ZUMul          = 0xD2,
-    C4M_ZUDiv          = 0xD3,
-    C4M_ZUMod          = 0xD4,
     // Perform a logical not operation on the top stack value. If the value is
     // zero, it will be replaced with a one value of the same type. If the value
     // is non-zero, it will be replaced with a zero value of the same type.

--- a/include/con4m/string.h
+++ b/include/con4m/string.h
@@ -30,6 +30,7 @@ extern bool                c4m_str_starts_with(const c4m_str_t *,
                                                const c4m_str_t *);
 extern bool                c4m_str_ends_with(const c4m_str_t *,
                                              const c4m_str_t *);
+extern c4m_list_t         *c4m_str_wrap(const c4m_str_t *, int64_t, int64_t);
 
 #define c4m_str_split(x, y) c4m_str_xsplit(x, y)
 // This is in richlit.c

--- a/src/con4m/collect.c
+++ b/src/con4m/collect.c
@@ -734,8 +734,8 @@ c4m_alloc_display_front_guard_error(c4m_alloc_hdr *hdr,
             "Alloc location: %s:%d\n\n",
             name_alloc(hdr),
             ptr,
-            c4m_gc_guard,
-            hdr->guard,
+            (long long unsigned)c4m_gc_guard,
+            (long long unsigned)hdr->guard,
             file ? file : hdr->alloc_file,
             file ? line : hdr->alloc_line);
 
@@ -766,8 +766,8 @@ c4m_alloc_display_rear_guard_error(c4m_alloc_hdr *hdr,
             ptr,
             len,
             rear_guard_loc,
-            c4m_end_guard,
-            *(uint64_t *)rear_guard_loc,
+            (long long unsigned int)c4m_end_guard,
+            (long long unsigned int)*(uint64_t *)rear_guard_loc,
             file ? file : hdr->alloc_file,
             file ? line : hdr->alloc_line);
 
@@ -833,9 +833,6 @@ memcheck_validate_old_records(c4m_arena_t *from_space)
                 }
                 p++;
             }
-        }
-        if (free) {
-            c4m_rc_free(a);
         }
         a = next;
     }

--- a/src/con4m/compiler/cfg.c
+++ b/src/con4m/compiler/cfg.c
@@ -669,6 +669,9 @@ cfg_process_node(cfg_ctx *ctx, c4m_cfg_node_t *node, c4m_cfg_node_t *parent)
         void          **v  = hatrack_dict_keys_sort(node->liveness_info,
                                           &n);
 
+        if (!ta) {
+            return NULL;
+        }
         if (!ta->sometimes_live) {
             ta->sometimes_live = c4m_new(c4m_type_list(c4m_type_ref()));
         }

--- a/src/con4m/compiler/check_pass.c
+++ b/src/con4m/compiler/check_pass.c
@@ -931,8 +931,9 @@ handle_break(pass2_ctx *ctx)
         c4m_control_info_t *bi = &li->branch_info;
 
         if (!label || (bi->label && !strcmp(label->data, bi->label->data))) {
-            c4m_pnode_t     *npnode      = c4m_get_pnode(n);
-            c4m_jump_info_t *ji          = npnode->extra_info;
+            c4m_pnode_t     *npnode = c4m_get_pnode(n);
+            c4m_jump_info_t *ji     = npnode->extra_info;
+            assert(bi);
             ji->linked_control_structure = bi;
             return;
         }
@@ -1750,9 +1751,12 @@ handle_switch_statement(pass2_ctx *ctx)
     c4m_pnode_t        *pnode        = c4m_get_pnode(saved);
     c4m_control_info_t *bi           = control_init(pnode->extra_info);
     c4m_list_t         *branches     = use_pattern(ctx, c4m_case_branches);
-    c4m_tree_node_t    *elsenode     = c4m_get_match_on_node(saved, c4m_case_else);
-    c4m_tree_node_t    *variant_node = c4m_get_match_on_node(saved, c4m_case_cond);
-    c4m_tree_node_t    *label        = c4m_get_match_on_node(saved, c4m_opt_label);
+    c4m_tree_node_t    *elsenode     = c4m_get_match_on_node(saved,
+                                                      c4m_case_else);
+    c4m_tree_node_t    *variant_node = c4m_get_match_on_node(saved,
+                                                          c4m_case_cond);
+    c4m_tree_node_t    *label        = c4m_get_match_on_node(saved,
+                                                   c4m_opt_label);
     int                 ncases       = c4m_list_len(branches);
     c4m_cfg_node_t     *entrance;
     c4m_cfg_node_t     *cfgbranch;

--- a/src/con4m/compiler/disasm.c
+++ b/src/con4m/compiler/disasm.c
@@ -220,6 +220,18 @@ const inst_info_t inst_info[256] = {
     [C4M_ZGte] = {
         .name = "ZGte",
     },
+    [C4M_ZULt] = {
+        .name = "ZULt",
+    },
+    [C4M_ZULte] = {
+        .name = "ZULte",
+    },
+    [C4M_ZUGt] = {
+        .name = "ZUGt",
+    },
+    [C4M_ZUGte] = {
+        .name = "ZGteU",
+    },
     [C4M_ZNeq] = {
         .name = "ZNeq",
     },

--- a/src/con4m/compiler/parse.c
+++ b/src/con4m/compiler/parse.c
@@ -3085,6 +3085,7 @@ assign(parse_ctx *ctx, c4m_tree_node_t *lhs, c4m_node_kind_t kind)
     adopt_kid(ctx, lhs);
     adopt_kid(ctx, expression(ctx));
     result = restore_tree(ctx);
+    end_of_statement(ctx);
 
     return result;
 }
@@ -3242,11 +3243,12 @@ expression_start(parse_ctx *ctx)
     switch (tok_kind(ctx)) {
     case c4m_tt_plus:
         consume(ctx);
+        return lt_expr_rhs(ctx);
         return NULL;
     case c4m_tt_minus:
         temporary_tree(ctx, c4m_nt_unary_op);
         consume(ctx);
-        adopt_kid(ctx, expression(ctx));
+        adopt_kid(ctx, minus_expr_rhs(ctx));
         return restore_tree(ctx);
     case c4m_tt_not:
         // Here the LHS is an empty string. For TtNot, if there is a LHS,
@@ -3848,7 +3850,7 @@ section(parse_ctx *ctx, c4m_tree_node_t *node)
     if (lhs->kind != c4m_nt_expression || !c4m_tree_get_number_children(node)) {
 bad_start:
         raise_err_at_node(ctx,
-                          current_parse_node(ctx),
+                          c4m_tree_get_contents(node),
                           c4m_err_parse_unexpected_after_expr,
                           false);
     }

--- a/src/con4m/format.c
+++ b/src/con4m/format.c
@@ -508,6 +508,10 @@ assemble_formatted_result(const c4m_str_t *fmt, c4m_list_t *arg_strings)
 
             i++; // Skip the } too.
             continue;
+        case '\0':
+            outp[out_ix] = 0;
+            style_adjustment(result, out_ix + 1, -1);
+            continue;
         default:
             outp[out_ix++] = fmtp[i];
             continue;

--- a/src/con4m/grid.c
+++ b/src/con4m/grid.c
@@ -905,8 +905,6 @@ render_to_cache(c4m_grid_t       *grid,
                 int16_t           width,
                 int16_t           height)
 {
-    assert(cell->raw_item != NULL);
-
     switch (c4m_base_type(cell->raw_item)) {
     case C4M_T_UTF8:
     case C4M_T_UTF32: {
@@ -1514,7 +1512,9 @@ grid_add_cell_contents(c4m_grid_t *grid,
                                                            NULL));
             if (!c4m_str_codepoint_len(piece)) {
                 c4m_style_t pad_style = c4m_get_pad_style(grid_style(grid));
-                assert(col_widths[i] < 1024);
+                if (col_widths[i] < 0) {
+                    col_widths[i] = 0;
+                }
                 piece = get_styled_pad(col_widths[i],
                                        pad_style);
             }

--- a/src/tests/test.c
+++ b/src/tests/test.c
@@ -15,14 +15,15 @@ static void
 err_basic_usage(c4m_utf8_t *fname)
 {
     c4m_printf(
-        "[red]error:[/][em]{}[/]: Bad test case format. The second doc "
+        "[red]error:[/][em]{}[/]:\nBad test case format. The second doc "
         "string may have 0 or 1 [em]$output[/] sections and 0 or 1 "
         "[em]$errors[/] sections ONLY. If neither are provided, "
         "then the harness expects no errors and ignores output. "
-        "There may be nothing else in the doc string except whitespace.\n"
-        "\n[i]Note: If you want to explicitly test for no output, then "
-        "provide `$output:` with nothing following.",
+        "There may be nothing else in the doc string except whitespace.",
         fname);
+    c4m_printf(
+        "\n[i inv]Note: If you want to explicitly test for no output, then "
+        "provide `$output:` with nothing following.\n");
 }
 
 static void

--- a/tests/break.c4m
+++ b/tests/break.c4m
@@ -1,0 +1,24 @@
+"""
+Just making sure the break statement finds its outer label just fine
+(since it isn't when there's an encompassing switch at the moment).
+"""
+"""
+$output:
+100
+"""
+
+i = 0
+
+foo:
+  while (true) {
+
+    while (true) {
+       if i == 100 {
+         break foo;
+       }
+
+      i += 1
+   }
+}
+
+print(i)

--- a/tests/fib-switch.c4m
+++ b/tests/fib-switch.c4m
@@ -1,7 +1,14 @@
+"""
+Basic switch test using fib()
+"""
+"""
+5
+"""
+
 func fib(x) {
   switch x {
     case 0:
-        return 0
+        return 1
     case 1:
         return 1
     else:
@@ -9,5 +16,6 @@ func fib(x) {
   }
 }
 
-print(fib(10))
+y = fib(4)
+print(y)
 

--- a/tests/fib.c4m
+++ b/tests/fib.c4m
@@ -21,9 +21,4 @@ if m == 1 {
     return -1;
   }
 }
-
-func foo(x) {
-  x + x
-}
-
 print(n(18))

--- a/tests/fn.c4m
+++ b/tests/fn.c4m
@@ -1,0 +1,26 @@
+"""
+Addded both to ensure functionality of switch statements, and
+to test precedence of unary plus / minus.
+"""
+"""
+$output:
+-4
+4
+"""
+func count(x)
+{
+  switch (x) {
+    case 0:
+        return 0
+    case 1:
+        return 1
+    else:
+      if (x > 0) {
+        return +1 + count(x - 1)
+      }
+      return -1 + count(x + 1)
+  }
+}
+
+print(count(-4))
+print(count(4))

--- a/tests/switch.c4m
+++ b/tests/switch.c4m
@@ -1,33 +1,45 @@
-a = 1
+"""
+Test of more advances switch features.
+"""
+"""
+
+12
+12
+3
+106
+6
+-1
+"""
+
+a = 12
 b = 2
 c = 3
 
-x = 12
-
-foo:
-switch x {
-    case a, 12, 13, 15 : 20, 11:
-    y = 12
-    for m in 0 to 10 {
-       if m == 2 {
-          continue
-       }
-       else {
-       x += x
-       }
-       y += x
-    }
-    if (y > 16) {
-       break
-    }
-
-    case b:
-       y = 1 + x
-    case c:
-       y = x + 100 + x
-    else:
-        y = -1
-        z = 2
+func test(x) {
+  foo:
+  switch x {
+      case a, 11, 13, 15 : 20, 11:
+         y = 12
+      case b:
+         y = 1 + x
+      case c:
+         y = x + 100 + x
+      else:
+         if (x < 100) {
+             y = 6
+             break foo
+         }
+         y = -1
   }
+
+  return y
+}
       
-       y += x
+
+
+print(test(12))
+print(test(16))
+print(test(2)) 
+print(test(3)) 
+print(test(4)) 
+print(test(106))


### PR DESCRIPTION
Code generation is done for switch statements, including multiple conditions in a case, and ranges in a case.

I also changed the default semantics around print() to wrap strings to the terminal width by default, but to truncate grids to the width.  As part of that, I did fix format() to not write nulls in a string; we were ignoring them, but when debugging trying to look at the raw c string wasn't always fun.

Some more test cases added; as part of doing them, I realized I had forgotten to do unsigned comparison operators, so fixed that as well.