### PR TITLE
meson: add `-fno-sanitize=function` to suppress some UBSan errors

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -73,6 +73,7 @@ endif
 
 if (get_option('use_ubsan') == true)
   c_args = c_args + ['-fsanitize=undefined',
+                     '-fno-sanitize=function',
                      '-fsanitize-recover=all'
                     ]
 link_args = link_args + ['-fsanitize=undefined',


### PR DESCRIPTION
Since Clang 17, the `-fsanitize=function` check is no longer only for C++, and the check is enabled by default by `-fsanitize=undefined`. See the [list of available UBSan checks][1].

The [discussion of the relevant LLVM patch][2] contains:

>The rationale for reporting errors is C11 6.5.2.2p9:
>
>If the function is defined with a type that is not compatible with the type (of the expression) pointed to by the expression that denotes the called function, the behavior is undefined.

Suppress these UBSan errors:

```text
src/hatrack/hash/dict.c:667:16: runtime error: call to function c4m_custom_string_hash through pointer to incorrect function type '__int128 (*)(void *)'
/home/runner/work/libcon4m/src/con4m/dict.c:22: note: c4m_custom_string_hash defined here

src/hatrack/hash/set.c:890:16: runtime error: call to function c4m_custom_string_hash through pointer to incorrect function type '__int128 (*)(void *)'
/home/runner/work/libcon4m/src/con4m/dict.c:22: note: c4m_custom_string_hash defined here

src/con4m/box.c:46:12: runtime error: call to function u64_fmt through pointer to incorrect function type 'struct c4m_str_t *(*)(void *, struct c4m_fmt_spec_t *)'
/home/runner/work/libcon4m/src/con4m/numbers.c:690: note: u64_fmt defined here

src/con4m/collect.c:174:13: runtime error: call to function c4m_finalize_allocation through pointer to incorrect function type 'void (*)(void *)'
/home/runner/work/libcon4m/src/con4m/object.c:909: note: c4m_finalize_allocation defined here

src/con4m/format.c:391:29: runtime error: call to function c4m_string_format through pointer to incorrect function type 'struct c4m_str_t *(*)(void *, struct c4m_fmt_spec_t *)'
/home/runner/work/libcon4m/src/con4m/string.c:1347: note: c4m_string_format defined here

src/con4m/list.c:153:13: runtime error: call to function sym_cmp through pointer to incorrect function type 'bool (*)(void *, void *)'
/home/runner/work/libcon4m/src/con4m/compiler/cfg.c:27: note: sym_cmp defined here

src/con4m/marshal.c:269:5: runtime error: call to function c4m_string_marshal through pointer to incorrect function type 'void (*)(void *, c4m_stream_t *, struct hatrack_dict_t *, long *)'
/home/runner/work/libcon4m/src/con4m/string.c:1158: note: c4m_string_marshal defined here

src/con4m/marshal.c:352:5: runtime error: call to function c4m_string_unmarshal through pointer to incorrect function type 'void (*)(void *, c4m_stream_t *, struct hatrack_dict_t *)'
/home/runner/work/libcon4m/src/con4m/string.c:1180: note: c4m_string_unmarshal defined here

src/con4m/object.c:471:13: runtime error: call to function c4m_sha_init through pointer to incorrect function type 'void (*)(void **, struct __va_list_tag *)'
/home/runner/work/libcon4m/src/con4m/crypto/sha.c:30: note: c4m_sha_init defined here

src/con4m/object.c:500:12: runtime error: call to function signed_repr through pointer to incorrect function type 'struct c4m_str_t *(*)(void *)'
/home/runner/work/libcon4m/src/con4m/numbers.c:22: note: signed_repr defined here

src/con4m/object.c:551:12: runtime error: call to function box_repr through pointer to incorrect function type 'struct c4m_str_t *(*)(void *)'
/home/runner/work/libcon4m/src/con4m/box.c:13: note: box_repr defined here

src/con4m/object.c:563:12: runtime error: call to function c4m_list_copy through pointer to incorrect function type 'void *(*)(void *)'
/home/runner/work/libcon4m/src/con4m/list.c:392: note: c4m_list_copy defined here

src/con4m/object.c:579:12: runtime error: call to function c4m_str_copy through pointer to incorrect function type 'void *(*)(void *)'
/home/runner/work/libcon4m/src/con4m/string.c:263: note: c4m_str_copy defined here

src/con4m/object.c:655:12: runtime error: call to function c4m_list_len through pointer to incorrect function type 'long (*)(void *)'
/home/runner/work/libcon4m/src/con4m/list.c:297: note: c4m_list_len defined here

src/con4m/object.c:669:12: runtime error: call to function c4m_list_safe_get through pointer to incorrect function type 'void *(*)(void *, void *)'
/home/runner/work/libcon4m/src/con4m/list.c:430: note: c4m_list_safe_get defined here

src/con4m/object.c:683:5: runtime error: call to function c4m_list_set through pointer to incorrect function type 'void (*)(void *, void *, void *)'
/home/runner/work/libcon4m/src/con4m/list.c:63: note: c4m_list_set defined here

src/con4m/object.c:697:12: runtime error: call to function c4m_list_get_slice through pointer to incorrect function type 'void *(*)(void *, long, long)'
/home/runner/work/libcon4m/src/con4m/list.c:454: note: c4m_list_get_slice defined here

src/con4m/object.c:711:5: runtime error: call to function c4m_list_set_slice through pointer to incorrect function type 'void (*)(void *, long, long, void *)'
/home/runner/work/libcon4m/src/con4m/list.c:500: note: c4m_list_set_slice defined here

src/con4m/object.c:746:12: runtime error: call to function any_int_coerce_to through pointer to incorrect function type 'void *(*)(void *, struct c4m_type_t *)'
/home/runner/work/libcon4m/src/con4m/numbers.c:393: note: any_int_coerce_to defined here

src/con4m/object.c:885:37: runtime error: call to function c4m_list_view through pointer to incorrect function type 'void *(*)(void *, unsigned long *)'
/home/runner/work/libcon4m/src/con4m/list.c:588: note: c4m_list_view defined here

src/con4m/object.c:904:12: runtime error: call to function c4m_to_list_lit through pointer to incorrect function type 'void *(*)(struct c4m_type_t *, c4m_list_t *, struct c4m_str_t *)'
/home/runner/work/libcon4m/src/con4m/list.c:613: note: c4m_to_list_lit defined here

src/con4m/tree_pattern.c:292:12: runtime error: call to function c4m_tcmp through pointer to incorrect function type 'bool (*)(void *, void *)'
/home/runner/work/libcon4m/src/con4m/compiler/ast_utils.c:6: note: c4m_tcmp defined here
```

Closes: https://github.com/crashappsec/libcon4m/issues/56

[1]: https://releases.llvm.org/17.0.1/tools/clang/docs/UndefinedBehaviorSanitizer.html#available-checks
[2]: https://reviews.llvm.org/D148827