### PR TITLE
hatrack: hash: set: don't call qsort with null first argument

### DIFF
--- a/src/hatrack/hash/set.c
+++ b/src/hatrack/hash/set.c
@@ -254,7 +254,7 @@ hatrack_set_items_base(hatrack_set_t *self, mmm_thread_t *thread, uint64_t *num,
     view = woolhat_view_epoch(&self->woolhat_instance, num, epoch);
     ret  = hatrack_malloc(sizeof(void *) * *num);
 
-    if (sort) {
+    if (sort && view != NULL) {
         qsort(view,
               *num,
               sizeof(hatrack_set_view_t),


### PR DESCRIPTION
Feel free to close this if this isn't the change we want.

---

Before this commit, compiling c4test with UBSan and then running it may produce 500+ lines of output like:

```text
../src/hatrack/hash/set.c:258:15: runtime error: null pointer passed as argument 1, which is declared to never be null
/usr/include/stdlib.h:971:30: note: nonnull attribute specified here
    #0 0x5899b1111647 in hatrack_set_items_base libcon4m/src/hatrack/hash/set.c:258:9
    #1 0x5899b1111ea1 in hatrack_set_items_sort libcon4m/src/hatrack/hash/set.c:305:12
    #2 0x5899b0fa6772 in c4m_set_to_xlist libcon4m/src/adts/set.c:158:38
    #3 0x5899b11430a6 in process_branch_exit libcon4m/src/compiler/cfg.c:497:30
    #4 0x5899b113cd67 in cfg_process_node libcon4m/src/compiler/cfg.c:633:9
    #5 0x5899b113d1a0 in cfg_process_node libcon4m/src/compiler/cfg.c:644:9
    #6 0x5899b113c070 in cfg_process_node libcon4m/src/compiler/cfg.c:577:31
    #7 0x5899b113d62a in cfg_process_node libcon4m/src/compiler/cfg.c:656:9
    #8 0x5899b113c070 in cfg_process_node libcon4m/src/compiler/cfg.c:577:31
    #9 0x5899b113b154 in c4m_cfg_analyze libcon4m/src/compiler/cfg.c:744:5
    #10 0x5899b106c882 in c4m_check_pass libcon4m/src/compiler/check_pass.c:3320:13
    #11 0x5899b1016fc5 in c4m_compile_from_entry_point libcon4m/src/compiler/compile.c:467:5
    #12 0x5899b0f07197 in execute_test libcon4m/src/harness/con4m_base/run.c:11:11
    #13 0x5899b0f05674 in run_one_item libcon4m/src/harness/con4m_base/run.c:61:29
    #14 0x5899b0f0535a in c4m_run_expected_value_tests libcon4m/src/harness/con4m_base/run.c:152:18
    #15 0x5899b0f01cdb in main libcon4m/src/harness/con4m_base/test.c:44:5
    #16 0x7fd148d45e07 in __libc_start_call_main /usr/src/debug/glibc/glibc/csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #17 0x7fd148d45ecb in __libc_start_main /usr/src/debug/glibc/glibc/csu/../csu/libc-start.c:360:3
    #18 0x5899b0ecf7b4 in _start (libcon4m/build_dev/c4test+0x14f7b4) (BuildId: eb75f65a7b383149176b9e55cbbfdfd116868794)

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../src/hatrack/hash/set.c:258:15
```

 This was because, on some machines, qsort specifies that the first argument must not be null:

```c
/* Sort NMEMB elements of BASE, of SIZE bytes each,
   using COMPAR to perform the comparisons.  */
extern void qsort (void *__base, size_t __nmemb, size_t __size,
          __compar_fn_t __compar) __nonnull ((1, 4));
```

and at one call site, qsort could be called with a null first argument. Skip the call in that case.

Closes: https://github.com/crashappsec/libcon4m/issues/92