### PR TITLE
builtins: add `high`, `starts_with`, `ends_with`

### DIFF
--- a/include/util/wrappers.h
+++ b/include/util/wrappers.h
@@ -2,6 +2,7 @@
 
 #include "con4m.h"
 
+extern int64_t     c4m_high(void);
 extern c4m_utf32_t *c4m_wrapper_join(c4m_list_t *, const c4m_str_t *);
 extern c4m_str_t   *c4m_wrapper_hostname(void);
 extern c4m_str_t   *c4m_wrapper_os(void);

--- a/src/core/init.c
+++ b/src/core/init.c
@@ -277,6 +277,8 @@ c4m_add_static_symbols(void)
     FSTAT(c4m_str_lower);
     FSTAT(c4m_str_split);
     FSTAT(c4m_str_pad);
+    FSTAT(c4m_str_starts_with);
+    FSTAT(c4m_str_ends_with);
     FSTAT(c4m_wrapper_hostname);
     FSTAT(c4m_wrapper_os);
     FSTAT(c4m_wrapper_arch);

--- a/src/core/init.c
+++ b/src/core/init.c
@@ -282,6 +282,7 @@ c4m_add_static_symbols(void)
     FSTAT(c4m_wrapper_arch);
     FSTAT(c4m_wrapper_repr);
     FSTAT(c4m_wrapper_to_str);
+    FSTAT(c4m_high);
     FSTAT(c4m_len);
     FSTAT(c4m_snap_column);
     FSTAT(c4m_now);

--- a/src/util/wrappers.c
+++ b/src/util/wrappers.c
@@ -63,3 +63,9 @@ c4m_clz(uint64_t n)
 {
     return __builtin_clzll(n);
 }
+
+int64_t
+c4m_high(void)
+{
+    return INT64_MAX;
+}

--- a/sys/builtins.c4m
+++ b/sys/builtins.c4m
@@ -10,6 +10,10 @@ extern c4m_wrapper_arch() -> ptr {
   local: arch() -> string
 }
 
+extern c4m_high() -> i64 {
+  local: high() -> int
+}
+
 extern c4m_len(ptr) -> i64 {
   local: len(s: `x) -> int
 }

--- a/sys/string.c4m
+++ b/sys/string.c4m
@@ -26,3 +26,10 @@ extern c4m_wrapper_to_str(ptr) -> ptr {
   local: str(s: `x) -> string       
 }
 
+extern c4m_str_starts_with(ptr, ptr) -> ptr {
+  local: starts_with(s1: string, s2: string) -> bool
+}
+
+extern c4m_str_ends_with(ptr, ptr) -> ptr {
+  local: ends_with(s1: string, s2: string) -> bool
+}

--- a/tests/builtins.c4m
+++ b/tests/builtins.c4m
@@ -7,6 +7,10 @@ $output:
 Hello, world!
 13
 9223372036854775807
+true
+false
+true
+false
 """
 
 x = "[h1]Hello, world!"'r
@@ -17,3 +21,7 @@ print(high())
 # Test these manually for now.
 # print(osname())
 # print(arch())
+print(starts_with("foo", "f"))
+print(starts_with("foo", "z"))
+print(ends_with("foo", "o"))
+print(ends_with("foo", "z"))

--- a/tests/builtins.c4m
+++ b/tests/builtins.c4m
@@ -6,12 +6,14 @@ $output:
 "Hello, world!"
 Hello, world!
 13
+9223372036854775807
 """
 
 x = "[h1]Hello, world!"'r
 print(repr(x))
 print(str(x))
 print(len(x))
+print(high())
 # Test these manually for now.
 # print(osname())
 # print(arch())


### PR DESCRIPTION
The chalk spec and config files use these, and my understanding is that we want them as language builtins.

Refs: #94 

---

I'm happy to implement some other builtins. But I wanted to double-check first which ones would be good for right now.

I've deliberately not implemented `low()` in this PR because:

- Chalk doesn't currently use it.
- My naive implemention plus `print(low())` in the tests produces `-'..--).0-*(+,))+(0(`, not `-9223372036854775808` (refs https://github.com/crashappsec/libcon4m/issues/72).

I heard there was a `c4m_path_split` to wrap, but I don't see it, so I've omitted that for now.

`util/wrappers.c` probably isn't the best place for `high()`. Please let me know if we want it somewhere else. The existing `include/util/math.h` or `src/adts/numbers.c` didn't seem quite right.

I've based this PR on top of `main` rather than `jtv/parity-push`. There's currently no merge conflict. But I'm happy to target `jtv/parity-push` instead, if we prefer that.